### PR TITLE
Add git, curl, gettext, sh-shim packages and integration test framework

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1778106249,
+        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1771369470,
@@ -18,7 +51,91 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "wasmer": "wasmer"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "wasmer",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778210054,
+        "narHash": "sha256-iYINsX0BVDxTXd0z4FzDpBYHZ9fWUtwjG9cKSXwe9Tg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "bc83d66023d19fb301ee98772643b24b6129ef48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "wasinix": {
+      "inputs": {
+        "nixpkgs": [
+          "wasmer",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777602448,
+        "narHash": "sha256-PUOAbbm1EjJOE4P5R3HWGVA3u+DU9UBYgFjuFTyelUE=",
+        "owner": "wasix-org",
+        "repo": "wasinix",
+        "rev": "e05ab6a712b586e13751444f03c521bbffa74d3a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wasix-org",
+        "repo": "wasinix",
+        "type": "github"
+      }
+    },
+    "wasmer": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay",
+        "wasinix": "wasinix"
+      },
+      "locked": {
+        "lastModified": 1779055991,
+        "narHash": "sha256-Q0T8k/PKGKEetb+fGFHFu4XDxiOx03L5TdpxFMe+uPM=",
+        "ref": "stacked",
+        "rev": "7b11934645c9118c268f791d36930135cec0e4f7",
+        "revCount": 20559,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/kilyanni/wasmer"
+      },
+      "original": {
+        "ref": "stacked",
+        "type": "git",
+        "url": "https://github.com/kilyanni/wasmer"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -123,19 +123,18 @@
         "wasinix": "wasinix"
       },
       "locked": {
-        "lastModified": 1779055991,
-        "narHash": "sha256-Q0T8k/PKGKEetb+fGFHFu4XDxiOx03L5TdpxFMe+uPM=",
-        "ref": "stacked",
-        "rev": "7b11934645c9118c268f791d36930135cec0e4f7",
-        "revCount": 20559,
+        "lastModified": 1781871600,
+        "narHash": "sha256-gop5/VQIxiOpTXB+N9zbdfgpn7xm0vTG1G/dpxe1xMQ=",
+        "ref": "refs/heads/main",
+        "rev": "ff378f927c8365a9958783a8433268e9f66a4496",
+        "revCount": 20665,
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/kilyanni/wasmer"
+        "url": "https://github.com/wasmerio/wasmer"
       },
       "original": {
-        "ref": "stacked",
         "type": "git",
-        "url": "https://github.com/kilyanni/wasmer"
+        "url": "https://github.com/wasmerio/wasmer"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    wasmer = {
+      # Pointing at the fork with the nix packaging updates and patches temporarily until PRs are merged
+      # Note: we have to use "git+url" instead of "github:" due to https://github.com/nixos/nix/issues/13571
+      # url = "git+https://github.com/wasmerio/wasmer";
+      url = "git+https://github.com/kilyanni/wasmer?ref=stacked";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     # self.submodules = true;
   };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, wasmer, ... }:
     let
       system = "x86_64-linux";
       wasix = import ./pkgs {
@@ -49,6 +56,7 @@
       checks.${system} = import ./tests {
         inherit (wasix) pkgs;
         wasmerPkgs = wasix.wasmer.wrappedPackages;
+        wasmer = wasmer.packages.${system}.wasmer;
       };
 
       packages.${system} =

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,11 @@
         '';
       };
 
+      checks.${system} = import ./tests {
+        inherit (wasix) pkgs;
+        wasmerPkgs = wasix.wasmer.wrappedPackages;
+      };
+
       packages.${system} =
         {
           # Actual system packages.

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     wasmer = {
-      # Pointing at the fork with the nix packaging updates and patches temporarily until PRs are merged
-      # Note: we have to use "git+url" instead of "github:" due to https://github.com/nixos/nix/issues/13571
-      # url = "git+https://github.com/wasmerio/wasmer";
-      url = "git+https://github.com/kilyanni/wasmer?ref=stacked";
+      url = "git+https://github.com/wasmerio/wasmer";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # self.submodules = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -92,6 +92,10 @@ let
     inherit makeWasmerPackage;
     crabsay = programs.crabsay;
   };
+  curlWasmer = pkgs.callPackage ./programs/curl/curlWasmer.nix {
+    inherit makeWasmerPackage;
+    curl = programs.curl;
+  };
 
   # phpixPhp83Wasmer = pkgs.callPackage ./programs/phpix/phpixPhp83Wasmer.nix {
   #   inherit makeWasmerPackage;
@@ -108,7 +112,7 @@ let
 
   wasmer = import ./wasmer {
     inherit (pkgs) lib;
-    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer cliPlatformWasmer;
+    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer cliPlatformWasmer;
   };
 
   allPackages = defaultLibraries // programs;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -96,6 +96,10 @@ let
     inherit makeWasmerPackage;
     curl = programs.curl;
   };
+  shShimWasmer = pkgs.callPackage ./programs/sh-shim/shWasmer.nix {
+    inherit makeWasmerPackage;
+    shShim = programs.shShim;
+  };
 
   # phpixPhp83Wasmer = pkgs.callPackage ./programs/phpix/phpixPhp83Wasmer.nix {
   #   inherit makeWasmerPackage;
@@ -112,7 +116,7 @@ let
 
   wasmer = import ./wasmer {
     inherit (pkgs) lib;
-    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer cliPlatformWasmer;
+    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer shShimWasmer cliPlatformWasmer;
   };
 
   allPackages = defaultLibraries // programs;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -104,6 +104,10 @@ let
     inherit makeWasmerPackage;
     gettext = programs.gettext;
   };
+  gitWasmer = pkgs.callPackage ./programs/git/gitWasmer.nix {
+    inherit makeWasmerPackage;
+    git = programs.git;
+  };
 
   # phpixPhp83Wasmer = pkgs.callPackage ./programs/phpix/phpixPhp83Wasmer.nix {
   #   inherit makeWasmerPackage;
@@ -120,7 +124,7 @@ let
 
   wasmer = import ./wasmer {
     inherit (pkgs) lib;
-    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer shShimWasmer gettextWasmer cliPlatformWasmer;
+    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer shShimWasmer gettextWasmer gitWasmer cliPlatformWasmer;
   };
 
   allPackages = defaultLibraries // programs;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -100,6 +100,10 @@ let
     inherit makeWasmerPackage;
     shShim = programs.shShim;
   };
+  gettextWasmer = pkgs.callPackage ./programs/gettext/gettextWasmer.nix {
+    inherit makeWasmerPackage;
+    gettext = programs.gettext;
+  };
 
   # phpixPhp83Wasmer = pkgs.callPackage ./programs/phpix/phpixPhp83Wasmer.nix {
   #   inherit makeWasmerPackage;
@@ -116,13 +120,13 @@ let
 
   wasmer = import ./wasmer {
     inherit (pkgs) lib;
-    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer shShimWasmer cliPlatformWasmer;
+    inherit pkgs nanoWasmer grepWasmer sedWasmer findWasmer gzipWasmer tarWasmer lessWasmer ncursesWasmer crabsayWasmer curlWasmer shShimWasmer gettextWasmer cliPlatformWasmer;
   };
 
   allPackages = defaultLibraries // programs;
   allWasmPackages = allPackages;
 
-  allWasm = pkgs.runCommand "wasix-all-wasm" { } ''
+  allWasm = pkgs.runCommand "wasix-all-wasm" {} ''
     mkdir -p "$out/bin"
     ${pkgs.lib.concatMapStringsSep "\n" (name: ''
       if [ -d "${allWasmPackages.${name}}/bin" ]; then

--- a/pkgs/libraries/default.nix
+++ b/pkgs/libraries/default.nix
@@ -200,7 +200,6 @@ let
         rtmpSupport = false;
         rustlsSupport = false;
         scpSupport = false;
-        wolfsslSupport = false;
         zlibSupport = true;
         zlib = self.zlib;
         zstdSupport = false;

--- a/pkgs/libraries/default.nix
+++ b/pkgs/libraries/default.nix
@@ -369,6 +369,13 @@ let
       doCheck = false;
     };
 
+    readline = mkUpstreamLibrary {
+      package = pkgsCross.readline.override {
+        ncurses = self.ncurses;
+      };
+      doCheck = false;
+    };
+
     ncurses = pkgsCross.callPackage ./ncurses {
       inherit nixpkgs toolchain;
     };

--- a/pkgs/libraries/default.nix
+++ b/pkgs/libraries/default.nix
@@ -364,6 +364,11 @@ let
       };
     };
 
+    expat = mkUpstreamLibrary {
+      package = pkgsCross.expat;
+      doCheck = false;
+    };
+
     ncurses = pkgsCross.callPackage ./ncurses {
       inherit nixpkgs toolchain;
     };

--- a/pkgs/libraries/default.nix
+++ b/pkgs/libraries/default.nix
@@ -23,6 +23,13 @@ let
       };
     };
 
