### PR TITLE
pkgs: build pandoc to wasm32-wasi via ghc-wasm bindist + nixpkgs

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -37,6 +37,7 @@ package's own bindings) fires on every run until resolved.
 | `crabsay`               | branch head                     | hashes                                        |
 | `nixpkgs`               | flake input                     | stale keys out of `python-registry/rels.json` |
 | `wasmer`, `treefmt-nix` | flake inputs                    |                                               |
+| `ghc-wasm-meta`         | flake input (wasm GHC bindist)  | full haskell rebuild + wasm-patch re-verify   |
 
 libffi has no pin: it follows nixpkgs' libffi with the wasix-org fork's wasi
 backend vendored as a patch (`packages/libffi/wasi-backend.patch`).

--- a/flake.lock
+++ b/flake.lock
@@ -33,7 +33,62 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-wasm-meta": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "host": "gitlab.haskell.org",
+        "lastModified": 1736549295,
+        "narHash": "sha256-a9rXRaQcSnW2Sxsn0RD4hIlCpNC7R63jAJAyyjBviaw=",
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "rev": "6a8b8457df83025bed2a8759f5502725a827104b",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.haskell.org",
+        "owner": "haskell-wasm",
+        "repo": "ghc-wasm-meta",
+        "type": "gitlab"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1783224372,
         "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
@@ -51,7 +106,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "ghc-wasm-meta": "ghc-wasm-meta",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix",
         "wasmer": "wasmer"
       }
@@ -78,6 +134,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -136,7 +207,7 @@
     "wasmer": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # The wasm32-wasi GHC toolchain (used by pkgs/toolchain/haskell). nixpkgs left
+    # un-followed on purpose: its pinned node is load-bearing for TH.
+    ghc-wasm-meta.url = "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org";
   };
 
   outputs = {
@@ -23,6 +26,7 @@
     nixpkgs,
     wasmer,
     treefmt-nix,
+    ghc-wasm-meta,
     ...
   }: let
     system = "x86_64-linux";
@@ -39,6 +43,10 @@
       inherit system nixpkgs;
       # runs the behavioural passthru.tests on the webc packages.
       inherit wasmerRuntime;
+      # bindist GHC for the wasi haskell toolchain (toolchain.haskell); pandoc
+      # (overlay/packages/pandoc) builds against it. TemplateHaskell works under
+      # node there (memory: wasix-haskell-th-blocked).
+      ghcWasm = ghc-wasm-meta.packages.${system};
     };
     lib = wasix.pkgs.lib;
     wasixLib = import ./pkgs/lib {inherit lib;};

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,11 +3,13 @@
   nixpkgs,
   # wasmer runtime for the behavioural tests; null falls back to nixpkgs' wasmer.
   wasmerRuntime ? null,
+  # ghc-wasm-meta bindist GHC, for toolchain.haskell.
+  ghcWasm,
 }: let
   pkgs = import nixpkgs {inherit system;};
   inherit (pkgs) lib;
   wasixLib = import ./lib {inherit lib;};
-  toolchain = import ./toolchain {inherit pkgs;};
+  toolchain = import ./toolchain {inherit pkgs ghcWasm;};
 
   # The wasix cross target. Defined here (not derived from a profile) so
   # pkgsCross can be built before the profiles, which consume it for their

--- a/pkgs/overlay/default.nix
+++ b/pkgs/overlay/default.nix
@@ -114,11 +114,19 @@
         mkTrivial = n: helpers.libTweaks {} prev.${n};
         trivialPosition = ./trivial.nix;
       });
+
+  # `final.haskellPackages`, like nixpkgs' top-level attr: the toolchain's base
+  # wasi set plus the per-package overrides in ./haskell-packages (loaded like
+  # ./packages, the way python3.pkgs takes packageOverrides from ./python-packages).
+  haskellPackages = toolchain.haskell.packages.extend (import ./haskell-packages {
+    callArgs = {inherit final prev helpers lib toolchain;};
+  });
 in
   packages
   // rustSupport
   // wrapperFix
   // lib.optionalAttrs isWasixHost {
+    inherit haskellPackages;
     # Opt-in setup hook: disables wasm-opt during configurePhase so a wasm-opt
     # failure on a throwaway conftest can't corrupt feature detection (e.g.
     # sqlite/libzip's libm checks).

--- a/pkgs/overlay/haskell-packages/basement.nix
+++ b/pkgs/overlay/haskell-packages/basement.nix
@@ -1,0 +1,13 @@
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.basement (old: {
+  patches =
+    (old.patches or [])
+    ++ [
+      ./patches/basement/wasi-system.patch
+      ./patches/basement/wasi-terminal-size.patch
+    ];
+})

--- a/pkgs/overlay/haskell-packages/conduit-extra.nix
+++ b/pkgs/overlay/haskell-packages/conduit-extra.nix
@@ -1,0 +1,13 @@
+# no sockets: drop the network modules. editedCabalFile=null forces the LF sdist
+# cabal, since the Hackage revision is CRLF and breaks the patch.
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.conduit-extra (old: {
+  editedCabalFile = null;
+  revision = null;
+  patches = (old.patches or []) ++ [./patches/conduit-extra/wasi-drop-network.patch];
+  libraryHaskellDepends = (import ./lib/deps.nix).dropDeps ["network"] old.libraryHaskellDepends;
+})

--- a/pkgs/overlay/haskell-packages/crypton.nix
+++ b/pkgs/overlay/haskell-packages/crypton.nix
@@ -1,0 +1,7 @@
+# crypton's argon2 C uses threads; disable (wasm is single-threaded).
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.appendConfigureFlags hprev.crypton ["--ghc-option=-optc-DARGON2_NO_THREADS"]

--- a/pkgs/overlay/haskell-packages/default.nix
+++ b/pkgs/overlay/haskell-packages/default.nix
@@ -1,0 +1,8 @@
+# wasix overrides for the haskell package set (toolchain.haskell.packages), the
+# analogue of python-packages/. Each <name>.nix overrides that package for wasm;
+# patches under patches/. hfinal/hprev are the set fixpoint, haskellLib is
+# haskell.lib, dropDeps filters *HaskellDepends by name.
+{callArgs}: hfinal: hprev:
+(callArgs.helpers.loadPackageDir {dir = ./.;}).mkPackages {
+  callArgs = callArgs // {inherit hfinal hprev;};
+}

