### PR TITLE
pkgs: package anybuild

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,7 @@ patch tree, so the two can't drift:
 
 ## Flake outputs
 
-- `packages.<system>`: `wasixcc` (default), `cargo-wasix`,
+- `packages.<system>`: `wasixcc` (default), `cargo-wasix`, `anybuild`,
   `wasix-rust-toolchain`, `wasmer-bin`, `wasix-{libc,llvm,compiler-rt,libcxx,sysroot}`.
 - `checks.<system>`: every `passthru.tests`: behavioural suites, toolchain
   suites (`sysroot`, `wasixcc`, `rust`), wheel imports (`wheel-<attr>`),

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
           # These carry their test suites as passthru.tests.
           inherit (wasix.toolchainTestPkgs) sysroot wasixcc;
 
+          anybuild = toolchain.anybuild;
           cargo-wasix = toolchain.cargoWasix;
           rust-toolchain = toolchain.wasixRustToolchain;
           libc = toolchain.libc;
@@ -398,6 +399,7 @@
 
     packages.${system} = {
       # the webc packages and the merged registry live under legacyPackages
+      anybuild = toolchain.anybuild;
       wasixcc = toolchain.wasixcc;
       cargo-wasix = toolchain.cargoWasix;
       wasix-rust-toolchain = toolchain.wasixRustToolchain;

--- a/pkgs/toolchain/anybuild.nix
+++ b/pkgs/toolchain/anybuild.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  bash,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "anybuild";
+  version = "0.26.4";
+
+  src = fetchFromGitHub {
+    owner = "wasmerio";
+    repo = "anybuild";
+    tag = "v${version}";
+    hash = "sha256-M6AP8QgIuoly9Gznw2JOAGEdKTY0+mJciYhA3JKicfk=";
+  };
+
+  cargoHash = "sha256-K9EkxIsTXOmqVnfv/ZQb97uXpO2100RKLQEyf5PjsAw=";
+
+  postPatch = ''
+    substituteInPlace crates/anybuild/src/run/local.rs \
+      --replace-fail '#!/bin/bash' '#!${bash}/bin/bash'
+  '';
+
+  # The e2e harness otherwise assumes a separate target/debug build exists.
+  preCheck = ''
+    export ANYBUILD_BIN="$(find target -type f -path '*/release/anybuild' | head -n 1)"
+  '';
+
+  passthru.updateScript = {
+    command = nix-update-script {extraArgs = ["--flake"];};
+    attrPath = "toolchain.anybuild";
+  };
+
+  meta = {
+    description = "Detect, build, and run projects";
+    homepage = "https://github.com/wasmerio/anybuild";
+    license = lib.licenses.mit;
+    mainProgram = "anybuild";
+  };
+}

--- a/pkgs/toolchain/anybuild.nix
+++ b/pkgs/toolchain/anybuild.nix
@@ -1,18 +1,19 @@
 {
+  stdenv,
   lib,
   bash,
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "anybuild";
   version = "0.26.4";
 
   src = fetchFromGitHub {
     owner = "wasmerio";
     repo = "anybuild";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-M6AP8QgIuoly9Gznw2JOAGEdKTY0+mJciYhA3JKicfk=";
   };
 
@@ -25,7 +26,7 @@ rustPlatform.buildRustPackage rec {
 
   # The e2e harness otherwise assumes a separate target/debug build exists.
   preCheck = ''
-    export ANYBUILD_BIN="$(find target -type f -path '*/release/anybuild' | head -n 1)"
+    export ANYBUILD_BIN="$PWD/target/${stdenv.hostPlatform.rust.rustcTarget}/release/anybuild"
   '';
 
   passthru.updateScript = {
@@ -39,4 +40,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     mainProgram = "anybuild";
   };
-}
+})

--- a/pkgs/toolchain/default.nix
+++ b/pkgs/toolchain/default.nix
@@ -41,6 +41,7 @@
     wasixSysrootEhpic = variants.ehpic.sysroot;
   };
   binaryen = pkgs.binaryen;
+  anybuild = pkgs.callPackage ./anybuild.nix {};
   wasixcc = pkgs.callPackage ./wasixcc.nix {
     inherit wasixLlvm binaryen wasixSysroot;
   };
@@ -50,7 +51,7 @@
 in {
   # The wasix rustPlatform is assembled in pkgs/default.nix, where the pkgsCross
   # it needs is in scope.
-  inherit wasixLlvm wasixSysroot wasixRustToolchain binaryen wasixcc cargoWasix;
+  inherit anybuild wasixLlvm wasixSysroot wasixRustToolchain binaryen wasixcc cargoWasix;
   inherit llvm variants sysroot tests libc compiler-rt libcxx flang flangCross;
   # Internal inputs for pkgs/default.nix and the overlay. Profile-sensitive
   # outputs are public through toolchainByProfile, never as implicit defaults.


### PR DESCRIPTION
## Summary

- package Anybuild v0.26.4 as a native Rust tool
- expose it as `.#anybuild` and `.#toolchain.anybuild`
- make generated local runner scripts use the Nix-provided Bash
- register update metadata and the native CI job

Closes ECO-422.

## Validation

- `nix build .#anybuild -L`
- upstream Rust test suite via `buildRustPackage`
- `nix build .#toolchain.anybuild --no-link`
- `nix fmt -- --fail-on-change`
- `git diff --check`
- `nix flake check --no-build` evaluates Anybuild successfully, then fails in the unrelated Python registry checks because a pydantic-core vendor derivation path is invalid in the local Nix store