+    zlib-ng = mkUpstreamLibrary {
+      package = pkgsCross.zlib-ng.override {
+        gtest = null;
+      };
+      doCheck = false;
+    };
+
     xz = mkUpstreamLibrary {
       package = pkgsCross.xz;
       doCheck = false;

--- a/pkgs/programs/curl/curl.nix
+++ b/pkgs/programs/curl/curl.nix
@@ -1,0 +1,46 @@
+{
+  toolchain,
+  curlMinimal,
+  openssl,
+  zlib,
+  ...
+}:
+(curlMinimal.override {
+  brotliSupport = false;
+  c-aresSupport = false;
+  gssSupport = false;
+  http2Support = false;
+  http3Support = false;
+  websocketSupport = false;
+  idnSupport = false;
+  ldapSupport = false;
+  opensslSupport = true;
+  inherit openssl;
+  pslSupport = false;
+  rtmpSupport = false;
+  rustlsSupport = false;
+  scpSupport = false;
+  zlibSupport = true;
+  inherit zlib;
+  zstdSupport = false;
+}).overrideAttrs (old: {
+  preConfigure =
+    (old.preConfigure or "")
+    + ''
+      ${toolchain.commonPreConfigure}
+    '';
+  configureFlags =
+    (old.configureFlags or [])
+    ++ [
+      "--host=${toolchain.host}"
+    ];
+  hardeningDisable = ["all"];
+  doCheck = false;
+  postInstall =
+    (old.postInstall or "")
+    + ''
+      if [ -f "$bin/bin/curl" ]; then
+        mv "$bin/bin/curl" "$bin/bin/curl.wasm"
+      fi
+    '';
+})

--- a/pkgs/programs/curl/curlWasmer.nix
+++ b/pkgs/programs/curl/curlWasmer.nix
@@ -1,0 +1,18 @@
+{
+  makeWasmerPackage,
+  curl,
+}:
+makeWasmerPackage {
+  package = curl;
+  name = "curl";
+  inherit (curl) version;
+  description = "command line tool and library for transferring data with URLs";
+  commands = [
+    {
+      name = "curl";
+      module = "curl";
+      wasm = "curl.wasm";
+      output = "curl.wasm";
+    }
+  ];
+}

--- a/pkgs/programs/default.nix
+++ b/pkgs/programs/default.nix
@@ -30,6 +30,10 @@ rec {
   crabsay = pkgs.callPackage ./crabsay/crabsay.nix {
     cargoWasix = toolchain.cargoWasix;
   };
+  curl = pkgsCross.callPackage ./curl/curl.nix {
+    inherit toolchain;
+    inherit (libraries) openssl zlib;
+  };
 
   # phpixPhp83 = pkgs.callPackage ./phpix/phpixPhp83.nix {
   #   cargoWasix = toolchain.cargoWasix;

--- a/pkgs/programs/default.nix
+++ b/pkgs/programs/default.nix
@@ -40,6 +40,15 @@ rec {
   gettext = pkgsCross.callPackage ./gettext/gettext.nix {
     inherit toolchain;
   };
+  git = pkgsCross.callPackage ./git/git.nix {
+    inherit toolchain gettext;
+    inherit (libraries) zlib-ng openssl curl expat libiconv;
+    sh = shShim;
+    gnugrep = grep;
+    gnused = sed;
+    gawk = pkgs.gawk;
+    coreutils = pkgs.coreutils;
+  };
 
   # phpixPhp83 = pkgs.callPackage ./phpix/phpixPhp83.nix {
   #   cargoWasix = toolchain.cargoWasix;

--- a/pkgs/programs/default.nix
+++ b/pkgs/programs/default.nix
@@ -34,6 +34,9 @@ rec {
     inherit toolchain;
     inherit (libraries) openssl zlib;
   };
+  shShim = pkgsCross.callPackage ./sh-shim/sh.nix {
+    inherit toolchain;
+  };
 
   # phpixPhp83 = pkgs.callPackage ./phpix/phpixPhp83.nix {
   #   cargoWasix = toolchain.cargoWasix;

--- a/pkgs/programs/default.nix
+++ b/pkgs/programs/default.nix
@@ -37,6 +37,9 @@ rec {
   shShim = pkgsCross.callPackage ./sh-shim/sh.nix {
     inherit toolchain;
   };
+  gettext = pkgsCross.callPackage ./gettext/gettext.nix {
+    inherit toolchain;
+  };
 
   # phpixPhp83 = pkgs.callPackage ./phpix/phpixPhp83.nix {
   #   cargoWasix = toolchain.cargoWasix;

--- a/pkgs/programs/gettext/gettext.nix
+++ b/pkgs/programs/gettext/gettext.nix
@@ -1,0 +1,71 @@
+{
+  toolchain,
+  gettext,
+  ...
+}:
+(gettext.override {
+  # bashNonInteractive is propagated into the closure as a runtime shell dep;
+  # not needed for the WASIX build.
+  bashNonInteractive = null;
+}).overrideAttrs (old: {
+  postPatch =
+    (old.postPatch or "")
+    + ''
+      # WASIX has a native locale_t so GNULIB_defined_locale_t=0, but none of
+      # the platform guards (glibc, BSD, …) match wasm32-wasi, so the #else
+      # #error fires. No configure variable fixes this safely; stub the
+      # unrecognised-platform branch to return "C".
+      substituteInPlace \
+        gettext-runtime/gnulib-lib/getlocalename_l-unsafe.c \
+        gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c \
+        gettext-tools/gnulib-lib/getlocalename_l-unsafe.c \
+        --replace-fail \
+        ' #error "Please port gnulib getlocalename_l-unsafe.c to your platform! Report this to bug-gnulib."' \
+        '  return (struct string_with_storage) { "C", STORAGE_INDEFINITE };'
+      # getlogin is declared in the WASIX sysroot headers but not in any sysroot
+      # library; NULL lets the existing if-guard skip the block at runtime.
+      substituteInPlace gettext-tools/src/msginit.c \
+        --replace-fail \
+        'username = getlogin ();' \
+        'username = NULL;'
+    '';
+  preConfigure =
+    (old.preConfigure or "")
+    + ''
+      ${toolchain.commonPreConfigure}
+      #
+      # ac_cv_func_posix_spawn / gl_cv_func_posix_spawn_works: WASIX sysroot
+      # provides posix_spawn via proc_spawn. By default it'll try to use fork(),
+      # which is not in the WASIX sysroot, so we tell it to use posix_spawn instead.
+      cat > "$TMPDIR/config.site" <<'EOF'
+      ac_cv_func_posix_spawn=yes
+      gl_cv_func_posix_spawn_works=yes
+      gl_cv_func_posix_spawn_secure_exec=yes
+      gl_cv_func_posix_spawnp_secure_exec=yes
+      ac_cv_func_fork=yes
+      EOF
+      export CONFIG_SITE="$TMPDIR/config.site"
+    '';
+  configureFlags =
+    (old.configureFlags or [])
+    ++ [
+      "--host=${toolchain.host}"
+      "--disable-java"
+      "--disable-csharp"
+      "--disable-native-java"
+      "--disable-openmp"
+      "--disable-acl"
+      "--without-emacs"
+      "--enable-static"
+      "--disable-shared"
+    ];
+  doCheck = false;
+  hardeningDisable = ["all"];
+  postInstall =
+    (old.postInstall or "")
+    + ''
+      for prog in "$out"/bin/*; do
+        [ -f "$prog" ] && mv "$prog" "$prog.wasm"
+      done
+    '';
+})

--- a/pkgs/programs/gettext/gettextWasmer.nix
+++ b/pkgs/programs/gettext/gettextWasmer.nix
@@ -1,0 +1,10 @@
+{
+  makeWasmerPackage,
+  gettext,
+}:
+makeWasmerPackage {
+  package = gettext;
+  name = "gettext";
+  inherit (gettext) version;
+  description = "GNU gettext internationalization and localization tools";
+}

--- a/pkgs/programs/git/git.nix
+++ b/pkgs/programs/git/git.nix
@@ -103,33 +103,28 @@
 
         asyncify "$out/bin/git.wasm"
 
-        # webc v3 has no symlinks, so it would deref every `→ git` symlink
-        # (bin/git-receive-pack, libexec/git-core/git-add, ...) into a full
-        # ~6.5MB copy of bin/git.wasm. Rewrite them as tiny exec shims that
-        # re-invoke the asyncified binary. Same for libexec/git-core/git
-        # itself, which run_command dispatches through and would otherwise
-        # stay pre-asyncify. Real helpers (git-remote-http, ...) get
-        # asyncified in place.
+        # git installs its subcommands as aliases of the main binary: bin/git-*
+        # and libexec/git-core/git-* are `→ git` symlinks, and libexec/git-core/git
+        # is a second full copy. Renaming git → git.wasm dangles those symlinks,
+        # so repoint them at the asyncified wasm. webc preserves symlinks since
+        # wasmerio/wasmer#6653 (webc 12), so each alias stays a link instead of
+        # deref'ing into a ~6.5MB copy of git.wasm; git's own argv[0] dispatch
+        # then routes `git-add` etc. through the binary as usual. Real helpers
+        # (git-remote-http, ...) are standalone wasm binaries, asyncified in place.
+        ln -sf ../../bin/git.wasm "$out/libexec/git-core/git"
         for f in "$out/bin/"* "$out/libexec/git-core/"*; do
           name=''${f##*/}
           [ "$name" = "git.wasm" ] && continue
-          # libexec/git-core/git isn't a symlink so the alias branch won't
-          # match; rewrite it (with no subcommand prefix) in the epilogue.
           [ "$name" = "git" ] && continue
 
           if [ -L "$f" ] && [ "$(readlink "$f")" = "git" ]; then
-            rm "$f"
-            printf '#!%s\nexec %s %s "$@"\n' \
-              "${sh}/bin/sh.wasm" "$out/bin/git.wasm" "''${name#git-}" > "$f"
-            chmod +x "$f"
+            case "$f" in
+              "$out/bin/"*) ln -sf git.wasm "$f" ;;
+              *)            ln -sf ../../bin/git.wasm "$f" ;;
+            esac
           elif [ -f "$f" ] && [ ! -L "$f" ] && od -An -N4 -tx1 "$f" | grep -q "00 61 73 6d"; then
             asyncify "$f"
           fi
         done
-
-        rm "$out/libexec/git-core/git"
-        printf '#!%s\nexec %s "$@"\n' \
-          "${sh}/bin/sh.wasm" "$out/bin/git.wasm" > "$out/libexec/git-core/git"
-        chmod +x "$out/libexec/git-core/git"
       '';
   })

--- a/pkgs/programs/git/git.nix
+++ b/pkgs/programs/git/git.nix
@@ -15,30 +15,40 @@
   coreutils,
 }:
 (gitMinimal.override {
-  inherit gnugrep gnused gawk gettext coreutils zlib-ng;
+  inherit
+    gnugrep
+    gnused
+    gawk
+    gettext
+    coreutils
+    zlib-ng
+    ;
   # makeWrapper wraps git in a bash script; bash is not packaged yet so null both.
   bash = null;
   makeWrapper = null;
-  inherit openssl curl expat libiconv;
+  inherit
+    openssl
+    curl
+    expat
+    libiconv
+    ;
   nlsSupport = false;
   doInstallCheck = false;
-}).overrideAttrs (old: {
-  passthru = (old.passthru or {}) // {
-    inherit sh;
-  };
-  makeFlags =
-    old.makeFlags
-    ++ [
+}).overrideAttrs
+  (old: {
+    passthru = (old.passthru or { }) // {
+      inherit sh;
+    };
+    makeFlags = old.makeFlags ++ [
       # nixpkgs cross builds set these to indicate missing symbols on plain WASI;
       # WASIX libc provides both, so clear them to re-enable the native path.
       "NO_INET_NTOP="
       "NO_INET_PTON="
       "NO_TCLTK=YesPlease"
-      # `git commit` fails with "invalid object" because WASIX's link()/unlink()
-      # pair doesn't cancel out — link(tmp, hash) followed by unlink(tmp) leaves
-      # both names in the dir. This flag switches the writer to rename(), which
-      # works correctly. (Distinct from the EINVAL-on-unlink bug for files not
-      # tracked in the parent dir's entries map, which we patched in wasmer.)
+      # `git commit` fails with "invalid object" because WASIX unlink()
+      # silently no-ops on files in .git/objects/aa/. Git writes objects as
+      # link(tmp_obj_X, hash) + unlink(tmp_obj_X), so both files end up in
+      # the dir. This flag switches the writer to rename().
       "OBJECT_CREATION_USES_RENAMES=YesPlease"
       # sysinfo() is in WASIX headers but absent from libc.a.
       "HAVE_SYSINFO="
@@ -49,9 +59,7 @@
       "OPENSSL_LINK=-lssl -lcrypto"
     ];
 
-  postPatch =
-    (old.postPatch or "")
-    + ''
+    postPatch = (old.postPatch or "") + ''
       sed -i "s|BASIC_CFLAGS += -DSHELL_PATH=.*|BASIC_CFLAGS += -DSHELL_PATH='\"${sh}/bin/sh.wasm\"'|" Makefile
       substituteInPlace run-command.c \
         --replace-fail 'if (is_executable(buf.buf))' 'if (!access(buf.buf, F_OK))'
@@ -61,9 +69,7 @@
       cp ${./wasix-compat/proc.c} wasix-compat/proc.c
     '';
 
-  preConfigure =
-    (old.preConfigure or "")
-    + ''
+    preConfigure = (old.preConfigure or "") + ''
       ${toolchain.commonPreConfigure}
 
       # Without this, for some reason, it doesn't see the compiler/linker flags.
@@ -76,59 +82,54 @@
       $CC $CPPFLAGS -c wasix-compat/proc.c -o wasix-compat/proc.o
       $AR rcs wasix-compat/libwasix-compat.a wasix-compat/proc.o
     '';
-  configureFlags =
-    (old.configureFlags or [])
-    ++ [
+    configureFlags = (old.configureFlags or [ ]) ++ [
       "--host=${toolchain.host}"
     ];
 
-  # postConfigure =
-  #   (old.postConfigure or "")
-  #   + ''
-  #     echo 'LDFLAGS += -Lwasix-compat -lwasix-compat' >> config.mak.autogen
-  #   '';
+    # postConfigure =
+    #   (old.postConfigure or "")
+    #   + ''
+    #     echo 'LDFLAGS += -Lwasix-compat -lwasix-compat' >> config.mak.autogen
+    #   '';
 
-  postInstall =
-    (lib.replaceStrings
-      [''rm "$out/$prog"'']
-      [''rm -f "$out/$prog"'']
-      (old.postInstall or ""))
-    + ''
-      mv "$out/bin/git" "$out/bin/git.wasm"
+    postInstall =
+      (lib.replaceStrings [ ''rm "$out/$prog"'' ] [ ''rm -f "$out/$prog"'' ] (old.postInstall or ""))
+      + ''
+        mv "$out/bin/git" "$out/bin/git.wasm"
 
-      asyncify() {
-        ${toolchain.binaryen}/bin/wasm-opt --asyncify -O2 "$1" -o "$1"
-      }
+        asyncify() {
+          ${toolchain.binaryen}/bin/wasm-opt --asyncify -O2 "$1" -o "$1"
+        }
 
-      asyncify "$out/bin/git.wasm"
+        asyncify "$out/bin/git.wasm"
 
-      # webc v3 has no symlinks, so it would deref every `→ git` symlink
-      # (bin/git-receive-pack, libexec/git-core/git-add, ...) into a full
-      # ~6.5MB copy of bin/git.wasm. Rewrite them as tiny exec shims that
-      # re-invoke the asyncified binary. Same for libexec/git-core/git
-      # itself, which run_command dispatches through and would otherwise
-      # stay pre-asyncify. Real helpers (git-remote-http, ...) get
-      # asyncified in place.
-      for f in "$out/bin/"* "$out/libexec/git-core/"*; do
-        name=''${f##*/}
-        [ "$name" = "git.wasm" ] && continue
-        # libexec/git-core/git isn't a symlink so the alias branch won't
-        # match; rewrite it (with no subcommand prefix) in the epilogue.
-        [ "$name" = "git" ] && continue
+        # webc v3 has no symlinks, so it would deref every `→ git` symlink
+        # (bin/git-receive-pack, libexec/git-core/git-add, ...) into a full
+        # ~6.5MB copy of bin/git.wasm. Rewrite them as tiny exec shims that
+        # re-invoke the asyncified binary. Same for libexec/git-core/git
+        # itself, which run_command dispatches through and would otherwise
+        # stay pre-asyncify. Real helpers (git-remote-http, ...) get
+        # asyncified in place.
+        for f in "$out/bin/"* "$out/libexec/git-core/"*; do
+          name=''${f##*/}
+          [ "$name" = "git.wasm" ] && continue
+          # libexec/git-core/git isn't a symlink so the alias branch won't
+          # match; rewrite it (with no subcommand prefix) in the epilogue.
+          [ "$name" = "git" ] && continue
 
-        if [ -L "$f" ] && [ "$(readlink "$f")" = "git" ]; then
-          rm "$f"
-          printf '#!%s\nexec %s %s "$@"\n' \
-            "${sh}/bin/sh.wasm" "$out/bin/git.wasm" "''${name#git-}" > "$f"
-          chmod +x "$f"
-        elif [ -f "$f" ] && [ ! -L "$f" ] && od -An -N4 -tx1 "$f" | grep -q "00 61 73 6d"; then
-          asyncify "$f"
-        fi
-      done
+          if [ -L "$f" ] && [ "$(readlink "$f")" = "git" ]; then
+            rm "$f"
+            printf '#!%s\nexec %s %s "$@"\n' \
+              "${sh}/bin/sh.wasm" "$out/bin/git.wasm" "''${name#git-}" > "$f"
+            chmod +x "$f"
+          elif [ -f "$f" ] && [ ! -L "$f" ] && od -An -N4 -tx1 "$f" | grep -q "00 61 73 6d"; then
+            asyncify "$f"
+          fi
+        done
 
-      rm "$out/libexec/git-core/git"
-      printf '#!%s\nexec %s "$@"\n' \
-        "${sh}/bin/sh.wasm" "$out/bin/git.wasm" > "$out/libexec/git-core/git"
-      chmod +x "$out/libexec/git-core/git"
-    '';
-})
+        rm "$out/libexec/git-core/git"
+        printf '#!%s\nexec %s "$@"\n' \
+          "${sh}/bin/sh.wasm" "$out/bin/git.wasm" > "$out/libexec/git-core/git"
+        chmod +x "$out/libexec/git-core/git"
+      '';
+  })

