### PR TITLE
pkgs: support multi-package dirs in the package loader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,10 @@ scripts/update.py    pin updater (nix run .#update)
   `pkgs/lib/default.nix`). Never set `meta.badPlatforms`/`meta.broken`
   directly.
 - Package placement: name in `trivial.nix` / flat `packages/<name>.nix` /
-  `packages/<name>/package.nix` dir. Same in `python-packages/`. Only
-  `pkgs/lib/load-packages.nix` enumerates these dirs.
+  `packages/<name>/package.nix` dir; a dir's `package.nix` may be
+  `{names, packages}` for version families (icu). Same in
+  `python-packages/`. Only `pkgs/lib/load-packages.nix` enumerates these
+  dirs.
 - Tweaks go through `helpers.libTweaks` (phases concatenate, lists append,
   attrsets merge, scalars replace, functions get the old value). No
   `(old.X or []) ++ ...` in package files.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -6,6 +6,9 @@ Lightest form that works (the loader finds all of these):
 - Changes, no extra files: `pkgs/overlay/packages/<name>.nix`.
 - Patches/tests: `pkgs/overlay/packages/<name>/` with `package.nix`,
   `patches/`, `tests/`.
+- Version families (icu, icu-data): one dir whose `package.nix` evaluates to
+  `{names, packages}` instead of a function; `names` is the static attr list
+  it provides, `packages = callArgs: {<name> = drv;}`.
 
 A package file is a function over one argument set:
 

--- a/pkgs/lib/load-packages.nix
+++ b/pkgs/lib/load-packages.nix
@@ -1,5 +1,8 @@
 # Auto-import convention for wasix package sets: a package is <dir>/<name>.nix,
 # <dir>/<name>/package.nix, or (if it needs no tweaks) a name in `trivial`.
+# A dir's package.nix may also evaluate to {names, packages} instead of a
+# function: a multi-package dir (version families like icu). `names` is the
+# static attr list it provides; `packages = callArgs: {<name> = drv;}`.
 # default.nix and dirs without a package.nix (e.g. shared patches/) are ignored.
 # Used by both the top-level overlay and the python packageOverrides, so the
 # convention can't drift between sets. `names` is eval-only (no callArgs),
@@ -18,8 +21,21 @@
   dirNames =
     builtins.filter (n: builtins.pathExists (dir + "/${n}/package.nix"))
     (lib.attrNames (lib.filterAttrs (_: t: t == "directory") entries));
+  dirEntry = n: import (dir + "/${n}/package.nix");
+  isMulti = e: !builtins.isFunction e;
 in {
-  names = fileNames ++ dirNames ++ trivial;
+  names =
+    fileNames
+    ++ lib.concatMap (
+      n: let
+        e = dirEntry n;
+      in
+        if isMulti e
+        then e.names
+        else [n]
+    )
+    dirNames
+    ++ trivial;
 
   # Instantiate the set: every package file is a function over one `callArgs`
   # attrset; trivial names go through `mkTrivial`.
@@ -29,5 +45,16 @@ in {
   }:
     (lib.genAttrs trivial mkTrivial)
     // (lib.genAttrs fileNames (n: import (dir + "/${n}.nix") callArgs))
-    // (lib.genAttrs dirNames (n: import (dir + "/${n}/package.nix") callArgs));
+    // (builtins.foldl' (
+        acc: n: let
+          e = dirEntry n;
+        in
+          acc
+          // (
+            if isMulti e
+            then e.packages callArgs
+            else {${n} = e callArgs;}
+          )
+      ) {}
+      dirNames);
 }


### PR DESCRIPTION
A dir's package.nix may evaluate to {names, packages} instead of a function, providing a whole version family from one file.