### PR TITLE
feat(pyarrow): enable parquet support

### DIFF
--- a/WASIX-TODO.md
+++ b/WASIX-TODO.md
@@ -93,13 +93,19 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
   run in a cross build.
 - Fix: binaryen asyncify support for EH; upstream the wasixcc setting.
 
-### `wasm-opt` corrupts autoconf feature detection 🟡 (not re-verified)
+### `wasm-opt` corrupts autoconf/cmake feature detection 🟡
 
 - A failing wasm-opt run on a throwaway conftest makes `configure`
   false-negative a feature (sqlite: "Cannot find libm functions").
+- Root cause (re-verified 2026-07-13, thrift at eh): function-exists probes
+  declare wrong signatures (`char strerror_r();`); wasm-ld silently links
+  that into invalid wasm, and wasm-opt fatals parsing it. Only eh is hit:
+  wasixcc always appends `--emit-exnref` there, so wasm-opt runs even for
+  -O0 probes; the other profiles skip it (no passes at -O0).
 - Workaround: `disableWasmOptInConfigureHook`, opt-in per package (sqlite,
-  libzip).
-- Fix: skip or tolerate wasm-opt during configure.
+  libzip, thrift).
+- Fix: wasm-ld should reject signature-mismatched direct calls (LLVM fork),
+  or wasixcc's autoconf workarounds mode skips post-link wasm-opt.
 
 ## Packages that don't cross-build
 

--- a/pkgs/overlay/packages/arrow-cpp.nix
+++ b/pkgs/overlay/packages/arrow-cpp.nix
@@ -1,10 +1,9 @@
 # arrow-cpp for wasix: a minimal static build carrying exactly what pyarrow