--- a/pkgs/programs/git/git.nix
+++ b/pkgs/programs/git/git.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  toolchain,
+  sh,
+  gitMinimal,
+  zlib-ng,
+  openssl,
+  curl,
+  expat,
+  libiconv,
+  gnugrep,
+  gnused,
+  gawk,
+  gettext,
+  coreutils,
+}:
+(gitMinimal.override {
+  inherit gnugrep gnused gawk gettext coreutils zlib-ng;
+  # makeWrapper wraps git in a bash script; bash is not packaged yet so null both.
+  bash = null;
+  makeWrapper = null;
+  inherit openssl curl expat libiconv;
+  nlsSupport = false;
+  doInstallCheck = false;
+}).overrideAttrs (old: {
+  passthru = (old.passthru or {}) // {
+    inherit sh;
+  };
+  makeFlags =
+    old.makeFlags
+    ++ [
+      # nixpkgs cross builds set these to indicate missing symbols on plain WASI;
+      # WASIX libc provides both, so clear them to re-enable the native path.
+      "NO_INET_NTOP="
+      "NO_INET_PTON="
+      "NO_TCLTK=YesPlease"
+      # `git commit` fails with "invalid object" because WASIX's link()/unlink()
+      # pair doesn't cancel out — link(tmp, hash) followed by unlink(tmp) leaves
+      # both names in the dir. This flag switches the writer to rename(), which
+      # works correctly. (Distinct from the EINVAL-on-unlink bug for files not
+      # tracked in the parent dir's entries map, which we patched in wasmer.)
+      "OBJECT_CREATION_USES_RENAMES=YesPlease"
+      # sysinfo() is in WASIX headers but absent from libc.a.
+      "HAVE_SYSINFO="
+      # configure cannot run WASM test binaries; force-enable curl and OpenSSL.
+      "NO_CURL="
+      "NO_OPENSSL="
+      "CURL_LDFLAGS=-lcurl -lssl -lcrypto"
+      "OPENSSL_LINK=-lssl -lcrypto"
+    ];
+
+  postPatch =
+    (old.postPatch or "")
+    + ''
+      sed -i "s|BASIC_CFLAGS += -DSHELL_PATH=.*|BASIC_CFLAGS += -DSHELL_PATH='\"${sh}/bin/sh.wasm\"'|" Makefile
+      substituteInPlace run-command.c \
+        --replace-fail 'if (is_executable(buf.buf))' 'if (!access(buf.buf, F_OK))'
+
+      mkdir -p wasix-compat
+      cp ${./wasix-compat/unistd.h} wasix-compat/unistd.h
+      cp ${./wasix-compat/proc.c} wasix-compat/proc.c
+    '';
+
+  preConfigure =
+    (old.preConfigure or "")
+    + ''
+      ${toolchain.commonPreConfigure}
+
+      # Without this, for some reason, it doesn't see the compiler/linker flags.
+      # And without -lz, it doesn't find libz-ng, even though it should be in buildInputs.
+      # TODO: Figure out why
+      export CPPFLAGS="-Iwasix-compat $NIX_CFLAGS_COMPILE"
+      export LDFLAGS="-Lwasix-compat -lwasix-compat $NIX_LDFLAGS -lz"
+
+      # Compile our shims
+      $CC $CPPFLAGS -c wasix-compat/proc.c -o wasix-compat/proc.o
+      $AR rcs wasix-compat/libwasix-compat.a wasix-compat/proc.o
+    '';
+  configureFlags =
+    (old.configureFlags or [])
+    ++ [
+      "--host=${toolchain.host}"
+    ];
+
+  # postConfigure =
+  #   (old.postConfigure or "")
+  #   + ''
+  #     echo 'LDFLAGS += -Lwasix-compat -lwasix-compat' >> config.mak.autogen
+  #   '';
+
+  postInstall =
+    (lib.replaceStrings
+      [''rm "$out/$prog"'']
+      [''rm -f "$out/$prog"'']
+      (old.postInstall or ""))
+    + ''
+      mv "$out/bin/git" "$out/bin/git.wasm"
+
+      asyncify() {
+        ${toolchain.binaryen}/bin/wasm-opt --asyncify -O2 "$1" -o "$1"
+      }
+
+      asyncify "$out/bin/git.wasm"
+
+      # webc v3 has no symlinks, so it would deref every `→ git` symlink
+      # (bin/git-receive-pack, libexec/git-core/git-add, ...) into a full
+      # ~6.5MB copy of bin/git.wasm. Rewrite them as tiny exec shims that
+      # re-invoke the asyncified binary. Same for libexec/git-core/git
+      # itself, which run_command dispatches through and would otherwise
+      # stay pre-asyncify. Real helpers (git-remote-http, ...) get
+      # asyncified in place.
+      for f in "$out/bin/"* "$out/libexec/git-core/"*; do
+        name=''${f##*/}
+        [ "$name" = "git.wasm" ] && continue
+        # libexec/git-core/git isn't a symlink so the alias branch won't
+        # match; rewrite it (with no subcommand prefix) in the epilogue.
+        [ "$name" = "git" ] && continue
+
+        if [ -L "$f" ] && [ "$(readlink "$f")" = "git" ]; then
+          rm "$f"
+          printf '#!%s\nexec %s %s "$@"\n' \
+            "${sh}/bin/sh.wasm" "$out/bin/git.wasm" "''${name#git-}" > "$f"
+          chmod +x "$f"
+        elif [ -f "$f" ] && [ ! -L "$f" ] && od -An -N4 -tx1 "$f" | grep -q "00 61 73 6d"; then
+          asyncify "$f"
+        fi
+      done
+
+      rm "$out/libexec/git-core/git"
+      printf '#!%s\nexec %s "$@"\n' \
+        "${sh}/bin/sh.wasm" "$out/bin/git.wasm" > "$out/libexec/git-core/git"
+      chmod +x "$out/libexec/git-core/git"
+    '';
+})