--- a/pkgs/overlay/haskell-packages/digest.nix
+++ b/pkgs/overlay/haskell-packages/digest.nix
@@ -1,0 +1,13 @@
+# -f-pkg-config makes digest use the haskell zlib, not the system C zlib.
+{
+  hfinal,
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.digest (old: {
+  configureFlags = (old.configureFlags or []) ++ ["-f-pkg-config"];
+  libraryPkgconfigDepends = [];
+  librarySystemDepends = [];
+  libraryHaskellDepends = (old.libraryHaskellDepends or []) ++ [hfinal.zlib];
+})

--- a/pkgs/overlay/haskell-packages/djot.nix
+++ b/pkgs/overlay/haskell-packages/djot.nix
@@ -1,0 +1,9 @@
+# wasm has no threaded RTS (libHSrts_thr); drop -threaded from the CLI exe.
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.djot (old: {
+  patches = (old.patches or []) ++ [./patches/djot/wasi-no-threaded.patch];
+})

--- a/pkgs/overlay/haskell-packages/jira-wiki-markup.nix
+++ b/pkgs/overlay/haskell-packages/jira-wiki-markup.nix
@@ -1,0 +1,9 @@
+# wasm has no threaded RTS (libHSrts_thr); drop -threaded from the CLI exe.
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.jira-wiki-markup (old: {
+  patches = (old.patches or []) ++ [./patches/jira-wiki-markup/wasi-no-threaded.patch];
+})

--- a/pkgs/overlay/haskell-packages/lib/deps.nix
+++ b/pkgs/overlay/haskell-packages/lib/deps.nix
@@ -1,0 +1,7 @@
+# shared helpers for the haskell overrides (like python-packages/lib/).
+{
+  # drop *HaskellDepends entries by exact package name: nixpkgs takes deps from
+  # hackage2nix, not the patched cabal, so a dep a wasm patch removes must also be
+  # filtered here.
+  dropDeps = names: builtins.filter (d: !(builtins.elem (d.pname or "") names));
+}

--- a/pkgs/overlay/haskell-packages/memory.nix
+++ b/pkgs/overlay/haskell-packages/memory.nix
@@ -1,0 +1,8 @@
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.memory (old: {
+  patches = (old.patches or []) ++ [./patches/memory/wasi.patch];
+})

--- a/pkgs/overlay/haskell-packages/pandoc-cli.nix
+++ b/pkgs/overlay/haskell-packages/pandoc-cli.nix
@@ -1,0 +1,43 @@
+# pandoc-cli with the lua/server engines off (their deps don't cross-compile).
+# -f-lua/-f-server disable the cabal flags, but nixpkgs' deps come from hackage2nix
+# (not the flags), so also filter the lua/server trees by name. GHC installs the
+# exe as bin/pandoc.wasm; nixpkgs' pandoc-cli override symlinks bin/pandoc-server
+# -> bin/pandoc (dangles, server disabled), so drop postInstall.
+{
+  hprev,
+  toolchain,
+  lib,
+  ...
+}: let
+  inherit (import ./lib/deps.nix) dropDeps;
+  hs = toolchain.haskell.lib;
+  dropLuaServer = deps:
+    dropDeps [
+      "pandoc-lua-engine"
+      "pandoc-server"
+      "pandoc-lua-marshal"
+      "lua"
+      "lpeg"
+      "isocline"
+      "readline"
+      "ncurses"
+      "warp"
+      "servant-server"
+      "network"
+      "http2"
+      "iproute"
+      "recv"
+      "simple-sendfile"
+      "http-semantics"
+      "http-api-data"
+      "servant"
+    ]
+    # hslua-* and wai-* are whole families; drop by prefix.
+    (builtins.filter (d: let n = d.pname or ""; in !(lib.hasPrefix "hslua" n || lib.hasPrefix "wai" n)) deps);
+in
+  hs.overrideCabal (hs.appendConfigureFlags hprev.pandoc-cli ["-f-lua" "-f-server"]) (old: {
+    patches = (old.patches or []) ++ [./patches/pandoc-cli/wasi-no-threaded.patch];
+    executableHaskellDepends = dropLuaServer (old.executableHaskellDepends or []);
+    libraryHaskellDepends = dropLuaServer (old.libraryHaskellDepends or []);
+    postInstall = "";
+  })

--- a/pkgs/overlay/haskell-packages/pandoc.nix
+++ b/pkgs/overlay/haskell-packages/pandoc.nix
@@ -1,0 +1,19 @@
+# wasm has no sockets; drop pandoc's HTTP/TLS stack (openURL is stubbed to error).
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.pandoc (old: {
+  patches = (old.patches or []) ++ [./patches/pandoc/wasi-drop-network.patch];
+  libraryHaskellDepends =
+    (import ./lib/deps.nix).dropDeps [
+      "http-client"
+      "http-client-tls"
+      "network"
+      "tls"
+      "crypton-connection"
+      "crypton-x509-system"
+    ]
+    old.libraryHaskellDepends;
+})

--- a/pkgs/overlay/haskell-packages/patches/basement/wasi-system.patch
+++ b/pkgs/overlay/haskell-packages/patches/basement/wasi-system.patch
@@ -1,0 +1,14 @@
+diff --git a/cbits/foundation_system.h b/cbits/foundation_system.h
+index 2419b43..f1cc8a9 100644
+--- a/cbits/foundation_system.h
++++ b/cbits/foundation_system.h
+@@ -53,6 +53,9 @@
+ #elif defined(_POSIX_VERSION)
+     #define FOUNDATION_SYSTEM_UNIX
+     // POSIX
++#elif defined(wasm32_HOST_ARCH)
++    #define FOUNDATION_SYSTEM_UNIX
++    // wasm32-wasi: POSIX-like
+ #else
+ #   error "foundation: system: Unknown compiler"
+ #endif

--- a/pkgs/overlay/haskell-packages/patches/basement/wasi-terminal-size.patch
+++ b/pkgs/overlay/haskell-packages/patches/basement/wasi-terminal-size.patch
@@ -1,0 +1,25 @@
+diff --git a/Basement/Terminal/Size.hsc b/Basement/Terminal/Size.hsc
+index 62c315e..07c80d2 100644
+--- a/Basement/Terminal/Size.hsc
++++ b/Basement/Terminal/Size.hsc
+@@ -31,6 +31,14 @@ import           Graphics.Win32.Misc (getStdHandle, sTD_OUTPUT_HANDLE, StdHandle
+ #let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
+ #endif
+ 
++#if defined(wasm32_HOST_ARCH)
++
++-- wasm32-wasi has no ioctl/TIOCGWINSZ; fall back to the default size.
++getDimensions :: IO (CountOf Char, CountOf Char)
++getDimensions = pure (CountOf 80, CountOf 24)
++
++#else
++
+ #ifdef FOUNDATION_SYSTEM_UNIX
+ data Winsize = Winsize
+     { ws_row    :: !Word16
+@@ -188,3 +196,5 @@ getDimensions =
+ #endif
+   where
+     defaultSize = (80, 24)
++
++#endif

--- a/pkgs/overlay/haskell-packages/patches/conduit-extra/wasi-drop-network.patch
+++ b/pkgs/overlay/haskell-packages/patches/conduit-extra/wasi-drop-network.patch
@@ -1,0 +1,41 @@
+diff --git a/conduit-extra.cabal b/conduit-extra.cabal
+index 6370404..322bf07 100644
+--- a/conduit-extra.cabal
++++ b/conduit-extra.cabal
+@@ -26,18 +26,25 @@ Library
+                        Data.Conduit.Filesystem
+                        Data.Conduit.Foldl
+                        Data.Conduit.Lazy
+-                       Data.Conduit.Network
+-                       Data.Conduit.Network.UDP
+-                       Data.Conduit.Network.Unix
+                        Data.Conduit.Process
+                        Data.Conduit.Process.Typed
+                        Data.Conduit.Text
+                        Data.Conduit.Zlib
+ 
++  -- wasm has no sockets (wasi-libc lacks netdb.h); drop the network modules.
++  if !arch(wasm32)
++      Exposed-modules:   Data.Conduit.Network
++                         Data.Conduit.Network.UDP
++  if !os(windows) && !arch(wasm32)
++      Exposed-modules:   Data.Conduit.Network.Unix
++
+   if arch(x86_64) || arch(i386)
+       -- These architectures are able to perform unaligned memory accesses
+       cpp-options: -DALLOW_UNALIGNED_ACCESS
+ 
++  if !arch(wasm32)
++      Build-depends:     network >= 2.3
++
+   Build-depends:       base                     >= 4.12         && < 5
+                      , conduit                  >= 1.3          && < 1.4
+ 
+@@ -49,7 +56,6 @@ Library
+                      , attoparsec               >= 0.10
+                      , directory
+                      , filepath
+-                     , network                  >= 2.3
+                      , primitive                >= 0.5
+                      , process
+                      , resourcet                >= 1.1

--- a/pkgs/overlay/haskell-packages/patches/djot/wasi-no-threaded.patch
+++ b/pkgs/overlay/haskell-packages/patches/djot/wasi-no-threaded.patch
@@ -1,0 +1,13 @@
+diff --git a/djot.cabal b/djot.cabal
+index c89babd..4e848ed 100644
+--- a/djot.cabal
++++ b/djot.cabal
+@@ -55,7 +55,7 @@ executable djoths
+                       text
+     hs-source-dirs:   app
+     default-language: Haskell2010
+-    ghc-options: -Wall -O2 -rtsopts -threaded
++    ghc-options: -Wall -O2 -rtsopts
+ 
+ test-suite test-djot
+   import: deps

--- a/pkgs/overlay/haskell-packages/patches/jira-wiki-markup/wasi-no-threaded.patch
+++ b/pkgs/overlay/haskell-packages/patches/jira-wiki-markup/wasi-no-threaded.patch
@@ -1,0 +1,13 @@
+diff --git a/jira-wiki-markup.cabal b/jira-wiki-markup.cabal
+index 11aac00..9050df0 100644
+--- a/jira-wiki-markup.cabal
++++ b/jira-wiki-markup.cabal
+@@ -73,7 +73,7 @@ executable jira-wiki-markup
+   hs-source-dirs:      app
+   main-is:             Main.hs
+   build-depends:       jira-wiki-markup
+-  ghc-options:         -threaded
++  ghc-options:         
+                        -rtsopts
+                        -with-rtsopts=-N
+ 

--- a/pkgs/overlay/haskell-packages/patches/memory/wasi.patch
+++ b/pkgs/overlay/haskell-packages/patches/memory/wasi.patch
@@ -1,0 +1,123 @@
+diff --git a/Data/Memory/MemMap/Posix.hsc b/Data/Memory/MemMap/Posix.hsc
+index 16bc246..4cf63a4 100644
+--- a/Data/Memory/MemMap/Posix.hsc
++++ b/Data/Memory/MemMap/Posix.hsc
+@@ -17,7 +17,9 @@
+ --
+ -----------------------------------------------------------------------------
+ 
++#if !defined(wasm32_HOST_ARCH)
+ #include <sys/mman.h>
++#endif
+ #include <unistd.h>
+ 
+ {-# LANGUAGE ForeignFunctionInterface #-}
+@@ -117,18 +119,26 @@ data MemorySyncFlag =
+     deriving (Show,Read,Eq)
+ 
+ cvalueOfMemoryProts :: [MemoryProtection] -> CInt
++#if defined(wasm32_HOST_ARCH)
++cvalueOfMemoryProts _ = error "Data.Memory.MemMap.cvalueOfMemoryProts"
++#else
+ cvalueOfMemoryProts = foldl (.|.) 0 . map toProt
+   where toProt :: MemoryProtection -> CInt
+         toProt MemoryProtectionNone    = (#const PROT_NONE)
+         toProt MemoryProtectionRead    = (#const PROT_READ)
+         toProt MemoryProtectionWrite   = (#const PROT_WRITE)
+         toProt MemoryProtectionExecute = (#const PROT_EXEC)
++#endif
+ 
+ cvalueOfMemorySync :: [MemorySyncFlag] -> CInt
++#if defined(wasm32_HOST_ARCH)
++cvalueOfMemorySync _ = error "Data.Memory.MemMap.cvalueOfMemorySync"
++#else
+ cvalueOfMemorySync = foldl (.|.) 0 . map toSync
+   where toSync MemorySyncAsync      = (#const MS_ASYNC)
+         toSync MemorySyncSync       = (#const MS_SYNC)
+         toSync MemorySyncInvalidate = (#const MS_INVALIDATE)
++#endif
+ 
+ -- | Map pages of memory.
+ --
+@@ -139,10 +149,13 @@ cvalueOfMemorySync = foldl (.|.) 0 . map toSync
+ memoryMap :: Maybe (Ptr a)      -- ^ The address to map to if MapFixed is used.
+           -> CSize              -- ^ The length of the mapping
+           -> [MemoryProtection] -- ^ the memory protection associated with the mapping
+-          -> MemoryMapFlag      -- ^ 
++          -> MemoryMapFlag      -- ^
+           -> Maybe Fd
+           -> COff
+           -> IO (Ptr a)
++#if defined(wasm32_HOST_ARCH)
++memoryMap _ _ _ _ _ _ = error "Data.Memory.MemMap.memoryMap"
++#else
+ memoryMap initPtr sz prots flag mfd off =
+     throwErrnoIf (== m1ptr) "mmap" (c_mmap (maybe nullPtr id initPtr) sz cprot cflags fd off)
+   where m1ptr  = nullPtr `plusPtr` (-1)
+@@ -161,6 +174,7 @@ memoryMap initPtr sz prots flag mfd off =
+ 
+         toMapFlag MemoryMapShared  = (#const MAP_SHARED)
+         toMapFlag MemoryMapPrivate = (#const MAP_PRIVATE)
++#endif
+ 
+ -- | Unmap pages of memory
+ --
+@@ -172,6 +186,9 @@ memoryUnmap ptr sz = throwErrnoIfMinus1_ "munmap" (c_munmap ptr sz)
+ --
+ -- call 'madvise'
+ memoryAdvise :: Ptr a -> CSize -> MemoryAdvice -> IO ()
++#if defined(wasm32_HOST_ARCH)
++memoryAdvise _ _ _ = error "Data.Memory.MemMap.memoryAdvise"
++#else
+ memoryAdvise ptr sz adv = throwErrnoIfMinus1_ "madvise" (c_madvise ptr sz cadv)
+   where cadv = toAdvice adv
+ #if defined(POSIX_MADV_NORMAL)
+@@ -187,6 +204,7 @@ memoryAdvise ptr sz adv = throwErrnoIfMinus1_ "madvise" (c_madvise ptr sz cadv)
+         toAdvice MemoryAdviceWillNeed = (#const MADV_WILLNEED)
+         toAdvice MemoryAdviceDontNeed = (#const MADV_DONTNEED)
+ #endif
++#endif
+ 
+ -- | lock a range of process address space
+ --
+@@ -216,7 +234,7 @@ memorySync ptr sz flags = throwErrnoIfMinus1_ "msync" (c_msync ptr sz cflags)
+   where cflags = cvalueOfMemorySync flags
+ 
+ -- | Return the operating system page size.
+--- 
++--
+ -- call 'sysconf'
+ sysconfPageSize :: Int
+ sysconfPageSize = fromIntegral $ c_sysconf (#const _SC_PAGESIZE)
+diff --git a/Data/Memory/PtrMethods.hs b/Data/Memory/PtrMethods.hs
+index 88b4328..76c7bd5 100644
+--- a/Data/Memory/PtrMethods.hs
++++ b/Data/Memory/PtrMethods.hs
+@@ -35,7 +35,7 @@ memCreateTemporary :: Int -> (Ptr Word8 -> IO a) -> IO a
+ memCreateTemporary size f = allocaBytesAligned size 8 f
+ 
+ -- | xor bytes from source1 and source2 to destination
+--- 
++--
+ -- d = s1 xor s2
+ --
+ -- s1, nor s2 are modified unless d point to s1 or s2
+@@ -63,7 +63,7 @@ memXorWith destination !v source bytes
+ 
+ -- | Copy a set number of bytes from @src to @dst
+ memCopy :: Ptr Word8 -> Ptr Word8 -> Int -> IO ()
+-memCopy dst src n = c_memcpy dst src (fromIntegral n)
++memCopy dst src n = c_memcpy dst src (fromIntegral n) >>= \_ -> return ()
+ {-# INLINE memCopy #-}
+ 
+ -- | Set @n number of bytes to the same value @v
+@@ -114,7 +114,7 @@ memConstEqual p1 p2 n = loop 0 0
+             loop (i+1) (acc .|. e)
+ 
+ foreign import ccall unsafe "memset"
+-    c_memset :: Ptr Word8 -> Word8 -> CSize -> IO ()
++    c_memset :: Ptr Word8 -> Word8 -> CSize -> IO (Ptr Word8)
+ 
+ foreign import ccall unsafe "memcpy"
+-    c_memcpy :: Ptr Word8 -> Ptr Word8 -> CSize -> IO ()
++    c_memcpy :: Ptr Word8 -> Ptr Word8 -> CSize -> IO (Ptr Word8)

--- a/pkgs/overlay/haskell-packages/patches/pandoc-cli/wasi-no-threaded.patch
+++ b/pkgs/overlay/haskell-packages/patches/pandoc-cli/wasi-no-threaded.patch
@@ -1,0 +1,13 @@
+diff --git a/pandoc-cli.cabal b/pandoc-cli.cabal
+index 958be7b..9c60f94 100644
+--- a/pandoc-cli.cabal
++++ b/pandoc-cli.cabal
+@@ -61,7 +61,7 @@ common common-options
+ 
+ common common-executable
+   import:           common-options
+-  ghc-options:      -rtsopts -with-rtsopts=-A8m -threaded
++  ghc-options:      -rtsopts -with-rtsopts=-A8m
+ 
+ executable pandoc
+   import:          common-executable

--- a/pkgs/overlay/haskell-packages/patches/pandoc/wasi-drop-network.patch
+++ b/pkgs/overlay/haskell-packages/patches/pandoc/wasi-drop-network.patch
@@ -1,0 +1,188 @@
+diff --git a/pandoc.cabal b/pandoc.cabal
+index 43f659b..c8ff338 100644
+--- a/pandoc.cabal
++++ b/pandoc.cabal
+@@ -501,7 +501,6 @@ library
+                  commonmark-pandoc     >= 0.2.3    && < 0.3,
+                  containers            >= 0.6.0.1  && < 0.9,
+                  crypton               >= 0.30     && < 1.1,
+-                 crypton-connection    >= 0.3.1    && < 0.5,
+                  data-default          >= 0.4      && < 0.9,
+                  deepseq               >= 1.3      && < 1.6,
+                  directory             >= 1.2.3    && < 1.4,
+@@ -513,14 +512,11 @@ library
+                  filepath              >= 1.1      && < 1.6,
+                  gridtables            >= 0.1      && < 0.2,
+                  haddock-library       >= 1.10     && < 1.12,
+-                 http-client           >= 0.4.30   && < 0.8,
+-                 http-client-tls       >= 0.2.4    && < 0.4,
+                  http-types            >= 0.8      && < 0.13,
+                  ipynb                 >= 0.2      && < 0.3,
+                  jira-wiki-markup      >= 1.5.1    && < 1.6,
+                  mime-types            >= 0.1.1    && < 0.2,
+                  mtl                   >= 2.2      && < 2.4,
+-                 network               >= 2.6      && < 3.3,
+                  network-uri           >= 2.6      && < 2.8,
+                  pandoc-types          >= 1.23.1   && < 1.24,
+                  parsec                >= 3.1      && < 3.2,
+@@ -549,9 +545,17 @@ library
+                  xml                   >= 1.3.12   && < 1.4,
+                  typst                 >= 0.8.0.1  && < 0.9,
+                  vector                >= 0.12     && < 0.14,
+-                 djot                  >= 0.1.2.2  && < 0.2,
+-                 tls                   >= 2.0.1    && < 2.2,
+-                 crypton-x509-system   >= 1.6.7    && < 1.7
++                 djot                  >= 0.1.2.2  && < 0.2
++
++  -- wasm has no sockets/DNS (wasi-libc lacks netdb.h); drop the HTTP/TLS stack.
++  -- openURL and the PandocHttpError paths are stubbed under wasm32_HOST_ARCH.
++  if !arch(wasm32)
++    build-depends: http-client         >= 0.4.30   && < 0.8,
++                   http-client-tls     >= 0.2.4    && < 0.4,
++                   network             >= 2.6      && < 3.3,
++                   tls                 >= 2.0.1    && < 2.2,
++                   crypton-connection  >= 0.3.1    && < 0.5,
++                   crypton-x509-system >= 1.6.7    && < 1.7
+ 
+   if !os(windows)
+     build-depends:  unix >= 2.4 && < 2.9
+diff --git a/src/Text/Pandoc/Class/IO.hs b/src/Text/Pandoc/Class/IO.hs
+index 2d337d9..6df6269 100644
+--- a/src/Text/Pandoc/Class/IO.hs
++++ b/src/Text/Pandoc/Class/IO.hs
+@@ -41,6 +41,7 @@ import Data.ByteString.Lazy (toChunks)
+ import Data.Text (Text, pack, unpack)
+ import Data.Time (TimeZone, UTCTime)
+ import Data.Unique (hashUnique)
++#if !defined(wasm32_HOST_ARCH)
+ import Network.Connection (TLSSettings(..))
+ import qualified Network.TLS as TLS
+ import qualified Network.TLS.Extra as TLS
+@@ -49,8 +50,9 @@ import Network.HTTP.Client
+         Request(port, host, requestHeaders), parseRequest, newManager)
+ import Network.HTTP.Client.Internal (addProxy)
+ import Network.HTTP.Client.TLS (mkManagerSettings)
+-import Network.HTTP.Types.Header ( hContentType )
+ import Network.Socket (withSocketsDo)
++#endif
++import Network.HTTP.Types.Header ( hContentType )
+ import Network.URI (URI(..), parseURI, unEscapeString)
+ import System.Directory (createDirectoryIfMissing)
+ import System.Environment (getEnv)
+@@ -83,7 +85,9 @@ import qualified System.FilePath.Glob
+ import qualified System.Random
+ import qualified Text.Pandoc.UTF8 as UTF8
+ import Data.Default (def)
++#if !defined(wasm32_HOST_ARCH)
+ import System.X509 (getSystemCertificateStore)
++#endif
+ #ifndef EMBED_DATA_FILES
+ import qualified Paths_pandoc as Paths
+ #endif
+@@ -129,6 +133,9 @@ openURL u
+  | Just (URI{ uriScheme = "data:",
+               uriPath = upath }) <- parseURI (T.unpack u)
+      = pure $ extractURIData upath
++#if defined(wasm32_HOST_ARCH)
++ | otherwise = error "Text.Pandoc.Class.IO.openURL"
++#else
+  | otherwise = do
+      let toReqHeader (n, v) = (CI.mk (UTF8.fromText n), UTF8.fromText v)
+      customHeaders <- map toReqHeader <$> getsCommonState stRequestHeaders
+@@ -168,6 +175,7 @@ openURL u
+      case res of
+           Right r -> return r
+           Left e  -> throwError $ PandocHttpError u e
++#endif
+ 
+ -- | Read the lazy ByteString contents from a file path, raising an error on
+ -- failure.
+diff --git a/src/Text/Pandoc/Class/PandocMonad.hs b/src/Text/Pandoc/Class/PandocMonad.hs
+index 850aff5..c238be0 100644
+--- a/src/Text/Pandoc/Class/PandocMonad.hs
++++ b/src/Text/Pandoc/Class/PandocMonad.hs
+@@ -496,11 +496,13 @@ fillMediaBag d = walkM handleImage d
+                             "replacing image with description"
+                   -- emit alt text
+                   return $ replacementSpan attr src tit lab
++#if !defined(wasm32_HOST_ARCH)
+                 PandocHttpError u er -> do
+                   report $ CouldNotFetchResource u
+                             (T.pack $ show er ++ "\rReplacing image with description.")
+                   -- emit alt text
+                   return $ replacementSpan attr src tit lab
++#endif
+                 _ -> throwError e)
+         handleImage x = return x
+ 
+diff --git a/src/Text/Pandoc/Error.hs b/src/Text/Pandoc/Error.hs
+index f9c9aea..d6ae3ca 100644
+--- a/src/Text/Pandoc/Error.hs
++++ b/src/Text/Pandoc/Error.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE DeriveDataTypeable #-}
+ {-# LANGUAGE DeriveGeneric      #-}
+ {-# LANGUAGE OverloadedStrings  #-}
+@@ -25,7 +26,9 @@ import Data.Word (Word8)
+ import Data.Text (Text)
+ import qualified Data.Text as T
+ import GHC.Generics (Generic)
++#if !defined(wasm32_HOST_ARCH)
+ import Network.HTTP.Client (HttpException)
++#endif
+ import System.Exit (ExitCode (..), exitWith)
+ import System.IO (stderr)
+ import qualified Text.Pandoc.UTF8 as UTF8
+@@ -34,7 +37,9 @@ import Text.Pandoc.Shared (tshow)
+ import Citeproc (CiteprocError, prettyCiteprocError)
+ 
+ data PandocError = PandocIOError Text IOError
++#if !defined(wasm32_HOST_ARCH)
+                  | PandocHttpError Text HttpException
++#endif
+                  | PandocShouldNeverHappenError Text
+                  | PandocSomeError Text
+                  | PandocParseError Text
+@@ -73,8 +78,10 @@ renderError :: PandocError -> Text
+ renderError e =
+   case e of
+     PandocIOError _ err' -> T.pack $ displayException err'
++#if !defined(wasm32_HOST_ARCH)
+     PandocHttpError u err' ->
+       "Could not fetch " <> u <> "\n" <> tshow err'
++#endif
+     PandocShouldNeverHappenError s ->
+       "Something we thought was impossible happened!\n" <>
+       "Please report this to pandoc's developers: " <> s
+@@ -170,7 +177,9 @@ handleError (Left e) =
+       PandocPDFError{} -> 43
+       PandocXMLError{} -> 44
+       PandocPDFProgramNotFoundError{} -> 47
++#if !defined(wasm32_HOST_ARCH)
+       PandocHttpError{} -> 61
++#endif
+       PandocShouldNeverHappenError{} -> 62
+       PandocSomeError{} -> 63
+       PandocParseError{} -> 64
+diff --git a/src/Text/Pandoc/SelfContained.hs b/src/Text/Pandoc/SelfContained.hs
+index 909a9d2..9455fac 100644
+--- a/src/Text/Pandoc/SelfContained.hs
++++ b/src/Text/Pandoc/SelfContained.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE ScopedTypeVariables #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ {-# LANGUAGE LambdaCase        #-}
+@@ -424,9 +425,11 @@ getData mimetype src
+                  PandocResourceNotFound r -> do
+                    report $ CouldNotFetchResource r ""
+                    return $ CouldNotFetch e
++#if !defined(wasm32_HOST_ARCH)
+                  PandocHttpError u er -> do
+                    report $ CouldNotFetchResource u (tshow er)
+                    return $ CouldNotFetch e
++#endif
+                  _ -> throwError e
+ 
+ 

--- a/pkgs/overlay/haskell-packages/patches/streaming-commons/wasi-drop-network.patch
+++ b/pkgs/overlay/haskell-packages/patches/streaming-commons/wasi-drop-network.patch
@@ -1,0 +1,33 @@
+diff --git a/streaming-commons.cabal b/streaming-commons.cabal
+index 2a69723..d5538cd 100644
+--- a/streaming-commons.cabal
++++ b/streaming-commons.cabal
+@@ -30,20 +30,25 @@ library
+                        Data.Streaming.ByteString.Builder.Buffer
+                        Data.Streaming.FileRead
+                        Data.Streaming.Filesystem
+-                       Data.Streaming.Network
+-                       Data.Streaming.Network.Internal
+                        Data.Streaming.Process
+                        Data.Streaming.Process.Internal
+                        Data.Streaming.Text
+                        Data.Streaming.Zlib
+                        Data.Streaming.Zlib.Lowlevel
+ 
++  -- wasm has no sockets (wasi-libc lacks netdb.h); drop the network modules.
++  if !arch(wasm32)
++      exposed-modules:   Data.Streaming.Network
++                         Data.Streaming.Network.Internal
++
++  if !arch(wasm32)
++      build-depends:     network >= 2.4.0.0
++
+   build-depends:       base >= 4.12 && < 5
+                      , array
+                      , async
+                      , bytestring
+                      , directory
+-                     , network >= 2.4.0.0
+                      , random
+                      , process
+                      , stm

--- a/pkgs/overlay/haskell-packages/patches/zlib-clib/wasi-errno.patch
+++ b/pkgs/overlay/haskell-packages/patches/zlib-clib/wasi-errno.patch
@@ -1,0 +1,14 @@
+diff --git a/cbits/gzguts.h b/cbits/gzguts.h
+index eba7208..083e2dc 100644
+--- a/cbits/gzguts.h
++++ b/cbits/gzguts.h
+@@ -127,8 +127,8 @@
+ #  include <windows.h>
+ #  define zstrerror() gz_strwinerror((DWORD)GetLastError())
+ #else
++#  include <errno.h>
+ #  ifndef NO_STRERROR
+-#    include <errno.h>
+ #    define zstrerror() strerror(errno)
+ #  else
+ #    define zstrerror() "stdio error (consult errno)"

--- a/pkgs/overlay/haskell-packages/streaming-commons.nix
+++ b/pkgs/overlay/haskell-packages/streaming-commons.nix
@@ -1,0 +1,10 @@
+# no sockets: drop the network modules.
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.streaming-commons (old: {
+  patches = (old.patches or []) ++ [./patches/streaming-commons/wasi-drop-network.patch];
+  libraryHaskellDepends = (import ./lib/deps.nix).dropDeps ["network"] old.libraryHaskellDepends;
+})

--- a/pkgs/overlay/haskell-packages/zlib-clib.nix
+++ b/pkgs/overlay/haskell-packages/zlib-clib.nix
@@ -1,0 +1,9 @@
+# bundled C zlib uses errno without errno.h under -DNO_STRERROR on wasi.
+{
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.zlib-clib (old: {
+  patches = (old.patches or []) ++ [./patches/zlib-clib/wasi-errno.patch];
+})

--- a/pkgs/overlay/haskell-packages/zlib.nix
+++ b/pkgs/overlay/haskell-packages/zlib.nix
@@ -1,0 +1,13 @@
+# on wasm the haskell zlib uses bundled zlib-clib; drop nixpkgs' system C-zlib
+# (doesn't cross-compile) and add zlib-clib.
+{
+  hfinal,
+  hprev,
+  toolchain,
+  ...
+}:
+toolchain.haskell.lib.overrideCabal hprev.zlib (old: {
+  librarySystemDepends = [];
+  libraryPkgconfigDepends = [];
+  libraryHaskellDepends = (old.libraryHaskellDepends or []) ++ [hfinal.zlib-clib];
+})

--- a/pkgs/overlay/packages/pandoc/package.nix
+++ b/pkgs/overlay/packages/pandoc/package.nix
@@ -1,0 +1,22 @@
+# pandoc as a wasm32-wasi command (wasmerPackages.pandoc): wasm-opt the pandoc-cli
+# from the haskell set and ship it. GHC emits wasm32-wasi and ignores the profile
+# EH/PIC flags, so it's one build at the preferred profile, not a per-profile set.
+{
+  final,
+  helpers,
+  toolchain,
+  ...
+}: let
+  pandoc-cli = final.haskellPackages.pandoc-cli;
+in
+  # the standard ghc-wasm post-link wasm-opt pass.
+  helpers.libTweaks {passthru.wasix.shipped = true;} (
+    final.buildPackages.runCommand "pandoc" {
+      inherit (pandoc-cli) version; # so the webc is pandoc-<ver>
+      nativeBuildInputs = [toolchain.haskell.binaryen];
+    } ''
+      wasm-opt --experimental-new-eh --low-memory-unused --converge --gufa \
+        --flatten --rereloop -Oz ${pandoc-cli}/bin/pandoc.wasm -o pandoc.opt.wasm
+      install -Dm755 pandoc.opt.wasm "$out/bin/pandoc.wasm"
+    ''
+  )

--- a/pkgs/overlay/python-packages/pypandoc.nix
+++ b/pkgs/overlay/python-packages/pypandoc.nix
@@ -1,0 +1,8 @@
+# nixpkgs' pypandoc patches in a native pandoc store path and pulls texlive for
+# its tests; drop both so it keeps upstream's PATH lookup (finds our wasm pandoc
+# at runtime) and stays a relocatable pure wheel.
+{pyprev, ...}:
+pyprev.pypandoc.overrideAttrs (_: {
+  patches = [];
+  nativeCheckInputs = [];
+})

--- a/pkgs/overlay/python-packages/wheels.nix
+++ b/pkgs/overlay/python-packages/wheels.nix
@@ -152,6 +152,7 @@
   {attr = "pycurl";} # curl; overlay/python-packages/pycurl.nix
   {attr = "jq";} # jq + oniguruma
   {attr = "jqpy";} # spawns the jq CLI; overlay/python-packages/jqpy.nix
+  {attr = "pypandoc";} # spawns the pandoc CLI; overlay/python-packages/pypandoc.nix
   {attr = "apsw";} # sqlite
   {
     attr = "pynacl";

--- a/pkgs/toolchain/default.nix
+++ b/pkgs/toolchain/default.nix
@@ -1,6 +1,12 @@
 # The wasix toolchain: LLVM fork, per-variant sysroot, and the wrappers that
 # drive them (wasixcc, cargo-wasix, binaryen). Everything is built from source.
-{pkgs}: let
+# Also carries the wasi haskell toolchain (`haskell`), a separate ghc-wasm bindist
+# GHC + nixpkgs haskellPackages; see haskell/.
+{
+  pkgs,
+  ghcWasm,
+}: let
+  haskell = import ./haskell {inherit pkgs ghcWasm;};
   inherit (import ./llvm.nix {inherit pkgs;}) llvm llvmTree version;
   sysroots = import ./sysroot {
     inherit pkgs llvm;
@@ -31,4 +37,5 @@ in {
   inherit wasixLlvm wasixSysroot wasixRustToolchain binaryen wasixcc cargoWasix;
   # Compiler, per-variant sysroot components, and smoke tests.
   inherit llvm variants sysroot tests libc compiler-rt libcxx;
+  inherit haskell; # the wasi haskell toolchain (exposes hp)
 }

--- a/pkgs/toolchain/haskell/default.nix
+++ b/pkgs/toolchain/haskell/default.nix
@@ -1,0 +1,118 @@
+# nixpkgs haskellPackages driving ghc-wasm-meta's prebuilt wasm32-wasi GHC.
+# Exposes `packages`, a haskell package set carrying the global wasm build config
+# (no per-package patches; those belong to the consumer). TemplateHaskell works
+# because wasm32-wasi runs the splice interpreter under node; the from-source
+# wasix GHC can't (node can't host a wasix interpreter), which is why it's separate.
+{
+  pkgs,
+  ghcWasm,
+}: let
+  # allowUnsupportedSystem: nixpkgs marks most of haskellPackages unsupported on wasm.
+  cross = import pkgs.path {
+    system = "x86_64-linux";
+    config.allowUnsupportedSystem = true;
+    crossSystem = {
+      config = "wasm32-unknown-wasi";
+      useLLVM = true;
+    };
+  };
+
+  wasiSdk = ghcWasm.wasi-sdk;
+  baseGhc = ghcWasm.wasm32-wasi-ghc-9_12;
+  # Patch the cp -as'd bindist tree (notes kept out of the string below so edits
+  # don't rebuild the closure):
+  # - chmod only the dirs we touch (recursive over the 3.2GB tree is slow).
+  # - Neuter the redundant ranlib: settings declare `ar flags = qcls` (writes the
+  #   symtab) AND a `ranlib command`; the extra re-index crashes ("malformed
+  #   uleb128") in the sandbox.
+  # - GHC reads settings via the wrapper's -B<libdir>, so repoint that libdir at
+  #   the patched tree and fix the unversioned symlink (cp -as escapes it back).
+  # - dyld.mjs (the node TH linker) must be a real file, not a symlink: node
+  #   resolves it back into the bindist, so relative loads escape the patched tree
+  #   and some TH splices die with "remoteCall: end of file".
+  # ghcDir is globbed so a point bump needs no edit.
+  patchedGhc = pkgs.runCommand "wasm32-wasi-ghc-9.12-noranlib" {} ''
+    mkdir -p "$out"
+    cp -as ${baseGhc}/. "$out/"
+    ghcDir=$(cd "$out/lib" && echo wasm32-wasi-ghc-*)
+    libdir="$out/lib/$ghcDir/lib"
+    chmod u+w "$out" "$out/bin" "$libdir" "$out/lib/$ghcDir/bin"
+    rm "$libdir/settings"
+    substitute ${baseGhc}/lib/"$ghcDir"/lib/settings "$libdir/settings" \
+      --replace-fail '"${wasiSdk}/bin/llvm-ranlib"' '"${pkgs.buildPackages.coreutils}/bin/true"'
+    wrapper="$out/bin/$ghcDir"
+    rm "$wrapper"
+    substitute ${baseGhc}/bin/"$ghcDir" "$wrapper" \
+      --replace-fail "libdir=\"${baseGhc}/lib/$ghcDir/lib\"" "libdir=\"$libdir\""
+    chmod +x "$wrapper"
+    rm "$out/bin/wasm32-wasi-ghc"
+    ln -s "$ghcDir" "$out/bin/wasm32-wasi-ghc"
+    rm "$libdir/dyld.mjs"
+    cp ${baseGhc}/lib/"$ghcDir"/lib/dyld.mjs "$libdir/dyld.mjs"
+    chmod +x "$libdir/dyld.mjs"
+  '';
+
+  wrappedGhc =
+    patchedGhc
+    // {
+      version = "9.12.1";
+      targetPrefix = "wasm32-wasi-";
+      haskellCompilerName = "ghc-9.12.1";
+      hasHaddock = false;
+      isHaLVM = false;
+      isGhcjs = false;
+      isMhs = false;
+      # The wasm RTS TH interpreter loads splice deps as .so, so advertise
+      # shared-lib support to let generic-builder pass --enable-shared.
+      enableShared = true;
+    };
+
+  # The wasm build config applied to every package, via the set's mkDerivation.
+  # Per-package fixes are the consumer's job, not the toolchain's.
+  packages = (cross.haskell.packages.ghc9123.override {ghc = wrappedGhc;}).extend (final: prev: {
+    mkDerivation = args:
+      prev.mkDerivation (args
+        // {
+          # nixpkgs' iserv-proxy TH needs network/getaddrinfo (absent on wasi);
+          # disable it so GHC's own dyld+node TH runs.
+          enableExternalInterpreter = false;
+          enableLibraryProfiling = false;
+          # wasm strip is unsupported (crashes); wasm-opt is the real size pass.
+          dontStrip = true;
+          # gates the generic-builder fixup that points each package conf's
+          # dynamic-library-dirs at the .so (so the dyld finds it).
+          enableSharedLibraries = true;
+          # nixpkgs appends a trailing --disable-shared on wasm and cabal is
+          # last-wins, so re-append --enable-shared after it to get the .so.
+          preConfigure =
+            (args.preConfigure or "")
+            + ''
+              configureFlags="$configureFlags --enable-shared"
+            '';
+          doHaddock = false;
+          # TH runs under node; the bindist pins one that works (nixpkgs' newer
+          # node crashes the dyld on splices that load many modules).
+          buildTools = (args.buildTools or []) ++ [ghcWasm.nodejs];
+          configureFlags =
+            (args.configureFlags or [])
+            ++ [
+              # Use the bindist's LLVM-19 toolchain, not nixpkgs' cross LLVM-21
+              # (version-skewed objects -> "malformed uleb128" when TH links).
+              "--with-gcc=${wasiSdk}/bin/clang"
+              "--with-ld=${wasiSdk}/bin/wasm-ld"
+              "--with-ar=${wasiSdk}/bin/llvm-ar"
+              "--disable-library-stripping"
+              "--disable-executable-stripping"
+              # text (via simdutf) needs wasi-sdk's libc++ (LLVM-19, std::__2::);
+              # nixpkgs' cross cc puts LLVM-21 libcxx (std::__1::) on -L, so a bare
+              # -lc++ picks the wrong ABI. Link wasi-sdk's by absolute path.
+              "--ghc-option=-optl${wasiSdk}/share/wasi-sysroot/lib/wasm32-wasi/libc++.a"
+              "--ghc-option=-optl${wasiSdk}/share/wasi-sysroot/lib/wasm32-wasi/libc++abi.a"
+            ];
+        });
+  });
+in {
+  inherit packages; # the wasm32-wasi haskell package set (no per-package patches)
+  inherit (cross.haskell) lib; # haskell.lib, for the consumer's overrideCabal
+  inherit (ghcWasm) binaryen; # for the consumer's wasm-opt
+}

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -205,6 +205,9 @@ TARGETS = [
     Target("nixpkgs", "flake", input="nixpkgs"),
     Target("wasmer", "flake", input="wasmer"),
     Target("treefmt-nix", "flake", input="treefmt-nix"),
+    # bumping this rebuilds the whole haskell closure and needs the wasm patches
+    # re-verified (see docs/updating.md).
+    Target("ghc-wasm-meta", "flake", input="ghc-wasm-meta"),
 ]
 
 


### PR DESCRIPTION
Adds the wasi (non-wasix) Haskell path: pandoc cross-compiled to wasm32-wasi using ghc-wasm-meta's prebuilt GHC driven by nixpkgs haskellPackages, TemplateHaskell works via the splice interpreter running under node via the JS dyld