-# needs (compute/csv/json/filesystem/ipc + zlib/zstd/lz4 codecs). All
-# network/storage backends, allocators (jemalloc/mimalloc don't target wasm),
-# orc/parquet/dataset/acero and the test/utility executables are off. snappy
-# in this overlay is off-ABI only, so it stays disabled too. RapidJSON comes
-# BUNDLED (header-only vendor drop) because nixpkgs' rapidjson derivation
-# builds wasm gtest binaries.
+# needs (compute/csv/json/filesystem/ipc/parquet + zlib/zstd/lz4/snappy
+# codecs). All network/storage backends, allocators (jemalloc/mimalloc don't
+# target wasm), orc/dataset/acero and the test/utility executables are off.
+# RapidJSON comes BUNDLED (header-only vendor drop) because nixpkgs'
+# rapidjson derivation builds wasm gtest binaries.
 {
   final,
   prev,
@@ -26,8 +25,8 @@ in
     # replace nixpkgs' full input set (orc/boost/grpc/gtest/... don't
     # cross-build); the static stdenv mirrors buildInputs into
     # propagatedBuildInputs, so replace both.
-    buildInputs = _: [final.zlib final.zstd final.lz4];
-    propagatedBuildInputs = _: [final.zlib final.zstd final.lz4];
+    buildInputs = _: [final.zlib final.zstd final.lz4 final.snappy final.thrift];
+    propagatedBuildInputs = _: [final.zlib final.zstd final.lz4 final.snappy final.thrift];
     doInstallCheck = false;
     # appended after nixpkgs' flags; for duplicated -D options the last wins
     cmakeFlags = [
@@ -43,10 +42,12 @@ in
       "-DARROW_HDFS=OFF"
       "-DARROW_DATASET=OFF"
       "-DARROW_ACERO=OFF"
-      "-DARROW_PARQUET=OFF"
+      "-DARROW_PARQUET=ON"
       "-DPARQUET_BUILD_EXECUTABLES=OFF"
       "-DPARQUET_REQUIRE_ENCRYPTION=OFF"
-      "-DARROW_WITH_SNAPPY=OFF"
+      # thrift pulls in a headers-only boost need; native headers serve
+      "-DBoost_INCLUDE_DIR=${final.buildPackages.boost.dev}/include"
+      "-DARROW_WITH_SNAPPY=ON"
       "-DARROW_WITH_BROTLI=OFF"
       "-DARROW_WITH_BZ2=OFF"
       "-DARROW_WITH_NLOHMANN_JSON=OFF"

--- a/pkgs/overlay/packages/snappy.nix
+++ b/pkgs/overlay/packages/snappy.nix
@@ -1,15 +1,14 @@
-# snappy's CMakeLists forces -fno-exceptions, which wasixcc deduces into
-# exceptions=off: whatever the profile, the artifact is built against the off
-# sysroot (the abi check caught eh columns shipping off-ABI snappy). Declare
-# what it actually is, an off-ABI library; nothing in the overlay consumes it
-# (matrix coverage only). If a consumer at an EH profile ever needs it, patch
-# the -fno-exceptions out of its CMakeLists instead.
+# Upstream forces -fno-exceptions, which wasixcc deduces into an off-ABI
+# artifact whatever the profile. Strip it; the profile decides.
 {
   prev,
   helpers,
   ...
 }:
 helpers.libTweaks {
-  passthru.wasix.supportedProfiles = ["off"];
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail ' -fno-exceptions"' '"'
+  '';
 }
 prev.snappy

--- a/pkgs/overlay/packages/thrift.nix
+++ b/pkgs/overlay/packages/thrift.nix
@@ -1,0 +1,35 @@
+# C++ runtime lib only, for parquet (arrow ships pre-generated thrift
+# sources). Boost is a header-only build dep; the native headers serve.
+{
+  final,
+  prev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  # eh: wasm-opt corrupts the function-exists probes (WASIX-TODO.md)
+  nativeBuildInputs = [final.disableWasmOptInConfigureHook];
+  cmakeFlags = [
+    "-DBUILD_COMPILER=OFF"
+    "-DWITH_AS3=OFF"
+    "-DWITH_C_GLIB=OFF"
+    "-DWITH_JAVA=OFF"
+    "-DWITH_JAVASCRIPT=OFF"
+    "-DWITH_NODEJS=OFF"
+    "-DWITH_PYTHON=OFF"
+    "-DWITH_OPENSSL=OFF"
+    "-DWITH_ZLIB=OFF"
+    "-DWITH_LIBEVENT=OFF"
+  ];
+  # throws (TException)
+  passthru.wasix.supportedProfiles = helpers.profiles.withEh;
+}
+(prev.thrift.override {
+  static = true;
+  boost = final.buildPackages.boost;
+  # unspliced withPackages would build a wasm env; only serves the compiler
+  python3 = final.buildPackages.python3;
+  openssl = null;
+  zlib = null;
+  libevent = null;
+})

--- a/pkgs/overlay/python-packages/patches/pyarrow-static-arrow-wasix.patch
+++ b/pkgs/overlay/python-packages/patches/pyarrow-static-arrow-wasix.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d550796..83ddcef 100644
+index d550796..0b8f0c0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -478,12 +478,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL
+@@ -478,11 +478,15 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL
                 PROPERTY COMPILE_FLAGS " -Wno-cast-qual ")
  endif()
  
@@ -13,36 +13,37 @@ index d550796..83ddcef 100644
      list(APPEND PYARROW_CPP_LINK_LIBS Arrow::arrow_shared)
 -  else()
 -    list(APPEND PYARROW_CPP_LINK_LIBS Arrow::arrow_static)
-   endif()
++  endif()
 +else()
-+  # static builds always link arrow itself (whole-archived below)
 +  list(APPEND PYARROW_CPP_LINK_LIBS Arrow::arrow_static)
++  if(PYARROW_BUILD_PARQUET)
++    # lazy link, for usage requirements only (headers, transitive thrift)
++    list(APPEND PYARROW_CPP_LINK_LIBS Parquet::parquet_static)
+   endif()
  endif()
  
- add_library(arrow_python SHARED ${PYARROW_CPP_SRCS})
-@@ -497,6 +498,16 @@ target_include_directories(arrow_python PUBLIC ${PYARROW_CPP_ROOT_DIR}
+@@ -497,6 +501,16 @@ target_include_directories(arrow_python PUBLIC ${PYARROW_CPP_ROOT_DIR}
  if(ARROW_BUILD_SHARED)
    target_link_libraries(arrow_python PUBLIC ${PYARROW_CPP_LINK_LIBS})
  else()
-+  # static build: every arrow symbol must land in (and be exported from)
-+  # libarrow_python.so; the cython modules link only arrow_python.
-+  # --whole-archive pulls all of libarrow.a into the dylib. The target still
-+  # follows for its usage requirements (includes, transitive codec libs); its
-+  # lazily-linked archive then contributes nothing (all symbols already
-+  # defined).
++  # the cython modules link only arrow_python, so it must export every
++  # arrow/parquet symbol: whole-archive the full archives into the dylib
++  set(PYARROW_WHOLE_ARCHIVE_LIBS "$<TARGET_FILE:Arrow::arrow_static>")
++  if(PYARROW_BUILD_PARQUET)
++    list(APPEND PYARROW_WHOLE_ARCHIVE_LIBS "$<TARGET_FILE:Parquet::parquet_static>")
++  endif()
 +  target_link_options(arrow_python PRIVATE
 +                      "-Wl,--whole-archive"
-+                      "$<TARGET_FILE:Arrow::arrow_static>"
++                      ${PYARROW_WHOLE_ARCHIVE_LIBS}
 +                      "-Wl,--no-whole-archive")
    target_link_libraries(arrow_python PRIVATE ${PYARROW_CPP_LINK_LIBS})
  endif()
  target_link_libraries(arrow_python PUBLIC Python3::NumPy)
-@@ -917,6 +928,9 @@ foreach(module ${CYTHON_EXTENSIONS})
+@@ -917,6 +931,8 @@ foreach(module ${CYTHON_EXTENSIONS})
    set_source_files_properties(${module_SRC} PROPERTIES CYTHON_IS_CXX TRUE)
  
    cython_add_module(${module_name} ${module_name}_pyx ${module_name}_output ${module_SRC})
-+  # static build: arrow headers aren't propagated through arrow_python's
-+  # PRIVATE link, include them directly
++  # arrow headers aren't propagated through arrow_python's PRIVATE link
 +  target_include_directories(${module_name} PRIVATE ${ARROW_INCLUDE_DIR})
  
    if(directories)

--- a/pkgs/overlay/python-packages/pyarrow.nix
+++ b/pkgs/overlay/python-packages/pyarrow.nix
@@ -1,8 +1,9 @@
 # pyarrow for wasix, over the minimal static arrow-cpp (see
-# overlay/packages/arrow-cpp.nix): no dataset/parquet/orc/flight/cloud-fs
+# overlay/packages/arrow-cpp.nix): parquet but no dataset/orc/flight/cloud-fs
 # extensions, all of arrow linked into libarrow_python.so (wasm has no shared
-# libarrow). The patch --whole-archives libarrow.a into libarrow_python.so so
-# every arrow symbol is exported for the cython modules. setup.py drives its
+# libarrow). The patch --whole-archives libarrow.a + libparquet.a into
+# libarrow_python.so so every symbol is exported for the cython modules.
+# setup.py drives its
 # own cmake (dontUseCmakeConfigure), so the cross identity and the wasix
 # python/numpy headers are injected via PYARROW_CMAKE_OPTIONS: cmake would
 # otherwise probe the build python and compile against native (64-bit long)
@@ -28,7 +29,7 @@ in
         NIX_LDFLAGS = "--rpath=$ORIGIN";
         PYARROW_WITH_DATASET = 0;
         PYARROW_WITH_HDFS = 0;
-        PYARROW_WITH_PARQUET = 0;
+        PYARROW_WITH_PARQUET = 1;
         PYARROW_WITH_PARQUET_ENCRYPTION = 0;
         PYARROW_CMAKE_OPTIONS = toString [
           "-DCMAKE_SYSTEM_NAME=Wasi"

--- a/pkgs/overlay/python-packages/wheels.nix
+++ b/pkgs/overlay/python-packages/wheels.nix
@@ -176,7 +176,10 @@
     attr = "grpcio";
     pyImport = "grpc";
   } # overlay/python-packages/grpcio.nix (vendored grpc core + abseil/boringssl/cares/re2/zlib)
-  {attr = "pyarrow";} # arrow-cpp; overlay/python-packages/pyarrow.nix
+  {
+    attr = "pyarrow";
+    pyImport = "pyarrow.parquet";
+  } # arrow-cpp; overlay/python-packages/pyarrow.nix
 
   # ── async / cython, no external C library ──────────────────────────────────────
   {attr = "aiohttp";} # vendored llhttp; deps multidict/yarl/frozenlist/aiosignal/…


### PR DESCRIPTION
PyArrow is often used for its Parquet implementation, and the default PyPi build has this enabled.

See #54 for the issue on this PR. 