--- a/pkgs/programs/git/gitWasmer.nix
+++ b/pkgs/programs/git/gitWasmer.nix
@@ -1,0 +1,37 @@
+{
+  makeWasmerPackage,
+  git,
+  cacert,
+}:
+makeWasmerPackage {
+  package = git;
+  name = "git";
+  owner = "kilyanni";
+  inherit (git) version;
+  description = "Distributed version control system";
+  license = "GPL-2.0-only";
+  fs = {
+    "/etc/ssl" = "${cacert}/etc/ssl";
+    # SHELL_PATH baked into the binary points at sh.wasm in the nix store.
+    # Mount the whole sh derivation at its store path so the baked-in path
+    # resolves on consumer machines. (wasmer [fs] doesn't mount individual
+    # files — only directories — hence mounting the dir, not the .wasm.)
+    # Same story for the git derivation: GIT_EXEC_PATH points into its
+    # libexec/git-core, mounted here so helpers resolve.
+    # Dep flows through the value; the key is just text in wasmer.toml.
+    ${builtins.unsafeDiscardStringContext (toString git.sh)} = git.sh;
+    ${builtins.unsafeDiscardStringContext (toString git)} = git;
+  };
+  commands = [
+    {
+      name = "git";
+      module = "git";
+      wasm = "git.wasm";
+      output = "git.wasm";
+      env = {
+        SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
+        GIT_SSL_CAINFO = "/etc/ssl/certs/ca-bundle.crt";
+      };
+    }
+  ];
+}

--- a/pkgs/programs/git/gitWasmer.nix
+++ b/pkgs/programs/git/gitWasmer.nix
@@ -12,16 +12,8 @@ makeWasmerPackage {
   license = "GPL-2.0-only";
   fs = {
     "/etc/ssl" = "${cacert}/etc/ssl";
-    # SHELL_PATH baked into the binary points at sh.wasm in the nix store.
-    # Mount the whole sh derivation at its store path so the baked-in path
-    # resolves on consumer machines. (wasmer [fs] doesn't mount individual
-    # files — only directories — hence mounting the dir, not the .wasm.)
-    # Same story for the git derivation: GIT_EXEC_PATH points into its
-    # libexec/git-core, mounted here so helpers resolve.
-    # Dep flows through the value; the key is just text in wasmer.toml.
-    ${builtins.unsafeDiscardStringContext (toString git.sh)} = git.sh;
-    ${builtins.unsafeDiscardStringContext (toString git)} = git;
   };
+  selfMounts = [ git.sh git ];
   commands = [
     {
       name = "git";

--- a/pkgs/programs/git/wasix-compat/proc.c
+++ b/pkgs/programs/git/wasix-compat/proc.c
@@ -1,0 +1,17 @@
+/* WASIX process-primitive shims for functions absent from sysroot libc.a. */
+#include <wasi/api.h>
+typedef int pid_t;
+extern int errno;
+
+pid_t fork(void) {
+    __wasi_pid_t pid;
+    __wasi_errno_t err = __wasi_proc_fork((__wasi_bool_t)1, &pid);
+    if (err != __WASI_ERRNO_SUCCESS) { errno = err; return -1; }
+    return (pid_t)pid;
+}
+
+pid_t setsid(void) {
+    __wasi_pid_t pid;
+    __wasi_proc_id(&pid);
+    return (pid_t)pid;
+}

--- a/pkgs/programs/git/wasix-compat/unistd.h
+++ b/pkgs/programs/git/wasix-compat/unistd.h
@@ -1,0 +1,9 @@
+#ifndef _WASIX_COMPAT_UNISTD_H
+#define _WASIX_COMPAT_UNISTD_H
+#include_next <unistd.h>
+/* fork() is hidden when __wasm_exception_handling__ is defined. */
+#ifndef __WASIX_FORK_DECLARED
+#define __WASIX_FORK_DECLARED
+pid_t fork(void);
+#endif
+#endif

--- a/pkgs/programs/sh-shim/sh.c
+++ b/pkgs/programs/sh-shim/sh.c
@@ -1,0 +1,198 @@
+/* Minimal sh for WASIX. Two modes:
+     sh -c "cmd"           run a single command string (git's system()/popen())
+     sh script args...     run a script file (git's ENOEXEC fallback retries
+                           failed-as-wasm execs via SHELL_PATH+script-path)
+
+   In -c mode we also replicate musl's ENOEXEC fallback: wasix-libc's execvp
+   reports ENOEXEC for shebang scripts instead of interpreting them, so when
+   the command would otherwise have been found via PATH we resolve it ourselves
+   and feed it through our script handler. (Triggered by e.g. `git clone
+   <local-path>`, which invokes `git-upload-pack` via sh.)
+
+   The script handler understands only what's needed to ship the git alias
+   scripts: skip blank/comment/shebang lines, execute a single `exec ... "$@"`
+   line. Anything else is rejected. */
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define MAX_ARGS 256
+
+/* Parse a POSIX command string into argv, handling '' and "" quoting.
+   Returns the number of arguments (argv is NULL-terminated). */
+static char **parse_cmd(const char *cmd, int *argc_out) {
+  char **argv = calloc(MAX_ARGS + 1, sizeof(char *));
+  char *buf = malloc(strlen(cmd) + 1);
+  if (!argv || !buf)
+    return NULL;
+
+  int argc = 0;
+  int bi = 0;
+  const char *p = cmd;
+
+  while (*p) {
+    while (*p && isspace((unsigned char)*p))
+      p++;
+    if (!*p)
+      break;
+    if (argc >= MAX_ARGS)
+      break;
+
+    bi = 0;
+    while (*p) {
+      if (*p == '\'') {
+        p++;
+        while (*p && *p != '\'')
+          buf[bi++] = *p++;
+        if (*p == '\'')
+          p++;
+      } else if (*p == '"') {
+        p++;
+        while (*p && *p != '"') {
+          if (*p == '\\' && *(p + 1))
+            p++;
+          buf[bi++] = *p++;
+        }
+        if (*p == '"')
+          p++;
+      } else if (*p == '\\' && *(p + 1)) {
+        p++;
+        buf[bi++] = *p++;
+      } else if (isspace((unsigned char)*p)) {
+        break;
+      } else {
+        buf[bi++] = *p++;
+      }
+    }
+
+    argv[argc] = malloc(bi + 1);
+    if (!argv[argc]) {
+      free(buf);
+      return NULL;
+    }
+    memcpy(argv[argc], buf, bi);
+    argv[argc][bi] = '\0';
+    argc++;
+  }
+
+  argv[argc] = NULL;
+  *argc_out = argc;
+  free(buf);
+  return argv;
+}
+
+/* PATH lookup: return malloc'd absolute path to name, or NULL. If name contains
+   a '/', only that path is tried. Used to resolve the file after an ENOEXEC
+   fallback, since execvp doesn't tell us which dir it actually tried. */
+static char *find_in_path(const char *name) {
+  if (strchr(name, '/'))
+    return access(name, F_OK) == 0 ? strdup(name) : NULL;
+  const char *path = getenv("PATH");
+  if (!path || !*path)
+    path = "/usr/local/bin:/bin:/usr/bin";
+  char *dup = strdup(path);
+  if (!dup)
+    return NULL;
+  char *saveptr = NULL;
+  for (char *tok = strtok_r(dup, ":", &saveptr); tok; tok = strtok_r(NULL, ":", &saveptr)) {
+    size_t n = strlen(tok) + 1 + strlen(name) + 1;
+    char *cand = malloc(n);
+    if (!cand)
+      continue;
+    snprintf(cand, n, "%s/%s", tok, name);
+    if (access(cand, F_OK) == 0) {
+      free(dup);
+      return cand;
+    }
+    free(cand);
+  }
+  free(dup);
+  return NULL;
+}
+
+/* Run a script file. Skips blank/comment/shebang lines. Executes the first
+   `exec <cmd> ...` line by replacing the current process. `"$@"` (which parses
+   as the bare token $@) expands to the positional params passed in. */
+static int run_script(const char *path, int pos_argc, char *pos_argv[]) {
+  FILE *fp = fopen(path, "r");
+  if (!fp) {
+    fprintf(stderr, "sh-shim: cannot open script '%s'\n", path);
+    return 127;
+  }
+
+  char *line = NULL;
+  size_t cap = 0;
+  ssize_t len;
+
+  while ((len = getline(&line, &cap, fp)) != -1) {
+    if (len > 0 && line[len - 1] == '\n')
+      line[--len] = '\0';
+    if (len > 0 && line[len - 1] == '\r')
+      line[--len] = '\0';
+
+    const char *p = line;
+    while (*p && isspace((unsigned char)*p))
+      p++;
+    if (*p == '\0' || *p == '#')
+      continue;
+
+    int line_argc = 0;
+    char **line_argv = parse_cmd(p, &line_argc);
+    if (!line_argv || line_argc == 0)
+      continue;
+    if (strcmp(line_argv[0], "exec") != 0 || line_argc < 2) {
+      fprintf(stderr, "sh-shim: only `exec` lines are supported in scripts: %s\n", p);
+      fclose(fp);
+      free(line);
+      return 1;
+    }
+
+    int new_argc = 0;
+    for (int i = 1; i < line_argc; i++)
+      new_argc += strcmp(line_argv[i], "$@") == 0 ? pos_argc : 1;
+
+    char **new_argv = calloc(new_argc + 1, sizeof(char *));
+    int j = 0;
+    for (int i = 1; i < line_argc; i++) {
+      if (strcmp(line_argv[i], "$@") == 0)
+        for (int k = 0; k < pos_argc; k++) new_argv[j++] = pos_argv[k];
+      else
+        new_argv[j++] = line_argv[i];
+    }
+    new_argv[new_argc] = NULL;
+
+    execvp(new_argv[0], new_argv);
+    fprintf(stderr, "sh-shim: exec '%s' failed\n", new_argv[0]);
+    return 127;
+  }
+
+  fclose(fp);
+  free(line);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc >= 3 && strcmp(argv[1], "-c") == 0) {
+    int n = 0;
+    char **exec_argv = parse_cmd(argv[2], &n);
+    if (!exec_argv || n == 0)
+      return exec_argv ? 0 : 1;
+    execvp(exec_argv[0], exec_argv);
+    if (errno == ENOEXEC) {
+      char *resolved = find_in_path(exec_argv[0]);
+      if (resolved)
+        return run_script(resolved, n - 1, &exec_argv[1]);
+    }
+    fprintf(stderr, "sh-shim: %s: %s\n", exec_argv[0], strerror(errno));
+    return 127;
+  }
+
+  if (argc >= 2 && argv[1][0] != '-')
+    return run_script(argv[1], argc - 2, &argv[2]);
+
+  fprintf(stderr, "sh-shim: usage: sh -c CMD | sh SCRIPT ARGS\n");
+  return 1;
+}

--- a/pkgs/programs/sh-shim/sh.nix
+++ b/pkgs/programs/sh-shim/sh.nix
@@ -1,0 +1,29 @@
+{
+  stdenv,
+  toolchain,
+}:
+stdenv.mkDerivation {
+  pname = "wasix-sh-shim";
+  version = "0.1.0";
+
+  src = builtins.path {
+    name = "sh-src";
+    path = ./.;
+  };
+
+  dontConfigure = true;
+  hardeningDisable = ["all"];
+  doCheck = false;
+
+  buildPhase = ''
+    ${toolchain.commonPreConfigure}
+    $CC -O2 -o sh.wasm sh.c
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sh.wasm $out/bin/sh.wasm
+    ${toolchain.binaryen}/bin/wasm-opt --asyncify -O2 \
+      $out/bin/sh.wasm -o $out/bin/sh.wasm
+  '';
+}

--- a/pkgs/programs/sh-shim/shWasmer.nix
+++ b/pkgs/programs/sh-shim/shWasmer.nix
@@ -1,0 +1,18 @@
+{
+  makeWasmerPackage,
+  shShim,
+}:
+makeWasmerPackage {
+  package = shShim;
+  name = "sh";
+  inherit (shShim) version;
+  description = "POSIX shell stub for WASIX environments";
+  commands = [
+    {
+      name = "sh";
+      module = "sh";
+      wasm = "sh.wasm";
+      output = "sh.wasm";
+    }
+  ];
+}

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, shShimWasmer, cliPlatformWasmer }:
+{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, shShimWasmer, gettextWasmer, cliPlatformWasmer }:
 let
   packages = {
     nano = nanoWasmer;
@@ -12,6 +12,7 @@ let
     crabsay = crabsayWasmer;
     curl = curlWasmer;
     shShim = shShimWasmer;
+    gettext = gettextWasmer;
     # phpixPhp83 = phpixPhp83Wasmer;
     # phpnixPhp83 = phpixPhp83Wasmer;
     # phpixPhp85 = phpixPhp85Wasmer;

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 { lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, cliPlatformWasmer }:
+=======
+{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, cliPlatformWasmer }:
+>>>>>>> 5c2b714 (fixup! programs/curl: init)
 let
   packages = {
     nano = nanoWasmer;
@@ -10,6 +14,10 @@ let
     less = lessWasmer;
     ncurses = ncursesWasmer;
     crabsay = crabsayWasmer;
+<<<<<<< HEAD
+=======
+    curl = curlWasmer;
+>>>>>>> 5c2b714 (fixup! programs/curl: init)
     # phpixPhp83 = phpixPhp83Wasmer;
     # phpnixPhp83 = phpixPhp83Wasmer;
     # phpixPhp85 = phpixPhp85Wasmer;

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, cliPlatformWasmer }:
-=======
-{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, cliPlatformWasmer }:
->>>>>>> 5c2b714 (fixup! programs/curl: init)
+{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, shShimWasmer, cliPlatformWasmer }:
 let
   packages = {
     nano = nanoWasmer;
@@ -14,10 +10,8 @@ let
     less = lessWasmer;
     ncurses = ncursesWasmer;
     crabsay = crabsayWasmer;
-<<<<<<< HEAD
-=======
     curl = curlWasmer;
->>>>>>> 5c2b714 (fixup! programs/curl: init)
+    shShim = shShimWasmer;
     # phpixPhp83 = phpixPhp83Wasmer;
     # phpnixPhp83 = phpixPhp83Wasmer;
     # phpixPhp85 = phpixPhp85Wasmer;

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, shShimWasmer, gettextWasmer, cliPlatformWasmer }:
+{ lib, pkgs, nanoWasmer, grepWasmer, sedWasmer, findWasmer, gzipWasmer, tarWasmer, lessWasmer, ncursesWasmer, crabsayWasmer, curlWasmer, shShimWasmer, gitWasmer, gettextWasmer, cliPlatformWasmer }:
 let
   packages = {
     nano = nanoWasmer;
@@ -12,6 +12,7 @@ let
     crabsay = crabsayWasmer;
     curl = curlWasmer;
     shShim = shShimWasmer;
+    git = gitWasmer;
     gettext = gettextWasmer;
     # phpixPhp83 = phpixPhp83Wasmer;
     # phpnixPhp83 = phpixPhp83Wasmer;

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -21,6 +21,7 @@ let
     cliPlatform = cliPlatformWasmer;
   };
   allWasmerPackages = packages;
+  wrappedPackages = lib.mapAttrs (_: p: p.shim) (lib.filterAttrs (_: p: p ? shim) packages);
 
   allWasmer = pkgs.runCommand "wasix-all-wasmer" { } ''
     set -euo pipefail
@@ -34,5 +35,5 @@ let
   '';
 in
 {
-  inherit packages allWasmer;
+  inherit packages wrappedPackages allWasmer;
 }

--- a/pkgs/wasmer/make-wasmer-package.nix
+++ b/pkgs/wasmer/make-wasmer-package.nix
@@ -15,8 +15,12 @@
   commands ? null,
   defaultRunner ? "https://webc.org/runner/wasi",
   metadata ? { },
+  fs ? { },
+  selfMounts ? [ ],
 }:
 let
+  wrapWasmerPackage = pkgs.callPackage ./wrap-wasmer-package.nix { };
+
   commandLines =
     if commands == null then
       ""
@@ -30,8 +34,12 @@ let
           runner = cmd.runner or defaultRunner;
           mainArgs = builtins.toJSON (cmd.mainArgs or null);
           atom = builtins.toJSON (cmd.atom or moduleName);
+          env = builtins.toJSON (
+            if cmd ? env then lib.mapAttrsToList (k: v: "${k}=${v}") cmd.env
+            else null
+          );
         in
-        "${commandName}|${moduleName}|${wasmFile}|${outputFile}|${runner}|${mainArgs}|${atom}"
+        "${commandName}|${moduleName}|${wasmFile}|${outputFile}|${runner}|${mainArgs}|${atom}|${env}"
       ) commands;
 
   extraMetadataLines =
@@ -43,8 +51,25 @@ let
           "${builtins.toJSON k} = ${builtins.toJSON v}"
         ) metadata
       );
+
+  # `selfMounts` covers the common case of mounting a store path at itself, e.g.
+  #   /nix/store/...-foo/:/nix/store/...-foo/
+  # Writing that directly via `fs = { ${toString src} = src; }` is rejected by
+  # Nix: it refuses to use a string that carries a reference to a store path
+  # as an attribute name. The dependency is already pulled in correctly through
+  # `src`, so we strip that reference off the virt side.
+  fsEntries =
+    (lib.mapAttrsToList (virt: src: { inherit virt src; }) fs)
+    ++ (map (src: {
+      virt = builtins.unsafeDiscardStringContext (toString src);
+      inherit src;
+    }) selfMounts);
+
 in
-pkgs.runCommand "wasmer-package-${name}" { } ''
+pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "wasmer-package-${name}";
+  passthru.shim = wrapWasmerPackage { package = finalAttrs.finalPackage; inherit name; };
+  buildCommand = ''
   set -euo pipefail
 
   pkg_dir="$out/pkg/${name}"
@@ -79,6 +104,7 @@ EOF
     runner="$4"
     main_args_json="$5"
     atom_json="$6"
+    env_json="$7"
 
     if [ -z "''${module_seen[$module_name]+x}" ]; then
       module_seen["$module_name"]=1
@@ -97,7 +123,7 @@ module = "$module_name"
 runner = "$runner"
 EOF
 
-    if [ "$main_args_json" != "null" ] || [ "$atom_json" != "null" ]; then
+    if [ "$main_args_json" != "null" ] || [ "$atom_json" != "null" ] || [ "$env_json" != "null" ]; then
       cat >> "$pkg_dir/wasmer.toml" <<EOF
 [command.annotations.wasi]
 EOF
@@ -109,6 +135,11 @@ EOF
       if [ "$main_args_json" != "null" ]; then
         cat >> "$pkg_dir/wasmer.toml" <<EOF
 main-args = $main_args_json
+EOF
+      fi
+      if [ "$env_json" != "null" ]; then
+        cat >> "$pkg_dir/wasmer.toml" <<EOF
+env = $env_json
 EOF
       fi
     fi
@@ -125,7 +156,7 @@ EOF
         output_file="$command_name.wasm"
 
         cp -f "$wasm_path" "$bin_dir/$output_file"
-        append_command "$command_name" "$module_name" "$output_file" "${defaultRunner}" "null" "\"$module_name\""
+        append_command "$command_name" "$module_name" "$output_file" "${defaultRunner}" "null" "\"$module_name\"" "null"
       done < <(${pkgs.findutils}/bin/find "${package}/bin" -maxdepth 1 -type f -name '*.wasm' -print0)
     fi
 
@@ -134,7 +165,7 @@ EOF
       exit 1
     fi
   '' else ''
-    while IFS='|' read -r command_name module_name wasm_file output_file runner main_args_json atom_json; do
+    while IFS='|' read -r command_name module_name wasm_file output_file runner main_args_json atom_json env_json; do
       [ -n "$command_name" ] || continue
       source_path="${package}/bin/$wasm_file"
       if [ ! -f "$source_path" ]; then
@@ -143,9 +174,26 @@ EOF
       fi
 
       cp -f "$source_path" "$bin_dir/$output_file"
-      append_command "$command_name" "$module_name" "$output_file" "$runner" "$main_args_json" "$atom_json"
+      append_command "$command_name" "$module_name" "$output_file" "$runner" "$main_args_json" "$atom_json" "$env_json"
     done <<'EOF'
 ${commandLines}
 EOF
   ''}
-''
+
+  ${if fsEntries == [ ] then "" else ''
+    cat >> "$pkg_dir/wasmer.toml" <<EOF
+
+[fs]
+EOF
+    ${lib.concatMapStringsSep "\n" (e: ''
+      virt=${lib.escapeShellArg e.virt}
+      target="$pkg_dir/fs$virt"
+      mkdir -p "$(dirname "$target")"
+      ${pkgs.coreutils}/bin/cp -R --no-preserve=mode,ownership ${lib.escapeShellArg "${e.src}"} "$target"
+      chmod -R u+w "$(dirname "$target")"
+      printf '%s = %s\n' ${lib.escapeShellArg (builtins.toJSON e.virt)} ${lib.escapeShellArg (builtins.toJSON ("fs" + e.virt))} >> "$pkg_dir/wasmer.toml"
+    '') fsEntries}
+  ''}
+
+  '';
+})

--- a/pkgs/wasmer/wrap-wasmer-package.nix
+++ b/pkgs/wasmer/wrap-wasmer-package.nix
@@ -1,16 +1,18 @@
-{ pkgs }:
-{ package, name }:
-pkgs.runCommand "wasmer-wrapped-${package.name}" { meta.mainProgram = name; } ''
-  set -euo pipefail
-  mkdir -p "$out/bin"
-  for wasm_path in "${package}/pkg/"*/bin/*.wasm; do
-    [ -f "$wasm_path" ] || continue
-    wasm_file=$(basename "$wasm_path")
-    cmd_name="''${wasm_file%.wasm}"
-    cat > "$out/bin/$cmd_name" <<WRAP
-#!/bin/sh
-exec wasmer run \$WASMER_FLAGS "$wasm_path" -- "\$@"
-WRAP
-    chmod +x "$out/bin/$cmd_name"
-  done
+{pkgs}: {
+  package,
+  name,
+}:
+pkgs.runCommand "wasmer-wrapped-${package.name}" {meta.mainProgram = name;} ''
+    set -euo pipefail
+    mkdir -p "$out/bin"
+    for wasm_path in "${package}/pkg/"*/bin/*.wasm; do
+      [ -f "$wasm_path" ] || continue
+      wasm_file=$(basename "$wasm_path")
+      cmd_name="''${wasm_file%.wasm}"
+      cat > "$out/bin/$cmd_name" <<WRAP
+  #!/bin/sh
+  exec wasmer run \$WASMER_FLAGS "$wasm_path" -- "\$@"
+  WRAP
+      chmod +x "$out/bin/$cmd_name"
+    done
 ''

--- a/pkgs/wasmer/wrap-wasmer-package.nix
+++ b/pkgs/wasmer/wrap-wasmer-package.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+{ package, name }:
+pkgs.runCommand "wasmer-wrapped-${package.name}" { meta.mainProgram = name; } ''
+  set -euo pipefail
+  mkdir -p "$out/bin"
+  for wasm_path in "${package}/pkg/"*/bin/*.wasm; do
+    [ -f "$wasm_path" ] || continue
+    wasm_file=$(basename "$wasm_path")
+    cmd_name="''${wasm_file%.wasm}"
+    cat > "$out/bin/$cmd_name" <<WRAP
+#!/bin/sh
+exec wasmer run \$WASMER_FLAGS "$wasm_path" -- "\$@"
+WRAP
+    chmod +x "$out/bin/$cmd_name"
+  done
+''

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,34 @@
+# tests/
+
+Nix-based integration tests that verify WASIX program behavior.
+
+## Structure
+
+- `lib.nix` — test primitives (`mkWasixRun`, `mkScriptComparison`, etc.)
+- `default.nix` — collects all program test suites into a grouped attrset
+- `programs/<name>/` — test suite per program; `helpers.nix` (if present) provides shared setup
+
+## Test patterns
+
+**`mkWasixRun`** — run a script under wasmer; pass if it exits 0.
+
+**`mkScriptComparison`** — run a script both natively and under wasmer, diff the outputs; pass if identical. Accepts an optional `normalize` script for deterministic comparison.
+
+## Running
+
+```sh
+# All tests
+nix build .#tests.all
+
+# Single program group
+nix build .#tests.git.all
+
+# Single test
+nix build .#tests.git.workflow-compare
+```
+
+To test against a local wasmer binary:
+
+```sh
+WASMER_BIN=/path/to/wasmer nix build .#tests.all --impure
+```

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,8 +1,8 @@
-{ pkgs, wasmerPkgs }:
+{ pkgs, wasmerPkgs, wasmer ? null }:
 let
   lib = pkgs.lib;
 
-  testLib = import ./lib.nix { inherit pkgs; };
+  testLib = import ./lib.nix { inherit pkgs wasmer; };
 
   makeAll = name: tests:
     pkgs.runCommand "test-all-${name}" { } ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, wasmerPkgs }:
+let
+  lib = pkgs.lib;
+
+  testLib = import ./lib.nix { inherit pkgs; };
+
+  makeAll = name: tests:
+    pkgs.runCommand "test-all-${name}" { } ''
+      ${lib.concatMapStringsSep "\n"
+        (n: "echo 'PASS: ${n}'; cat ${tests.${n}} > /dev/null")
+        (builtins.attrNames tests)}
+      touch $out
+    '';
+
+  importProgramTests = dir:
+    let
+      helpers =
+        if builtins.pathExists "${dir}/helpers.nix"
+        then import "${dir}/helpers.nix" { inherit pkgs; }
+        else {};
+      scope = { inherit pkgs wasmerPkgs testLib helpers; };
+      testFiles = lib.filterAttrs (name: type:
+        type == "regular" && lib.hasSuffix ".nix" name && name != "helpers.nix"
+      ) (builtins.readDir dir);
+    in
+    builtins.foldl'
+      (acc: name:
+        let
+          f = import "${dir}/${name}";
+        in acc // f (builtins.intersectAttrs (lib.functionArgs f) scope))
+      {}
+      (builtins.attrNames testFiles);
+
+  groups = lib.mapAttrs (name: _:
+    let tests = importProgramTests ./programs/${name};
+        all = makeAll name tests;
+    in all // tests // { inherit all; }
+  ) (lib.filterAttrs (_: type: type == "directory") (builtins.readDir ./programs));
+in
+  groups // { all = makeAll "all" (lib.mapAttrs (_: g: g.all) groups); }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -1,4 +1,4 @@
-{pkgs}: let
+{ pkgs, wasmer ? null }: let
   lib = pkgs.lib;
   # Set WASMER_BIN=/path/to/wasmer and build with --impure to test against a local binary.
   localWasmerBin = builtins.getEnv "WASMER_BIN";
@@ -23,6 +23,7 @@
           chmod +x $out/bin/wasmer
         '';
       }
+    else if wasmer != null then wasmer
     else pkgs.wasmer;
 in rec {
   # Run a bash script with the given packages in PATH.

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -1,0 +1,150 @@
+{pkgs}: let
+  lib = pkgs.lib;
+  # Set WASMER_BIN=/path/to/wasmer and build with --impure to test against a local binary.
+  localWasmerBin = builtins.getEnv "WASMER_BIN";
+
+  # Wrap the local binary in a proper nix derivation so the sandbox can access it.
+  # autoPatchelfHook re-links it against nixpkgs's own copies of glibc/libffi/etc.
+  effectiveWasmer =
+    if localWasmerBin != ""
+    then
+      pkgs.stdenv.mkDerivation {
+        name = "local-wasmer";
+        src = builtins.path {
+          path = localWasmerBin;
+          name = "wasmer";
+        };
+        dontUnpack = true;
+        nativeBuildInputs = [pkgs.autoPatchelfHook];
+        buildInputs = [pkgs.glibc pkgs.libffi pkgs.zlib pkgs.stdenv.cc.cc.lib];
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/wasmer
+          chmod +x $out/bin/wasmer
+        '';
+      }
+    else pkgs.wasmer;
+in rec {
+  # Run a bash script with the given packages in PATH.
+  # $out is a file containing captured stdout+stderr.
+  mkScriptRun = {
+    name,
+    script,
+    packages ? [],
+    extra ? [],
+  }: let
+    scriptFile =
+      if builtins.isString script
+      then pkgs.writeShellScript "${name}.sh" script
+      else script;
+  in
+    pkgs.runCommand "script-run-${name}" {
+      nativeBuildInputs = extra ++ packages;
+    } ''
+      export HOME=$TMPDIR/home
+      mkdir -p "$HOME"
+      cd "$(mktemp -d)"
+      bash -euo pipefail ${scriptFile} >"$out" 2>&1 || { cat "$out" >&2; exit 1; }
+    '';
+
+  # Run a bash script with wasmer-package stubs available by name.
+  #
+  # For each binary in wasixPkgs, generates a shim that:
+  #   1. Computes WASMER_FLAGS at invocation time ($HOME, $(pwd) resolved then)
+  #   2. Calls the original wasmer-package stub, which reads $WASMER_FLAGS
+  #
+  # nativePkgs: native tools put directly in PATH (not shimmed)
+  # wasixPkgs:  wasmer-package outputs whose stubs get shims
+  # wasmerArgs: extra static wasmer flags appended after the defaults, e.g. ["--net"]
+  mkWasixRun = {
+    name,
+    script,
+    nativePkgs ? [],
+    wasixPkgs ? [],
+    wasmer ? effectiveWasmer,
+    wasmerArgs ? [],
+  }: let
+    scriptFile =
+      if builtins.isString script
+      then pkgs.writeShellScript "${name}.sh" script
+      else script;
+    wasixBinDirs = lib.concatStringsSep " " (map (p: "${p}/bin") wasixPkgs);
+    extraFlags = lib.escapeShellArgs wasmerArgs;
+  in
+    pkgs.runCommand "script-run-${name}" {
+      nativeBuildInputs = [wasmer] ++ nativePkgs ++ wasixPkgs;
+    } ''
+            export HOME=$TMPDIR/home
+            mkdir -p "$HOME"
+
+            shim_dir=$(mktemp -d)
+            for pkg_bin_dir in ${wasixBinDirs}; do
+              [ -d "$pkg_bin_dir" ] || continue
+              for original_bin in "$pkg_bin_dir/"*; do
+                [ -f "$original_bin" ] || continue
+                bin_name=$(basename "$original_bin")
+                cat > "$shim_dir/$bin_name" <<SHIMEOF
+      #!/bin/sh
+      export WASMER_FLAGS="--forward-host-env --volume /nix/store:/nix/store --volume \$HOME:\$HOME --volume \$WASIX_TEST_ROOT:\$WASIX_TEST_ROOT --cwd \$(pwd) ${extraFlags}"
+      exec "$original_bin" "\$@"
+      SHIMEOF
+                chmod +x "$shim_dir/$bin_name"
+              done
+            done
+
+            export WASIX_TEST_ROOT="$(mktemp -d)"
+            cd "$WASIX_TEST_ROOT"
+            PATH="$shim_dir:$PATH" bash -euo pipefail ${scriptFile} >"$out" 2>&1 || { cat "$out" >&2; exit 1; }
+    '';
+
+  # Run a script in both native and wasix environments.
+  # Returns { native, wasix } as output derivation pair.
+  mkScriptOutputs = {
+    name,
+    script,
+    common ? [],
+    nativePkgs,
+    wasixPkgs,
+    wasmer ? effectiveWasmer,
+    wasmerArgs ? [],
+  }: {
+    native = mkScriptRun {
+      name = "${name}-native";
+      inherit script;
+      packages = common ++ nativePkgs;
+    };
+    wasix = mkWasixRun {
+      name = "${name}-wasix";
+      inherit script wasmer wasmerArgs;
+      nativePkgs = common;
+      inherit wasixPkgs;
+    };
+  };
+
+  # Run a script in both environments and fail if outputs differ.
+  #
+  # normalize: optional executable invoked as `normalize native|wasix`, reading from stdin.
+  mkScriptComparison = {
+    name,
+    script,
+    common ? [],
+    nativePkgs,
+    wasixPkgs,
+    wasmer ? effectiveWasmer,
+    wasmerArgs ? [],
+    normalize ? null,
+  }: let
+    outputs = mkScriptOutputs {inherit name script common nativePkgs wasixPkgs wasmer wasmerArgs;};
+    process = mode: out:
+      if normalize == null
+      then out
+      else
+        pkgs.runCommand "normalize-${name}-${mode}" {} ''
+          ${normalize} ${mode} < ${out} > $out
+        '';
+  in
+    pkgs.runCommand "wasix-compare-${name}" {} ''
+      ${pkgs.diffutils}/bin/diff ${process "native" outputs.native} ${process "wasix" outputs.wasix}
+      touch $out
+    '';
+}

--- a/tests/programs/curl/basic.nix
+++ b/tests/programs/curl/basic.nix
@@ -1,0 +1,82 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  helpers,
+}: let
+  inherit (helpers) startHttpServer startHttpsServer;
+  nativeCurl = [pkgs.curl];
+  wasixCurl = [wasmerPkgs.curl];
+in {
+  version = testLib.mkWasixRun {
+    name = "curl-version";
+    wasixPkgs = wasixCurl;
+    script = "curl --version";
+  };
+
+  http-get = testLib.mkScriptComparison {
+    name = "curl-http-get";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpServer}
+      curl -s http://127.0.0.1:8765/hello.txt
+    '';
+  };
+
+  http-post = testLib.mkScriptComparison {
+    name = "curl-http-post";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpServer}
+      curl -s -X POST -d "hello world" http://127.0.0.1:8765/echo.cgi
+    '';
+  };
+
+  http-redirect = testLib.mkScriptComparison {
+    name = "curl-http-redirect";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpServer}
+      curl -s -L http://127.0.0.1:8765/redirect.cgi
+    '';
+  };
+
+  https-get = testLib.mkScriptComparison {
+    name = "curl-https-get";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpsServer}
+      curl -s --cacert "$HOME/server.crt" https://127.0.0.1:8766/hello.txt
+    '';
+  };
+
+  https-post = testLib.mkScriptComparison {
+    name = "curl-https-post";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpsServer}
+      curl -s --cacert "$HOME/server.crt" -X POST -d "hello world" https://127.0.0.1:8766/echo.cgi
+    '';
+  };
+
+  https-redirect = testLib.mkScriptComparison {
+    name = "curl-https-redirect";
+    nativePkgs = nativeCurl ++ [pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = wasixCurl;
+    wasmerArgs = ["--net"];
+    script = ''
+      ${startHttpsServer}
+      curl -s -L --cacert "$HOME/server.crt" https://127.0.0.1:8766/redirect.cgi
+    '';
+  };
+}

--- a/tests/programs/curl/helpers.nix
+++ b/tests/programs/curl/helpers.nix
@@ -1,0 +1,63 @@
+{ pkgs }:
+rec {
+  # Plain HTTP server on port 8765.
+  # Serves docroot/hello.txt, docroot/echo.cgi (echoes body), docroot/redirect.cgi (301→/hello.txt).
+  startHttpServer = ''
+    mkdir -p docroot
+    echo "hello" > docroot/hello.txt
+    cat > docroot/echo.cgi << 'CGI'
+#!/bin/sh
+printf "Content-Type: text/plain\r\n\r\n"
+${pkgs.coreutils}/bin/cat
+CGI
+    cat > docroot/redirect.cgi << 'CGI'
+#!/bin/sh
+printf "Status: 301 Moved Permanently\r\nLocation: /hello.txt\r\nContent-Type: text/plain\r\n\r\n"
+CGI
+    chmod +x docroot/echo.cgi docroot/redirect.cgi
+    cat > lighttpd.conf << EOF
+server.document-root = "$(pwd)/docroot"
+server.port = 8765
+server.bind = "127.0.0.1"
+server.modules = ("mod_cgi")
+server.errorlog = "$(pwd)/lighttpd.log"
+cgi.assign = (".cgi" => "")
+EOF
+    ${pkgs.lighttpd}/sbin/lighttpd -D -f lighttpd.conf &
+    sleep 1
+  '';
+
+  # TLS HTTP server on port 8766. Same docroot as startHttpServer.
+  # Copies the self-signed cert to $HOME/server.crt for use with --cacert.
+  startHttpsServer = ''
+    mkdir -p docroot
+    echo "hello" > docroot/hello.txt
+    cat > docroot/echo.cgi << 'CGI'
+#!/bin/sh
+printf "Content-Type: text/plain\r\n\r\n"
+${pkgs.coreutils}/bin/cat
+CGI
+    cat > docroot/redirect.cgi << 'CGI'
+#!/bin/sh
+printf "Status: 301 Moved Permanently\r\nLocation: /hello.txt\r\nContent-Type: text/plain\r\n\r\n"
+CGI
+    chmod +x docroot/echo.cgi docroot/redirect.cgi
+    ${pkgs.openssl}/bin/openssl req -x509 -newkey rsa:2048 \
+      -keyout server.key -out server.crt -days 1 -nodes \
+      -subj "/CN=127.0.0.1" 2>/dev/null
+    cat > lighttpd.conf << EOF
+server.document-root = "$(pwd)/docroot"
+server.port = 8766
+server.bind = "127.0.0.1"
+server.modules = ("mod_cgi", "mod_openssl")
+server.errorlog = "$(pwd)/lighttpd.log"
+ssl.engine = "enable"
+ssl.pemfile = "$(pwd)/server.crt"
+ssl.privkey = "$(pwd)/server.key"
+cgi.assign = (".cgi" => "")
+EOF
+    ${pkgs.lighttpd}/sbin/lighttpd -D -f lighttpd.conf &
+    sleep 1
+    cp server.crt "$HOME/server.crt"
+  '';
+}

--- a/tests/programs/git/basic.nix
+++ b/tests/programs/git/basic.nix
@@ -1,0 +1,109 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  helpers,
+}: let
+  inherit (helpers) gitNative normalizeGitPaths gitSetup;
+in {
+  version = testLib.mkWasixRun {
+    name = "version";
+    wasixPkgs = [wasmerPkgs.git];
+    script = "git --version";
+  };
+
+  version-compare = testLib.mkScriptComparison {
+    name = "version";
+    nativePkgs = [gitNative];
+    wasixPkgs = [wasmerPkgs.git];
+    normalize = normalizeGitPaths;
+    script = "git --version";
+  };
+
+  workflow = testLib.mkWasixRun {
+    name = "workflow";
+    wasixPkgs = [wasmerPkgs.git];
+    script = ''
+      ${gitSetup}
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      git --no-pager log --oneline
+    '';
+  };
+
+  workflow-compare = testLib.mkScriptComparison {
+    name = "workflow";
+    nativePkgs = [gitNative];
+    wasixPkgs = [wasmerPkgs.git];
+    normalize = normalizeGitPaths;
+    script = ''
+      ${gitSetup}
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      echo "world" >> hello.txt
+      git add .
+      git commit -m "second commit"
+      git --no-pager log --oneline
+    '';
+  };
+
+  diff = testLib.mkWasixRun {
+    name = "diff";
+    wasixPkgs = [wasmerPkgs.git];
+    script = ''
+      ${gitSetup}
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      echo "world" >> hello.txt
+      git --no-pager diff hello.txt
+      git add .
+      git commit -m "second commit"
+      git --no-pager diff HEAD~1 HEAD
+    '';
+  };
+
+  diff-compare = testLib.mkScriptComparison {
+    name = "diff";
+    nativePkgs = [gitNative];
+    wasixPkgs = [wasmerPkgs.git];
+    normalize = normalizeGitPaths;
+    script = ''
+      ${gitSetup}
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      echo "world" >> hello.txt
+      git --no-pager diff hello.txt
+      git add .
+      git commit -m "second commit"
+      git --no-pager diff HEAD~1 HEAD
+    '';
+  };
+
+  branch = testLib.mkWasixRun {
+    name = "branch";
+    wasixPkgs = [wasmerPkgs.git];
+    script = ''
+      ${gitSetup}
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      git checkout -b feature
+      echo "feature content" > feature.txt
+      git add .
+      git commit -m "add feature"
+      git checkout main
+      git merge --no-edit feature
+      git --no-pager log --oneline
+      cat feature.txt
+    '';
+  };
+}

--- a/tests/programs/git/git-daemon.nix
+++ b/tests/programs/git/git-daemon.nix
@@ -1,0 +1,103 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  helpers,
+}: let
+  inherit (helpers) gitSetup;
+in {
+  clone-net = testLib.mkWasixRun {
+    name = "clone-net";
+    nativePkgs = [pkgs.git];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      mkdir source && cd source
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      cd ..
+      ${pkgs.git}/bin/git daemon --base-path=. --export-all --reuseaddr --port=9418 &
+      sleep 1
+      git clone git://127.0.0.1:9418/source cloned
+      cat cloned/hello.txt
+    '';
+  };
+
+  fetch-net = testLib.mkWasixRun {
+    name = "fetch-net";
+    nativePkgs = [pkgs.git];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      mkdir source && cd source
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      cd ..
+      ${pkgs.git}/bin/git daemon --base-path=. --export-all --reuseaddr --port=9418 &
+      sleep 1
+      git clone git://127.0.0.1:9418/source cloned
+      echo "world" >> source/hello.txt
+      ${pkgs.git}/bin/git -C source add .
+      ${pkgs.git}/bin/git -C source commit -m "second commit"
+      cd cloned
+      git fetch origin
+      git --no-pager log --oneline origin/main
+    '';
+  };
+
+  push-net = testLib.mkWasixRun {
+    name = "push-net";
+    nativePkgs = [pkgs.git];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${pkgs.git}/bin/git init --bare remote.git
+      ${pkgs.git}/bin/git daemon --base-path=. --enable=receive-pack \
+        --export-all --reuseaddr --port=9418 &
+      sleep 1
+      mkdir work && cd work
+      git init
+      git remote add origin git://127.0.0.1:9418/remote.git
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      git push origin main
+      cd ..
+      git clone git://127.0.0.1:9418/remote.git cloned
+      cat cloned/hello.txt
+    '';
+  };
+
+  pull-net = testLib.mkWasixRun {
+    name = "pull-net";
+    nativePkgs = [pkgs.git];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      mkdir source && cd source
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      cd ..
+      ${pkgs.git}/bin/git daemon --base-path=. --export-all --reuseaddr --port=9418 &
+      sleep 1
+      git clone git://127.0.0.1:9418/source cloned
+      cat cloned/hello.txt
+      echo "world" >> source/hello.txt
+      ${pkgs.git}/bin/git -C source add .
+      ${pkgs.git}/bin/git -C source commit -m "second commit"
+      cd cloned
+      git pull
+      cat hello.txt
+    '';
+  };
+}

--- a/tests/programs/git/helpers.nix
+++ b/tests/programs/git/helpers.nix
@@ -1,0 +1,101 @@
+{ pkgs }:
+rec {
+  gitNative = pkgs.gitMinimal.override {
+    nlsSupport = false;
+    svnSupport = false;
+    guiSupport = false;
+    sendEmailSupport = false;
+    withLibsecret = false;
+    withSsh = false;
+    doInstallCheck = false;
+    rustSupport = false;
+    bash = null;
+  };
+
+  # Normalize paths and ANSI codes so native and WASM outputs can be diff'd.
+  normalizeGitPaths = pkgs.writeShellScript "normalize-git-paths" ''
+    sed -e 's/\r//' \
+        -e 's/\x1b\[[0-9;]*m//g' \
+        -e 's|Initialized empty Git repository in .*/\.git/|Initialized empty Git repository in TMPDIR/.git/|'
+  '';
+
+  # Common setup for all tests: identity, deterministic timestamps, no noise.
+  gitSetup = ''
+    git config --global user.email "test@example.com"
+    git config --global user.name "Test"
+    git config --global init.defaultBranch main
+    git config --global advice.detachedHead false
+    git config --global advice.statusHints false
+    git config --global log.decorate false
+    export GIT_AUTHOR_DATE="2000-01-01T00:00:00+00:00"
+    export GIT_COMMITTER_DATE="2000-01-01T00:00:00+00:00"
+  '';
+
+  # Create repos/remote.git (bare, one "hello" commit) and docroot/ via native git.
+  setupNativeRemote = ''
+    mkdir -p repos source docroot
+    ${pkgs.git}/bin/git -C source init --initial-branch=main
+    echo "hello" > source/hello.txt
+    ${pkgs.git}/bin/git -C source add .
+    ${pkgs.git}/bin/git -C source commit -m "initial commit"
+    ${pkgs.git}/bin/git init --bare --initial-branch=main repos/remote.git
+    ${pkgs.git}/bin/git -C source push ../repos/remote.git HEAD:main
+  '';
+
+  # Write docroot/git-http-backend wrapper that bakes the env vars in.
+  # GIT_HTTP_RECEIVE_PACK env var alone is not reliably inherited through
+  # lighttpd's CGI; git config http.receivepack is the authoritative knob.
+  makeGitHttpBackendWrapper = { receivePack ? false }: ''
+    repos_path=$(realpath repos)
+    cat > docroot/git-http-backend << WRAPPER
+#!/bin/sh
+export GIT_HTTP_EXPORT_ALL=1
+export GIT_PROJECT_ROOT=$repos_path
+${if receivePack then "export GIT_HTTP_RECEIVE_PACK=1" else ""}
+exec ${pkgs.git}/libexec/git-core/git-http-backend
+WRAPPER
+    chmod +x docroot/git-http-backend
+    ${if receivePack then "${pkgs.git}/bin/git -C repos/remote.git config http.receivepack true" else ""}
+  '';
+
+  # Start lighttpd on port 8765 (HTTP). receivePack enables push.
+  startLighttpdHttp = { receivePack ? false }: ''
+    mkdir -p docroot
+    ${makeGitHttpBackendWrapper { inherit receivePack; }}
+    cat > lighttpd.conf << EOF
+server.document-root = "$(pwd)/docroot"
+server.port = 8765
+server.bind = "127.0.0.1"
+server.modules = ("mod_cgi")
+server.errorlog = "/dev/stderr"
+cgi.assign = ("git-http-backend" => "")
+EOF
+    ${pkgs.lighttpd}/sbin/lighttpd -D -f lighttpd.conf &
+    sleep 1
+  '';
+
+  # Start lighttpd on port 8766 (HTTPS). Generates a self-signed cert and
+  # copies it to $HOME/server.crt so WASM git can find it via GIT_SSL_CAINFO.
+  startLighttpdHttps = { receivePack ? false }: ''
+    mkdir -p docroot
+    ${makeGitHttpBackendWrapper { inherit receivePack; }}
+    ${pkgs.openssl}/bin/openssl req -x509 -newkey rsa:2048 \
+      -keyout server.key -out server.crt -days 1 -nodes \
+      -subj "/CN=127.0.0.1"
+    cat > lighttpd.conf << EOF
+server.document-root = "$(pwd)/docroot"
+server.port = 8766
+server.bind = "127.0.0.1"
+server.modules = ("mod_cgi", "mod_openssl")
+server.errorlog = "/dev/stderr"
+cgi.assign = ("git-http-backend" => "")
+ssl.engine = "enable"
+ssl.pemfile = "$(pwd)/server.crt"
+ssl.privkey = "$(pwd)/server.key"
+EOF
+    ${pkgs.lighttpd}/sbin/lighttpd -D -f lighttpd.conf &
+    sleep 1
+    cp server.crt "$HOME/server.crt"
+    export GIT_SSL_CAINFO=$HOME/server.crt
+  '';
+}

--- a/tests/programs/git/http.nix
+++ b/tests/programs/git/http.nix
@@ -1,0 +1,114 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  helpers,
+}: let
+  inherit (helpers) gitSetup setupNativeRemote startLighttpdHttp startLighttpdHttps;
+in {
+  clone-http = testLib.mkWasixRun {
+    name = "clone-http";
+    nativePkgs = [pkgs.git pkgs.lighttpd];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttp {}}
+      git clone http://127.0.0.1:8765/git-http-backend/remote.git cloned
+      cat cloned/hello.txt
+    '';
+  };
+
+  fetch-http = testLib.mkWasixRun {
+    name = "fetch-http";
+    nativePkgs = [pkgs.git pkgs.lighttpd];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttp {}}
+      git clone http://127.0.0.1:8765/git-http-backend/remote.git cloned
+      echo "world" >> source/hello.txt
+      ${pkgs.git}/bin/git -C source add .
+      ${pkgs.git}/bin/git -C source commit -m "second commit"
+      ${pkgs.git}/bin/git -C source push ../repos/remote.git HEAD:main
+      cd cloned
+      git fetch origin
+      git --no-pager log --oneline origin/main
+    '';
+  };
+
+  push-http = testLib.mkWasixRun {
+    name = "push-http";
+    nativePkgs = [pkgs.git pkgs.lighttpd];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttp {receivePack = true;}}
+      git clone http://127.0.0.1:8765/git-http-backend/remote.git work
+      cd work
+      echo "world" >> hello.txt
+      git add .
+      git commit -m "second commit"
+      git push origin main
+      ${pkgs.git}/bin/git -C ../repos/remote.git log --oneline
+    '';
+  };
+
+  clone-https = testLib.mkWasixRun {
+    name = "clone-https";
+    nativePkgs = [pkgs.git pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttps {}}
+      git clone https://127.0.0.1:8766/git-http-backend/remote.git cloned
+      cat cloned/hello.txt
+    '';
+  };
+
+  fetch-https = testLib.mkWasixRun {
+    name = "fetch-https";
+    nativePkgs = [pkgs.git pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttps {}}
+      git clone https://127.0.0.1:8766/git-http-backend/remote.git cloned
+      echo "world" >> source/hello.txt
+      ${pkgs.git}/bin/git -C source add .
+      ${pkgs.git}/bin/git -C source commit -m "second commit"
+      ${pkgs.git}/bin/git -C source push ../repos/remote.git HEAD:main
+      cd cloned
+      git fetch origin
+      git --no-pager log --oneline origin/main
+    '';
+  };
+
+  push-https = testLib.mkWasixRun {
+    name = "push-https";
+    nativePkgs = [pkgs.git pkgs.lighttpd pkgs.openssl];
+    wasixPkgs = [wasmerPkgs.git];
+    wasmerArgs = ["--net"];
+    script = ''
+      ${gitSetup}
+      ${setupNativeRemote}
+      ${startLighttpdHttps {receivePack = true;}}
+      git clone https://127.0.0.1:8766/git-http-backend/remote.git work
+      cd work
+      echo "world" >> hello.txt
+      git add .
+      git commit -m "second commit"
+      git push origin main
+      ${pkgs.git}/bin/git -C ../repos/remote.git log --oneline
+    '';
+  };
+}

--- a/tests/programs/git/local-transport.nix
+++ b/tests/programs/git/local-transport.nix
@@ -1,0 +1,53 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  helpers,
+}: let
+  inherit (helpers) gitSetup;
+in {
+  clone-local = testLib.mkWasixRun {
+    name = "clone-local";
+    wasixPkgs = [wasmerPkgs.git];
+    script = ''
+      ${gitSetup}
+      mkdir source
+      cd source
+      git init
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      cd ..
+      git clone source cloned
+      cat cloned/hello.txt
+    '';
+  };
+
+  push-local = testLib.mkWasixRun {
+    name = "push-local";
+    nativePkgs = [pkgs.git];
+    wasixPkgs = [wasmerPkgs.git];
+    script = ''
+      ${gitSetup}
+      ${pkgs.git}/bin/git init --bare --initial-branch=main remote.git
+      mkdir work && cd work
+      git init
+      git remote add origin "$WASIX_TEST_ROOT/remote.git"
+      echo "hello" > hello.txt
+      git add .
+      git commit -m "initial commit"
+      git push origin main
+      cd ..
+      git clone "$WASIX_TEST_ROOT/remote.git" cloned
+      cat cloned/hello.txt
+      cd work
+      echo "world" >> hello.txt
+      git add .
+      git commit -m "second commit"
+      git push origin main
+      cd ../cloned
+      git pull
+      cat hello.txt
+    '';
+  };
+}

--- a/tests/programs/sed/basic.nix
+++ b/tests/programs/sed/basic.nix
@@ -1,0 +1,71 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  ...
+}: let
+  nativeSed = [pkgs.gnused];
+  wasixSed = [wasmerPkgs.sed];
+in {
+  version = testLib.mkWasixRun {
+    name = "sed-version";
+    wasixPkgs = wasixSed;
+    script = "sed --version";
+  };
+
+  substitute = testLib.mkScriptComparison {
+    name = "sed-substitute";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      echo "hello world" | sed 's/world/there/'
+    '';
+  };
+
+  delete = testLib.mkScriptComparison {
+    name = "sed-delete";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      printf 'keep\ndelete me\nkeep\n' | sed '/delete/d'
+    '';
+  };
+
+  print = testLib.mkScriptComparison {
+    name = "sed-print";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      printf 'foo\nbar\nbaz\n' | sed -n '/bar/p'
+    '';
+  };
+
+  address-range = testLib.mkScriptComparison {
+    name = "sed-address-range";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      printf 'a\nb\nc\nd\ne\n' | sed '2,4d'
+    '';
+  };
+
+  inplace = testLib.mkScriptComparison {
+    name = "sed-inplace";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      echo "hello world" > test.txt
+      sed -i 's/world/there/' test.txt
+      cat test.txt
+    '';
+  };
+
+  multiple-expressions = testLib.mkScriptComparison {
+    name = "sed-multiple-expressions";
+    nativePkgs = nativeSed;
+    wasixPkgs = wasixSed;
+    script = ''
+      echo "foo bar baz" | sed -e 's/foo/FOO/' -e 's/bar/BAR/'
+    '';
+  };
+}


### PR DESCRIPTION
Adds git, as well as various dependencies.
While git works, keep in mind that advanced features like commit signing or credential helpers won't work.

---
Some notes:

It adds curl as a program. It's currently already packaged as a library, so this is a bit of a duplication. The program curl serves as a basic test case of the test framework itself (more on that in a bit).
A small shim for `sh` is added, that exclusively allows launching programs, with no further syntax (e.g. `sh -c "foo --bar"`). Used for trivial scripts with shebangs.
Uses some questionable(?) hacks to get git to fork properly. I'm far from an expert on the details of forking in WASIX, so LMK if what I did there is sensible.

---
Adds a simple `.shim` output to wasmer packages, that allows `nix run .#wasmer.foobar.shim` to work, given that wasmer is in the PATH. (I intentionally made it look in the path rather than hardcoding it, though I'm not certain if that's for the best).

---
Adds a basic test framework for testing packages built, by running them with wasmer.
See `tests/README.md` for more info on tests.
TL;DR: run `nix build .#checks.x86_64-linux.all`, `.curl.all`, `.git.all`, `.git.push-https`, etc. Optionally with `WASMER_BIN=path/to/wasmer` and `--impure` to run against a local build of wasmer.

Note that currently it pulls in my fork of wasmer by default, due to upstreams nix packaging being out of date. This can be dropped once upstreams packaging is updated.
The branch also includes a few patches required for git to work properly.
Patches in question:
https://github.com/wasmerio/wasmer/pull/6581
https://github.com/wasmerio/wasmer/pull/6579
https://github.com/wasmerio/wasmer/pull/6578

---
Open ends:
- `--no-pager` is set because wasix does not properly communicate whether stdout is a TTY; fix that inside wasix
- Deduplicate curl (maybe merge programs & libraries into a nixpkgs-like `by-name/<first two letters>/<name>` structure, and have wasmer packages exist inside passthru, like `wasinix#wasix.curl.wasmerPkg` or similar?)
- Decide whether the `.shim` stuff should stay (it's currently mostly for tests, though can be convenient for general testing via the CLI)
- and if yes, decide whether the shims should hardcode the wasmer path, or keep looking it up in the users path
- Test and support more git functionality
- Copilot spotted a potential pre-existing bug during review of one of the PR reviews, [see here](https://github.com/wasmerio/wasmer/pull/6578#pullrequestreview-4255850957). Sounds credible enough to look into IMO