### PR TITLE
pkgs: port static-web-server to wasix

### DIFF
--- a/pkgs/lib/wasix-crate-patches/socket2/0.5.10.patch
+++ b/pkgs/lib/wasix-crate-patches/socket2/0.5.10.patch
@@ -1,0 +1,1564 @@
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/Cargo.toml b/Cargo.toml
+--- a/Cargo.toml	2026-08-07 02:26:25.116370682 +0200
++++ b/Cargo.toml	2026-08-07 02:26:25.125824258 +0200
+@@ -50,6 +50,16 @@
+ license = "MIT OR Apache-2.0"
+ repository = "https://github.com/rust-lang/socket2"
+ 
++[package.metadata.cargo_check_external_types]
++allowed_external_types = [
++    "libc::socklen_t",
++    "libc::*::socklen_t",
++    "libc::sa_family_t",
++    "libc::*::sa_family_t",
++    "windows_sys::Win32::Networking::WinSock::socklen_t",
++    "windows_sys::Win32::Networking::WinSock::ADDRESS_FAMILY",
++]
++
+ [package.metadata.docs.rs]
+ all-features = true
+ rustdoc-args = [
+@@ -83,7 +93,7 @@
+ name = "socket2"
+ path = "src/lib.rs"
+ 
+-[target."cfg(unix)".dependencies.libc]
++[target.'cfg(any(unix, target_os = "wasi"))'.dependencies.libc]
+ version = "0.2.171"
+ 
+ [target."cfg(windows)".dependencies.windows-sys]
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs	2026-08-07 02:26:25.116520042 +0200
++++ b/src/lib.rs	2026-08-07 02:26:25.122432051 +0200
+@@ -107,7 +107,7 @@
+     ($from: ty, $for: ty) => {
+         impl From<$from> for $for {
+             fn from(socket: $from) -> $for {
+-                #[cfg(unix)]
++                #[cfg(any(unix, target_os = "wasi"))]
+                 unsafe {
+                     <$for>::from_raw_fd(socket.into_raw_fd())
+                 }
+@@ -176,9 +176,10 @@
+ 
+ #[cfg_attr(unix, path = "sys/unix.rs")]
+ #[cfg_attr(windows, path = "sys/windows.rs")]
++#[cfg_attr(target_os = "wasi", path = "sys/wasi.rs")]
+ mod sys;
+ 
+-#[cfg(not(any(windows, unix)))]
++#[cfg(not(any(windows, unix, target_os = "wasi")))]
+ compile_error!("Socket2 doesn't support the compile target");
+ 
+ use sys::c_int;
+@@ -255,12 +256,12 @@
+     /// Type corresponding to `SOCK_STREAM`.
+     ///
+     /// Used for protocols such as TCP.
+-    pub const STREAM: Type = Type(sys::SOCK_STREAM);
++    pub const STREAM: Type = Type(sys::SOCK_STREAM as i32);
+ 
+     /// Type corresponding to `SOCK_DGRAM`.
+     ///
+     /// Used for protocols such as UDP.
+-    pub const DGRAM: Type = Type(sys::SOCK_DGRAM);
++    pub const DGRAM: Type = Type(sys::SOCK_DGRAM as i32);
+ 
+     /// Type corresponding to `SOCK_DCCP`.
+     ///
+@@ -523,6 +524,7 @@
+         target_os = "watchos",
+         target_os = "windows",
+         target_os = "cygwin",
++        target_os = "wasi",
+     ))]
+     #[cfg_attr(
+         docsrs,
+@@ -536,6 +538,7 @@
+             target_os = "visionos",
+             target_os = "linux",
+             target_os = "macos",
++            target_os = "wasi",
+             target_os = "netbsd",
+             target_os = "tvos",
+             target_os = "watchos",
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/sockaddr.rs b/src/sockaddr.rs
+--- a/src/sockaddr.rs	2026-08-07 02:26:25.116551380 +0200
++++ b/src/sockaddr.rs	2026-08-07 02:26:25.122607971 +0200
+@@ -1,6 +1,7 @@
+ use std::hash::Hash;
+ use std::mem::{self, size_of, MaybeUninit};
+ use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
++#[cfg(not(target_os = "wasi"))]
+ use std::path::Path;
+ use std::{fmt, io, ptr};
+ 
+@@ -146,6 +147,7 @@
+     /// Constructs a `SockAddr` with the family `AF_UNIX` and the provided path.
+     ///
+     /// Returns an error if the path is longer than `SUN_LEN`.
++    #[cfg(not(target_os = "wasi"))]
+     pub fn unix<P>(path: P) -> io::Result<SockAddr>
+     where
+         P: AsRef<Path>,
+@@ -225,7 +227,7 @@
+                 ip,
+                 port,
+                 addr.sin6_flowinfo,
+-                #[cfg(unix)]
++                #[cfg(any(unix, all(target_os = "wasi", target_vendor = "wasmer")))]
+                 addr.sin6_scope_id,
+                 #[cfg(windows)]
+                 unsafe {
+@@ -317,7 +319,7 @@
+             storage.sin6_port = addr.port().to_be();
+             storage.sin6_addr = crate::sys::to_in6_addr(addr.ip());
+             storage.sin6_flowinfo = addr.flowinfo();
+-            #[cfg(unix)]
++            #[cfg(any(unix, all(target_os = "wasi", target_vendor = "wasmer")))]
+             {
+                 storage.sin6_scope_id = addr.scope_id();
+             }
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/socket.rs b/src/socket.rs
+--- a/src/socket.rs	2026-08-07 02:26:25.116580335 +0200
++++ b/src/socket.rs	2026-08-07 02:26:25.127940747 +0200
+@@ -16,6 +16,8 @@
+ use std::net::{self, Ipv4Addr, Shutdown};
+ #[cfg(unix)]
+ use std::os::unix::io::{FromRawFd, IntoRawFd};
++#[cfg(all(target_os = "wasi", not(unix)))]
++use std::os::wasi::io::{FromRawFd, IntoRawFd};
+ #[cfg(windows)]
+ use std::os::windows::io::{FromRawSocket, IntoRawSocket};
+ use std::time::Duration;
+@@ -238,7 +240,7 @@
+         match res {
+             Ok(()) => return Ok(()),
+             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
+-            #[cfg(unix)]
++            #[cfg(any(unix, target_os = "wasi"))]
+             Err(ref e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+             Err(e) => return Err(e),
+         }
+@@ -283,6 +285,7 @@
+             target_os = "fuchsia",
+             target_os = "illumos",
+             target_os = "linux",
++            target_os = "wasi",
+             target_os = "netbsd",
+             target_os = "openbsd",
+             target_os = "cygwin",
+@@ -297,6 +300,7 @@
+             target_os = "fuchsia",
+             target_os = "illumos",
+             target_os = "linux",
++            target_os = "wasi",
+             target_os = "netbsd",
+             target_os = "openbsd",
+             target_os = "cygwin",
+@@ -639,6 +643,7 @@
+     /// but suppresses the `WSAEMSGSIZE` error on Windows.
+     ///
+     /// [`peek_from`]: Socket::peek_from
++    #[cfg(not(all(target_os = "wasi", target_vendor = "unknown")))]
+     pub fn peek_sender(&self) -> io::Result<SockAddr> {
+         sys::peek_sender(self.as_raw())
+     }
+@@ -1177,7 +1182,7 @@
+     )]
+     pub fn header_included_v4(&self) -> io::Result<bool> {
+         unsafe {
+-            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IP, sys::IP_HDRINCL)
++            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IP, libc::IP_HDRINCL)
+                 .map(|included| included != 0)
+         }
+     }
+@@ -1222,7 +1227,7 @@
+             setsockopt(
+                 self.as_raw(),
+                 sys::IPPROTO_IP,
+-                sys::IP_HDRINCL,
++                libc::IP_HDRINCL,
+                 included as c_int,
+             )
+         }
+@@ -1999,7 +2004,7 @@
+         target_os = "redox",
+         target_os = "solaris",
+         target_os = "haiku",
+-        target_os = "hurd",
++        target_os = "wasi",
+         target_os = "espidf",
+         target_os = "vita",
+     )))]
+@@ -2024,6 +2029,7 @@
+         target_os = "redox",
+         target_os = "solaris",
+         target_os = "haiku",
++        target_os = "wasi",
+         target_os = "hurd",
+         target_os = "espidf",
+         target_os = "vita",
+@@ -2155,6 +2161,7 @@
+             target_os = "visionos",
+             target_os = "linux",
+             target_os = "macos",
++            target_os = "wasi",
+             target_os = "netbsd",
+             target_os = "tvos",
+             target_os = "watchos",
+@@ -2205,6 +2212,7 @@
+             target_os = "visionos",
+             target_os = "linux",
+             target_os = "macos",
++            target_os = "wasi",
+             target_os = "netbsd",
+             target_os = "tvos",
+             target_os = "watchos",
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/sockref.rs b/src/sockref.rs
+--- a/src/sockref.rs	2026-08-07 02:26:25.116629036 +0200
++++ b/src/sockref.rs	2026-08-07 02:26:25.132251722 +0200
+@@ -4,6 +4,8 @@
+ use std::ops::Deref;
+ #[cfg(unix)]
+ use std::os::unix::io::{AsFd, AsRawFd, FromRawFd};
++#[cfg(all(target_os = "wasi", not(unix)))]
++use std::os::wasi::io::{AsFd, AsRawFd, FromRawFd};
+ #[cfg(windows)]
+ use std::os::windows::io::{AsRawSocket, AsSocket, FromRawSocket};
+ 
+@@ -77,7 +79,7 @@
+ }
+ 
+ /// On Windows, a corresponding `From<&impl AsSocket>` implementation exists.
+-#[cfg(unix)]
++#[cfg(any(unix, target_os = "wasi"))]
+ #[cfg_attr(docsrs, doc(cfg(unix)))]
+ impl<'s, S> From<&'s S> for SockRef<'s>
+ where
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/sys/unix.rs b/src/sys/unix.rs
+--- a/src/sys/unix.rs	2026-08-07 02:26:25.116695410 +0200
++++ b/src/sys/unix.rs	2026-08-07 02:26:25.123370808 +0200
+@@ -3302,4 +3302,4 @@
+     let want = [32, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7];
+     assert_eq!(raw.s6_addr, want);
+     assert_eq!(from_in6_addr(raw), ip);
+-}
++}
+\ No newline at end of file
+diff -ruN '--exclude=.cargo-checksum.json' '--exclude=Cargo.lock' '--exclude=*.orig' '--exclude=*.rej' a/src/sys/wasi.rs b/src/sys/wasi.rs
+--- a/src/sys/wasi.rs	1970-01-01 01:00:00.000000000 +0100
++++ b/src/sys/wasi.rs	2026-08-07 02:27:37.111703209 +0200
+@@ -0,0 +1,1312 @@
++#![allow(unused_imports)]
++use std::cmp::min;
++use std::io::IoSlice;
++use std::marker::PhantomData;
++use std::mem::{self, size_of, MaybeUninit};
++use std::net::Shutdown;
++use std::net::{Ipv4Addr, Ipv6Addr};
++use std::num::NonZeroU32;
++use std::num::NonZeroUsize;
++use std::os::wasi::io::RawFd;
++use std::os::wasi::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
++use std::path::Path;
++use std::ptr;
++use std::time::{Duration, Instant};
++use std::{io, slice};
++
++use libc::ssize_t;
++use libc::{c_void, in6_addr, in_addr};
++
++use std::os::wasi::ffi::OsStrExt;
++
++use crate::RecvFlags;
++use crate::{Domain, Protocol, SockAddr, TcpKeepalive, Type};
++
++pub(crate) use libc::c_int;
++
++// Used in `Domain`.
++pub(crate) use libc::{AF_INET, AF_INET6, AF_UNIX};
++// Used in `Type`.
++pub(crate) use libc::SOCK_RAW;
++#[cfg(feature = "all")]
++pub(crate) use libc::SOCK_SEQPACKET;
++pub(crate) use libc::{SOCK_DGRAM, SOCK_STREAM};
++// Used in `Protocol`.
++pub(crate) use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP};
++// Used in `SockAddr`.
++pub(crate) use libc::{
++    sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t,
++};
++// Used in `RecvFlags`.
++pub(crate) use libc::{MSG_TRUNC, SO_OOBINLINE};
++// Used in `Socket`.
++pub(crate) use libc::IPV6_RECVHOPLIMIT;
++pub(crate) use libc::IP_HDRINCL;
++pub(crate) use libc::IP_RECVTOS;
++pub(crate) use libc::IP_TOS;
++pub(crate) use libc::SO_LINGER;
++pub(crate) use libc::{
++    ip_mreq as IpMreq, ipv6_mreq as Ipv6Mreq, linger, IPPROTO_IP, IPPROTO_IPV6,
++    IPV6_MULTICAST_HOPS, IPV6_MULTICAST_IF, IPV6_MULTICAST_LOOP, IPV6_UNICAST_HOPS, IPV6_V6ONLY,
++    IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP, IP_MULTICAST_IF, IP_MULTICAST_LOOP, IP_MULTICAST_TTL,
++    IP_TTL, MSG_OOB, MSG_PEEK, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_KEEPALIVE, SO_RCVBUF,
++    SO_RCVTIMEO, SO_REUSEADDR, SO_SNDBUF, SO_SNDTIMEO, SO_TYPE, TCP_NODELAY,
++};
++pub(crate) use libc::{
++    ip_mreq_source as IpMreqSource, IP_ADD_SOURCE_MEMBERSHIP, IP_DROP_SOURCE_MEMBERSHIP,
++};
++pub(crate) use libc::{IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP};
++pub(crate) use libc::{TCP_KEEPCNT, TCP_KEEPINTVL};
++
++// See this type in the Windows file.
++pub(crate) type Bool = c_int;
++
++use libc::TCP_KEEPIDLE as KEEPALIVE_TIME;
++
++/// Helper macro to execute a system call that returns an `io::Result`.
++macro_rules! syscall {
++    ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
++        #[allow(unused_unsafe)]
++        let res = unsafe { libc::$fn($($arg, )*) };
++        if res == -1 {
++            Err(std::io::Error::last_os_error())
++        } else {
++            Ok(res)
++        }
++    }};
++}
++
++/// Maximum size of a buffer passed to system call like `recv` and `send`.
++const MAX_BUF_LEN: usize = ssize_t::MAX as usize;
++
++type IovLen = usize;
++
++impl_debug!(
++    Domain,
++    libc::AF_INET,
++    libc::AF_INET6,
++    libc::AF_UNSPEC, // = 0.
++);
++
++/// Unix only API.
++impl Type {
++    /// Set `SOCK_NONBLOCK` on the `Type`.
++    pub const fn nonblocking(self) -> Type {
++        Type(self.0 | libc::SOCK_NONBLOCK)
++    }
++
++    /// Set `SOCK_CLOEXEC` on the `Type`.
++    pub const fn cloexec(self) -> Type {
++        self._cloexec()
++    }
++    pub(crate) const fn _cloexec(self) -> Type {
++        Type(self.0 | libc::SOCK_CLOEXEC)
++    }
++}
++
++impl_debug!(Type, libc::SOCK_STREAM, libc::SOCK_DGRAM, libc::SOCK_RAW,);
++
++impl_debug!(
++    Protocol,
++    libc::IPPROTO_ICMP,
++    libc::IPPROTO_ICMPV6,
++    libc::IPPROTO_TCP,
++    libc::IPPROTO_UDP,
++);
++
++#[repr(transparent)]
++pub struct MaybeUninitSlice<'a> {
++    vec: libc::iovec,
++    _lifetime: PhantomData<&'a mut [MaybeUninit<u8>]>,
++}
++
++unsafe impl<'a> Send for MaybeUninitSlice<'a> {}
++
++unsafe impl<'a> Sync for MaybeUninitSlice<'a> {}
++
++impl std::fmt::Debug for RecvFlags {
++    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++        f.debug_struct("RecvFlags")
++            .field("is_truncated", &self.is_truncated())
++            .finish()
++    }
++}
++
++impl<'a> MaybeUninitSlice<'a> {
++    pub(crate) fn new(buf: &'a mut [MaybeUninit<u8>]) -> MaybeUninitSlice<'a> {
++        MaybeUninitSlice {
++            vec: libc::iovec {
++                iov_base: buf.as_mut_ptr().cast(),
++                iov_len: buf.len(),
++            },
++            _lifetime: PhantomData,
++        }
++    }
++
++    pub(crate) fn as_slice(&self) -> &[MaybeUninit<u8>] {
++        unsafe { slice::from_raw_parts(self.vec.iov_base.cast(), self.vec.iov_len) }
++    }
++
++    pub(crate) fn as_mut_slice(&mut self) -> &mut [MaybeUninit<u8>] {
++        unsafe { slice::from_raw_parts_mut(self.vec.iov_base.cast(), self.vec.iov_len) }
++    }
++}
++
++// Used in `MsgHdr`.
++pub(crate) use libc::msghdr;
++
++pub(crate) fn set_msghdr_name(msg: &mut msghdr, name: &SockAddr) {
++    msg.msg_name = name.as_ptr() as *mut _;
++    msg.msg_namelen = name.len();
++}
++
++#[allow(clippy::unnecessary_cast)] // IovLen type can be `usize`.
++pub(crate) fn set_msghdr_iov(msg: &mut msghdr, ptr: *mut libc::iovec, len: usize) {
++    msg.msg_iov = ptr;
++    msg.msg_iovlen = min(len, IovLen::MAX as usize) as IovLen;
++}
++
++pub(crate) fn set_msghdr_control(msg: &mut msghdr, ptr: *mut libc::c_void, len: usize) {
++    msg.msg_control = ptr as *mut u8;
++    msg.msg_controllen = len as _;
++}
++
++pub(crate) fn set_msghdr_flags(msg: &mut msghdr, flags: libc::c_int) {
++    msg.msg_flags = flags;
++}
++
++pub(crate) fn msghdr_flags(msg: &msghdr) -> RecvFlags {
++    RecvFlags(msg.msg_flags)
++}
++
++pub(crate) fn msghdr_control_len(msg: &msghdr) -> usize {
++    msg.msg_controllen as _
++}
++
++/// Unix only API.
++impl SockAddr {
++    /// Constructs a `SockAddr` with the family `AF_UNIX` and the provided path.
++    ///
++    /// # Failure
++    ///
++    /// Returns an error if the path is longer than `SUN_LEN`.
++    #[cfg(feature = "all")]
++    #[cfg_attr(docsrs, doc(cfg(feature = "all")))]
++    #[allow(unused_unsafe)] // TODO: replace with `unsafe_op_in_unsafe_fn` once stable.
++    pub fn unix<P>(path: P) -> io::Result<SockAddr>
++    where
++        P: AsRef<Path>,
++    {
++        unsafe {
++            SockAddr::try_init(|storage, len| {
++                // Safety: `SockAddr::try_init` zeros the address, which is a valid
++                // representation.
++                let storage: &mut libc::sockaddr_un = unsafe { &mut *storage.cast() };
++                let len: &mut socklen_t = unsafe { &mut *len };
++
++                let bytes = path.as_ref().as_os_str().as_bytes();
++                let too_long = match bytes.first() {
++                    None => false,
++                    // linux abstract namespaces aren't null-terminated
++                    Some(&0) => bytes.len() > storage.sun_path.len(),
++                    Some(_) => bytes.len() >= storage.sun_path.len(),
++                };
++                if too_long {
++                    return Err(io::Error::new(
++                        io::ErrorKind::InvalidInput,
++                        "path must be shorter than SUN_LEN",
++                    ));
++                }
++
++                storage.sun_family = libc::AF_UNIX as sa_family_t;
++                // Safety: `bytes` and `addr.sun_path` are not overlapping and
++                // both point to valid memory.
++                // `SockAddr::try_init` zeroes the memory, so the path is already
++                // null terminated.
++                unsafe {
++                    ptr::copy_nonoverlapping(
++                        bytes.as_ptr(),
++                        storage.sun_path.as_mut_ptr() as *mut u8,
++                        bytes.len(),
++                    )
++                };
++
++                let base = storage as *const _ as usize;
++                let path = &storage.sun_path as *const _ as usize;
++                let sun_path_offset = path - base;
++                let length = sun_path_offset
++                    + bytes.len()
++                    + match bytes.first() {
++                        Some(&0) | None => 0,
++                        Some(_) => 1,
++                    };
++                *len = length as socklen_t;
++
++                Ok(())
++            })
++        }
++        .map(|(_, addr)| addr)
++    }
++}
++
++pub(crate) type Socket = c_int;
++
++pub(crate) type RawSocket = c_int;
++
++
++pub(crate) unsafe fn socket_from_raw(socket: Socket) -> crate::socket::Inner {
++    crate::socket::Inner::from_raw_fd(socket)
++}
++
++pub(crate) fn socket_as_raw(socket: &crate::socket::Inner) -> Socket {
++    socket.as_raw_fd()
++}
++
++pub(crate) fn socket_into_raw(socket: crate::socket::Inner) -> Socket {
++    socket.into_raw_fd()
++}
++
++pub(crate) fn socket(family: c_int, ty: c_int, protocol: c_int) -> io::Result<RawSocket> {
++    syscall!(socket(family, ty, protocol))
++}
++
++#[cfg(feature = "all")]
++pub(crate) fn socketpair(family: c_int, ty: c_int, protocol: c_int) -> io::Result<[RawSocket; 2]> {
++    let mut fds = [0, 0];
++    syscall!(socketpair(family, ty, protocol, fds.as_mut_ptr())).map(|_| fds)
++}
++
++pub(crate) fn bind(fd: RawSocket, addr: &SockAddr) -> io::Result<()> {
++    syscall!(bind(fd, addr.as_ptr().cast::<sockaddr>(), addr.len() as _)).map(|_| ())
++}
++
++pub(crate) fn connect(fd: RawSocket, addr: &SockAddr) -> io::Result<()> {
++    syscall!(connect(fd, addr.as_ptr().cast::<sockaddr>(), addr.len())).map(|_| ())
++}
++
++pub(crate) fn poll_connect(socket: &crate::Socket, timeout: Duration) -> io::Result<()> {
++    let start = Instant::now();
++
++    let mut pollfd = libc::pollfd {
++        fd: socket.as_raw(),
++        events: libc::POLLIN | libc::POLLOUT,
++        revents: 0,
++    };
++
++    loop {
++        let elapsed = start.elapsed();
++        if elapsed >= timeout {
++            return Err(io::ErrorKind::TimedOut.into());
++        }
++
++        let timeout = (timeout - elapsed).as_millis();
++        let timeout = clamp(timeout, 1, c_int::MAX as u128) as c_int;
++
++        match syscall!(poll(&mut pollfd, 1, timeout)) {
++            Ok(0) => return Err(io::ErrorKind::TimedOut.into()),
++            Ok(_) => {
++                // Error or hang up indicates an error (or failure to connect).
++                if (pollfd.revents & libc::POLLHUP) != 0 || (pollfd.revents & libc::POLLERR) != 0 {
++                    match socket.take_error() {
++                        Ok(Some(err)) => return Err(err),
++                        Ok(None) => {
++                            return Err(io::Error::new(
++                                io::ErrorKind::Other,
++                                "no error set after POLLHUP",
++                            ))
++                        }
++                        Err(err) => return Err(err),
++                    }
++                }
++                return Ok(());
++            }
++            // Got interrupted, try again.
++            Err(ref err) if err.kind() == io::ErrorKind::Interrupted => continue,
++            Err(err) => return Err(err),
++        }
++    }
++}
++
++// TODO: use clamp from std lib, stable since 1.50.
++fn clamp<T>(value: T, min: T, max: T) -> T
++where
++    T: Ord,
++{
++    if value <= min {
++        min
++    } else if value >= max {
++        max
++    } else {
++        value
++    }
++}
++
++pub(crate) fn listen(fd: RawSocket, backlog: c_int) -> io::Result<()> {
++    syscall!(listen(fd, backlog)).map(|_| ())
++}
++
++pub(crate) fn accept(fd: RawSocket) -> io::Result<(RawSocket, SockAddr)> {
++    // Safety: `accept` initialises the `SockAddr` for us.
++    unsafe { SockAddr::try_init(|storage, len| syscall!(accept(fd, storage.cast(), len))) }
++}
++
++pub(crate) fn getsockname(fd: RawSocket) -> io::Result<SockAddr> {
++    // Safety: `accept` initialises the `SockAddr` for us.
++    unsafe { SockAddr::try_init(|storage, len| syscall!(getsockname(fd, storage.cast(), len))) }
++        .map(|(_, addr)| addr)
++}
++
++pub(crate) fn getpeername(fd: RawSocket) -> io::Result<SockAddr> {
++    // Safety: `accept` initialises the `SockAddr` for us.
++    unsafe { SockAddr::try_init(|storage, len| syscall!(getpeername(fd, storage.cast(), len))) }
++        .map(|(_, addr)| addr)
++}
++
++pub(crate) fn try_clone(fd: RawSocket) -> io::Result<RawSocket> {
++    syscall!(fcntl(fd, libc::F_DUPFD_CLOEXEC, 0))
++}
++
++pub(crate) fn set_nonblocking(fd: RawSocket, nonblocking: bool) -> io::Result<()> {
++    if nonblocking {
++        fcntl_add(fd, libc::F_GETFL, libc::F_SETFL, libc::O_NONBLOCK)
++    } else {
++        fcntl_remove(fd, libc::F_GETFL, libc::F_SETFL, libc::O_NONBLOCK)
++    }
++}
++
++pub(crate) fn shutdown(fd: RawSocket, how: Shutdown) -> io::Result<()> {
++    let how = match how {
++        Shutdown::Write => libc::SHUT_WR,
++        Shutdown::Read => libc::SHUT_RD,
++        Shutdown::Both => libc::SHUT_RDWR,
++    };
++    syscall!(shutdown(fd, how)).map(|_| ())
++}
++
++pub(crate) fn recv(fd: RawSocket, buf: &mut [MaybeUninit<u8>], flags: c_int) -> io::Result<usize> {
++    syscall!(recv(
++        fd,
++        buf.as_mut_ptr().cast(),
++        min(buf.len(), MAX_BUF_LEN),
++        flags,
++    ))
++    .map(|n| n as usize)
++}
++
++pub(crate) fn recv_from(
++    fd: RawSocket,
++    buf: &mut [MaybeUninit<u8>],
++    flags: c_int,
++) -> io::Result<(usize, SockAddr)> {
++    // Safety: `recvfrom` initialises the `SockAddr` for us.
++    unsafe {
++        SockAddr::try_init(|addr, addrlen| {
++            syscall!(recvfrom(
++                fd,
++                buf.as_mut_ptr().cast(),
++                min(buf.len(), MAX_BUF_LEN),
++                flags,
++                addr.cast(),
++                addrlen
++            ))
++            .map(|n| n as usize)
++        })
++    }
++}
++
++pub(crate) fn peek_sender(fd: RawSocket) -> io::Result<SockAddr> {
++    // Unix-like platforms simply truncate the returned data, so this implementation is trivial.
++    // However, for Windows this requires suppressing the `WSAEMSGSIZE` error,
++    // so that requires a different approach.
++    // NOTE: macOS does not populate `sockaddr` if you pass a zero-sized buffer.
++    let (_, sender) = recv_from(fd, &mut [MaybeUninit::uninit(); 8], MSG_PEEK)?;
++    Ok(sender)
++}
++
++pub(crate) fn recv_vectored(
++    fd: RawSocket,
++    bufs: &mut [crate::MaybeUninitSlice<'_>],
++    flags: c_int,
++) -> io::Result<(usize, RecvFlags)> {
++    recvmsg(fd, ptr::null_mut(), bufs, flags).map(|(n, _, recv_flags)| (n, recv_flags))
++}
++
++pub(crate) fn recv_from_vectored(
++    fd: RawSocket,
++    bufs: &mut [crate::MaybeUninitSlice<'_>],
++    flags: c_int,
++) -> io::Result<(usize, RecvFlags, SockAddr)> {
++    // Safety: `recvmsg` initialises the address storage and we set the length
++    // manually.
++    unsafe {
++        SockAddr::try_init(|storage, len| {
++            recvmsg(fd, storage.cast(), bufs, flags).map(|(n, addrlen, recv_flags)| {
++                // Set the correct address length.
++                *len = addrlen;
++                (n, recv_flags)
++            })
++        })
++    }
++    .map(|((n, recv_flags), addr)| (n, recv_flags, addr))
++}
++
++/// Returns the (bytes received, sending address len, `RecvFlags`).
++pub(crate) fn recvmsg(
++    fd: RawSocket,
++    msg_name: *mut sockaddr_storage,
++    bufs: &mut [crate::MaybeUninitSlice<'_>],
++    flags: c_int,
++) -> io::Result<(usize, libc::socklen_t, RecvFlags)> {
++    let msg_namelen = if msg_name.is_null() {
++        0
++    } else {
++        size_of::<sockaddr_storage>() as libc::socklen_t
++    };
++    // libc::msghdr contains unexported padding fields on Fuchsia.
++    let mut msg: libc::msghdr = unsafe { mem::zeroed() };
++    msg.msg_name = msg_name.cast();
++    msg.msg_namelen = msg_namelen;
++    msg.msg_iov = bufs.as_mut_ptr().cast();
++    msg.msg_iovlen = min(bufs.len(), IovLen::MAX as usize) as IovLen;
++    syscall!(recvmsg(fd, &mut msg, flags))
++        .map(|n| (n as usize, msg.msg_namelen, RecvFlags(msg.msg_flags)))
++}
++
++pub(crate) fn send(fd: RawSocket, buf: &[u8], flags: c_int) -> io::Result<usize> {
++    syscall!(send(
++        fd,
++        buf.as_ptr().cast(),
++        min(buf.len(), MAX_BUF_LEN),
++        flags,
++    ))
++    .map(|n| n as usize)
++}
++
++pub(crate) fn send_vectored(
++    fd: RawSocket,
++    bufs: &[IoSlice<'_>],
++    flags: c_int,
++) -> io::Result<usize> {
++    sendmsg_internal(fd, ptr::null(), 0, bufs, flags)
++}
++
++pub(crate) fn send_to(
++    fd: RawSocket,
++    buf: &[u8],
++    addr: &SockAddr,
++    flags: c_int,
++) -> io::Result<usize> {
++    syscall!(sendto(
++        fd,
++        buf.as_ptr().cast(),
++        min(buf.len(), MAX_BUF_LEN),
++        flags,
++        addr.as_ptr().cast::<sockaddr>(),
++        addr.len(),
++    ))
++    .map(|n| n as usize)
++}
++
++pub(crate) fn send_to_vectored(
++    fd: RawSocket,
++    bufs: &[IoSlice<'_>],
++    addr: &SockAddr,
++    flags: c_int,
++) -> io::Result<usize> {
++    let msg = crate::MsgHdr::new().with_addr(addr).with_buffers(bufs);
++    sendmsg(fd, &msg, flags)
++}
++
++pub(crate) fn sendmsg(
++    fd: RawSocket,
++    msg: &crate::MsgHdr<'_, '_, '_>,
++    flags: c_int,
++) -> io::Result<usize> {
++    syscall!(sendmsg(fd, &msg.inner, flags)).map(|n| n as usize)
++}
++
++/// Returns the (bytes received, sending address len, `RecvFlags`).
++fn sendmsg_internal(
++    fd: RawSocket,
++    msg_name: *const sockaddr_storage,
++    msg_namelen: socklen_t,
++    bufs: &[IoSlice<'_>],
++    flags: c_int,
++) -> io::Result<usize> {
++    // libc::msghdr contains unexported padding fields on Fuchsia.
++    let mut msg: libc::msghdr = unsafe { mem::zeroed() };
++    // Safety: we're creating a `*mut` pointer from a reference, which is UB
++    // once actually used. However the OS should not write to it in the
++    // `sendmsg` system call.
++    msg.msg_name = (msg_name as *mut sockaddr_storage).cast();
++    msg.msg_namelen = msg_namelen;
++    // Safety: Same as above about `*const` -> `*mut`.
++    msg.msg_iov = bufs.as_ptr() as *mut _;
++    msg.msg_iovlen = min(bufs.len(), IovLen::MAX as usize) as IovLen;
++    syscall!(sendmsg(fd, &msg, flags)).map(|n| n as usize)
++}
++
++/// Wrapper around `getsockopt` to deal with platform specific timeouts.
++pub(crate) fn timeout_opt(fd: RawSocket, opt: c_int, val: c_int) -> io::Result<Option<Duration>> {
++    unsafe { getsockopt(fd, opt, val).map(from_timeval) }
++}
++
++fn from_timeval(duration: libc::timeval) -> Option<Duration> {
++    if duration.tv_sec == 0 && duration.tv_usec == 0 {
++        None
++    } else {
++        let sec = duration.tv_sec as u64;
++        let nsec = (duration.tv_usec as u32) * 1000;
++        Some(Duration::new(sec, nsec))
++    }
++}
++
++/// Wrapper around `setsockopt` to deal with platform specific timeouts.
++pub(crate) fn set_timeout_opt(
++    fd: RawSocket,
++    opt: c_int,
++    val: c_int,
++    duration: Option<Duration>,
++) -> io::Result<()> {
++    let duration = into_timeval(duration);
++    unsafe { setsockopt(fd, opt, val, duration) }
++}
++
++fn into_timeval(duration: Option<Duration>) -> libc::timeval {
++    match duration {
++        // https://github.com/rust-lang/libc/issues/1848
++        #[cfg_attr(target_env = "musl", allow(deprecated))]
++        Some(duration) => libc::timeval {
++            tv_sec: min(duration.as_secs(), libc::time_t::MAX as u64) as libc::time_t,
++            tv_usec: duration.subsec_micros() as libc::suseconds_t,
++        },
++        None => libc::timeval {
++            tv_sec: 0,
++            tv_usec: 0,
++        },
++    }
++}
++
++pub(crate) fn tcp_keepalive_time(fd: RawSocket) -> io::Result<Duration> {
++    unsafe {
++        getsockopt::<c_int>(fd, IPPROTO_TCP, KEEPALIVE_TIME)
++            .map(|secs| Duration::from_secs(secs as u64))
++    }
++}
++
++pub(crate) fn keepalive_time(fd: RawSocket) -> io::Result<Duration> {
++    tcp_keepalive_time(fd)
++}
++
++#[allow(unused_variables)]
++pub(crate) fn set_tcp_keepalive(fd: RawSocket, keepalive: &TcpKeepalive) -> io::Result<()> {
++    #[cfg(not(any(target_os = "haiku", target_os = "openbsd")))]
++    if let Some(time) = keepalive.time {
++        let secs = into_secs(time);
++        unsafe { setsockopt(fd, libc::IPPROTO_TCP, KEEPALIVE_TIME, secs)? }
++    }
++
++    {
++        if let Some(interval) = keepalive.interval {
++            let secs = into_secs(interval);
++            unsafe { setsockopt(fd, libc::IPPROTO_TCP, libc::TCP_KEEPINTVL, secs)? }
++        }
++
++        if let Some(retries) = keepalive.retries {
++            unsafe { setsockopt(fd, libc::IPPROTO_TCP, libc::TCP_KEEPCNT, retries as c_int)? }
++        }
++    }
++
++    Ok(())
++}
++
++fn into_secs(duration: Duration) -> c_int {
++    min(duration.as_secs(), c_int::MAX as u64) as c_int
++}
++
++/// Add `flag` to the current set flags of `F_GETFD`.
++fn fcntl_add(fd: RawSocket, get_cmd: c_int, set_cmd: c_int, flag: c_int) -> io::Result<()> {
++    let previous = syscall!(fcntl(fd, get_cmd))?;
++    let new = previous | flag;
++    if new != previous {
++        syscall!(fcntl(fd, set_cmd, new)).map(|_| ())
++    } else {
++        // Flag was already set.
++        Ok(())
++    }
++}
++
++/// Remove `flag` to the current set flags of `F_GETFD`.
++fn fcntl_remove(fd: RawSocket, get_cmd: c_int, set_cmd: c_int, flag: c_int) -> io::Result<()> {
++    let previous = syscall!(fcntl(fd, get_cmd))?;
++    let new = previous & !flag;
++    if new != previous {
++        syscall!(fcntl(fd, set_cmd, new)).map(|_| ())
++    } else {
++        // Flag was already set.
++        Ok(())
++    }
++}
++
++/// Caller must ensure `T` is the correct type for `opt` and `val`.
++pub(crate) unsafe fn getsockopt<T>(fd: RawSocket, opt: c_int, val: c_int) -> io::Result<T> {
++    let mut payload: MaybeUninit<T> = MaybeUninit::uninit();
++    let mut len = size_of::<T>() as libc::socklen_t;
++    syscall!(getsockopt(
++        fd,
++        opt,
++        val,
++        payload.as_mut_ptr().cast(),
++        &mut len,
++    ))
++    .map(|_| {
++        debug_assert_eq!(len as usize, size_of::<T>());
++        // Safety: `getsockopt` initialised `payload` for us.
++        payload.assume_init()
++    })
++}
++
++/// Caller must ensure `T` is the correct type for `opt` and `val`.
++pub(crate) unsafe fn setsockopt<T>(
++    fd: RawSocket,
++    opt: c_int,
++    val: c_int,
++    payload: T,
++) -> io::Result<()> {
++    let payload = &payload as *const T as *const c_void;
++    syscall!(setsockopt(
++        fd,
++        opt,
++        val,
++        payload,
++        mem::size_of::<T>() as libc::socklen_t,
++    ))
++    .map(|_| ())
++}
++
++pub(crate) fn to_in_addr(addr: &Ipv4Addr) -> in_addr {
++    // `s_addr` is stored as BE on all machines, and the array is in BE order.
++    // So the native endian conversion method is used so that it's never
++    // swapped.
++    in_addr {
++        s_addr: u32::from_ne_bytes(addr.octets()),
++    }
++}
++
++pub(crate) fn from_in_addr(in_addr: in_addr) -> Ipv4Addr {
++    Ipv4Addr::from(in_addr.s_addr.to_ne_bytes())
++}
++
++pub(crate) fn to_in6_addr(addr: &Ipv6Addr) -> in6_addr {
++    in6_addr {
++        s6_addr: addr.octets(),
++    }
++}
++
++pub(crate) fn from_in6_addr(addr: in6_addr) -> Ipv6Addr {
++    Ipv6Addr::from(addr.s6_addr)
++}
++
++pub(crate) fn to_mreqn(
++    multiaddr: &Ipv4Addr,
++    interface: &crate::socket::InterfaceIndexOrAddress,
++) -> libc::ip_mreqn {
++    match interface {
++        crate::socket::InterfaceIndexOrAddress::Index(interface) => libc::ip_mreqn {
++            imr_multiaddr: to_in_addr(multiaddr),
++            imr_address: to_in_addr(&Ipv4Addr::UNSPECIFIED),
++            imr_ifindex: *interface as _,
++        },
++        crate::socket::InterfaceIndexOrAddress::Address(interface) => libc::ip_mreqn {
++            imr_multiaddr: to_in_addr(multiaddr),
++            imr_address: to_in_addr(interface),
++            imr_ifindex: 0,
++        },
++    }
++}
++
++/// Unix only API.
++impl crate::Socket {
++    /// Accept a new incoming connection from this listener.
++    ///
++    /// This function directly corresponds to the `accept4(2)` function.
++    ///
++    /// This function will block the calling thread until a new connection is
++    /// established. When established, the corresponding `Socket` and the remote
++    /// peer's address will be returned.
++    pub fn accept4(&self, flags: c_int) -> io::Result<(crate::Socket, SockAddr)> {
++        self._accept4(flags)
++    }
++
++    pub(crate) fn _accept4(&self, flags: c_int) -> io::Result<(crate::Socket, SockAddr)> {
++        // Safety: `accept4` initialises the `SockAddr` for us.
++        unsafe {
++            SockAddr::try_init(|storage, len| {
++                syscall!(accept4(self.as_raw(), storage.cast(), len, flags))
++                    .map(crate::Socket::from_raw)
++            })
++        }
++    }
++
++    /// Sets `CLOEXEC` on the socket.
++    ///
++    /// # Notes
++    ///
++    /// On supported platforms you can use [`Type::cloexec`].
++    pub fn set_cloexec(&self, close_on_exec: bool) -> io::Result<()> {
++        self._set_cloexec(close_on_exec)
++    }
++
++    pub(crate) fn _set_cloexec(&self, close_on_exec: bool) -> io::Result<()> {
++        if close_on_exec {
++            fcntl_add(
++                self.as_raw(),
++                libc::F_GETFD,
++                libc::F_SETFD,
++                libc::FD_CLOEXEC,
++            )
++        } else {
++            fcntl_remove(
++                self.as_raw(),
++                libc::F_GETFD,
++                libc::F_SETFD,
++                libc::FD_CLOEXEC,
++            )
++        }
++    }
++
++    /// Gets the value of the `TCP_MAXSEG` option on this socket.
++    ///
++    /// For more information about this option, see [`set_mss`].
++    ///
++    /// [`set_mss`]: crate::Socket::set_mss
++    pub fn mss(&self) -> io::Result<u32> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_MAXSEG)
++                .map(|mss| mss as u32)
++        }
++    }
++
++    /// Sets the value of the `TCP_MAXSEG` option on this socket.
++    ///
++    /// The `TCP_MAXSEG` option denotes the TCP Maximum Segment Size and is only
++    /// available on TCP sockets.
++    pub fn set_mss(&self, mss: u32) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_MAXSEG,
++                mss as c_int,
++            )
++        }
++    }
++
++    /// Returns `true` if `listen(2)` was called on this socket by checking the
++    /// `SO_ACCEPTCONN` option on this socket.
++    pub fn is_listener(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_ACCEPTCONN)
++                .map(|v| v != 0)
++        }
++    }
++
++    /// Returns the [`Protocol`] of this socket by checking the `SO_PROTOCOL`
++    /// option on this socket.
++    pub fn protocol(&self) -> io::Result<Option<Protocol>> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_PROTOCOL).map(|v| match v
++            {
++                0 => None,
++                p => Some(Protocol(p)),
++            })
++        }
++    }
++
++    /// Gets the value for the `SO_MARK` option on this socket.
++    ///
++    /// This value gets the socket mark field for each packet sent through
++    /// this socket.
++    ///
++    /// On Linux this function requires the `CAP_NET_ADMIN` capability.
++    pub fn mark(&self) -> io::Result<u32> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_MARK)
++                .map(|mark| mark as u32)
++        }
++    }
++
++    /// Sets the value for the `SO_MARK` option on this socket.
++    ///
++    /// This value sets the socket mark field for each packet sent through
++    /// this socket. Changing the mark can be used for mark-based routing
++    /// without netfilter or for packet filtering.
++    ///
++    /// On Linux this function requires the `CAP_NET_ADMIN` capability.
++    pub fn set_mark(&self, mark: u32) -> io::Result<()> {
++        unsafe {
++            setsockopt::<c_int>(
++                self.as_raw(),
++                libc::SOL_SOCKET,
++                libc::SO_MARK,
++                mark as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `TCP_CORK` option on this socket.
++    ///
++    /// For more information about this option, see [`set_cork`].
++    ///
++    /// [`set_cork`]: Socket::set_cork
++    pub fn cork(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_CORK)
++                .map(|cork| cork != 0)
++        }
++    }
++
++    /// Set the value of the `TCP_CORK` option on this socket.
++    ///
++    /// If set, don't send out partial frames. All queued partial frames are
++    /// sent when the option is cleared again. There is a 200 millisecond ceiling on
++    /// the time for which output is corked by `TCP_CORK`. If this ceiling is reached,
++    /// then queued data is automatically transmitted.
++    pub fn set_cork(&self, cork: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_CORK,
++                cork as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `TCP_QUICKACK` option on this socket.
++    ///
++    /// For more information about this option, see [`set_quickack`].
++    ///
++    /// [`set_quickack`]: Socket::set_quickack
++    pub fn quickack(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<Bool>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_QUICKACK)
++                .map(|quickack| quickack != 0)
++        }
++    }
++
++    /// Set the value of the `TCP_QUICKACK` option on this socket.
++    ///
++    /// If set, acks are sent immediately, rather than delayed if needed in accordance to normal
++    /// TCP operation. This flag is not permanent, it only enables a switch to or from quickack mode.
++    /// Subsequent operation of the TCP protocol will once again enter/leave quickack mode depending on
++    /// internal protocol processing and factors such as delayed ack timeouts occurring and data transfer.
++    pub fn set_quickack(&self, quickack: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_QUICKACK,
++                quickack as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this socket.
++    ///
++    /// For more information about this option, see [`set_thin_linear_timeouts`].
++    ///
++    /// [`set_thin_linear_timeouts`]: Socket::set_thin_linear_timeouts
++    pub fn thin_linear_timeouts(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<Bool>(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_THIN_LINEAR_TIMEOUTS,
++            )
++            .map(|timeouts| timeouts != 0)
++        }
++    }
++
++    /// Set the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this socket.
++    ///
++    /// If set, the kernel will dynamically detect a thin-stream connection if there are less than four packets in flight.
++    /// With less than four packets in flight the normal TCP fast retransmission will not be effective.
++    /// The kernel will modify the retransmission to avoid the very high latencies that thin stream suffer because of exponential backoff.
++    pub fn set_thin_linear_timeouts(&self, timeouts: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_THIN_LINEAR_TIMEOUTS,
++                timeouts as c_int,
++            )
++        }
++    }
++
++    /// Gets the value for the `SO_BINDTODEVICE` option on this socket.
++    ///
++    /// This value gets the socket binded device's interface name.
++    pub fn device(&self) -> io::Result<Option<Vec<u8>>> {
++        // TODO: replace with `MaybeUninit::uninit_array` once stable.
++        let mut buf: [MaybeUninit<u8>; libc::IFNAMSIZ] =
++            unsafe { MaybeUninit::uninit().assume_init() };
++        let mut len = buf.len() as libc::socklen_t;
++        syscall!(getsockopt(
++            self.as_raw(),
++            libc::SOL_SOCKET,
++            libc::SO_BINDTODEVICE,
++            buf.as_mut_ptr().cast(),
++            &mut len,
++        ))?;
++        if len == 0 {
++            Ok(None)
++        } else {
++            let buf = &buf[..len as usize - 1];
++            // TODO: use `MaybeUninit::slice_assume_init_ref` once stable.
++            Ok(Some(unsafe { &*(buf as *const [_] as *const [u8]) }.into()))
++        }
++    }
++
++    /// Sets the value for the `SO_BINDTODEVICE` option on this socket.
++    ///
++    /// If a socket is bound to an interface, only packets received from that
++    /// particular interface are processed by the socket. Note that this only
++    /// works for some socket types, particularly `AF_INET` sockets.
++    ///
++    /// If `interface` is `None` or an empty string it removes the binding.
++    pub fn bind_device(&self, interface: Option<&[u8]>) -> io::Result<()> {
++        let (value, len) = if let Some(interface) = interface {
++            (interface.as_ptr(), interface.len())
++        } else {
++            (ptr::null(), 0)
++        };
++        syscall!(setsockopt(
++            self.as_raw(),
++            libc::SOL_SOCKET,
++            libc::SO_BINDTODEVICE,
++            value.cast(),
++            len as libc::socklen_t,
++        ))
++        .map(|_| ())
++    }
++
++    /// Get the value of the `SO_INCOMING_CPU` option on this socket.
++    ///
++    /// For more information about this option, see [`set_cpu_affinity`].
++    ///
++    /// [`set_cpu_affinity`]: crate::Socket::set_cpu_affinity
++    pub fn cpu_affinity(&self) -> io::Result<usize> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_INCOMING_CPU)
++                .map(|cpu| cpu as usize)
++        }
++    }
++
++    /// Set value for the `SO_INCOMING_CPU` option on this socket.
++    ///
++    /// Sets the CPU affinity of the socket.
++    pub fn set_cpu_affinity(&self, cpu: usize) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::SOL_SOCKET,
++                libc::SO_INCOMING_CPU,
++                cpu as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `SO_REUSEPORT` option on this socket.
++    ///
++    /// For more information about this option, see [`set_reuse_port`].
++    ///
++    /// [`set_reuse_port`]: crate::Socket::set_reuse_port
++    pub fn reuse_port(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_SOCKET, libc::SO_REUSEPORT)
++                .map(|reuse| reuse != 0)
++        }
++    }
++
++    /// Set value for the `SO_REUSEPORT` option on this socket.
++    ///
++    /// This indicates that further calls to `bind` may allow reuse of local
++    /// addresses. For IPv4 sockets this means that a socket may bind even when
++    /// there's a socket already listening on this port.
++    pub fn set_reuse_port(&self, reuse: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::SOL_SOCKET,
++                libc::SO_REUSEPORT,
++                reuse as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `IP_FREEBIND` option on this socket.
++    ///
++    /// For more information about this option, see [`set_freebind`].
++    ///
++    /// [`set_freebind`]: crate::Socket::set_freebind
++    pub fn freebind(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_IP, libc::IP_FREEBIND)
++                .map(|freebind| freebind != 0)
++        }
++    }
++
++    /// Set value for the `IP_FREEBIND` option on this socket.
++    ///
++    /// If enabled, this boolean option allows binding to an IP address that is
++    /// nonlocal or does not (yet) exist.  This permits listening on a socket,
++    /// without requiring the underlying network interface or the specified
++    /// dynamic IP address to be up at the time that the application is trying
++    /// to bind to it.
++    pub fn set_freebind(&self, freebind: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::SOL_IP,
++                libc::IP_FREEBIND,
++                freebind as c_int,
++            )
++        }
++    }
++
++    /// Get the value of the `IPV6_FREEBIND` option on this socket.
++    ///
++    /// This is an IPv6 counterpart of `IP_FREEBIND` socket option on
++    /// Android/Linux. For more information about this option, see
++    /// [`set_freebind`].
++    ///
++    /// [`set_freebind`]: crate::Socket::set_freebind
++    pub fn freebind_ipv6(&self) -> io::Result<bool> {
++        unsafe {
++            getsockopt::<c_int>(self.as_raw(), libc::SOL_IPV6, libc::IPV6_FREEBIND)
++                .map(|freebind| freebind != 0)
++        }
++    }
++
++    /// Set value for the `IPV6_FREEBIND` option on this socket.
++    ///
++    /// This is an IPv6 counterpart of `IP_FREEBIND` socket option on
++    /// Android/Linux. For more information about this option, see
++    /// [`set_freebind`].
++    ///
++    /// [`set_freebind`]: crate::Socket::set_freebind
++    ///
++    /// # Examples
++    ///
++    /// On Linux:
++    ///
++    /// ```
++    /// use socket2::{Domain, Socket, Type};
++    /// use std::io::{self, Error, ErrorKind};
++    ///
++    /// fn enable_freebind(socket: &Socket) -> io::Result<()> {
++    ///     match socket.domain()? {
++    ///         Domain::IPV4 => socket.set_freebind(true)?,
++    ///         Domain::IPV6 => socket.set_freebind_ipv6(true)?,
++    ///         _ => return Err(Error::new(ErrorKind::Other, "unsupported domain")),
++    ///     };
++    ///     Ok(())
++    /// }
++    ///
++    /// # fn main() -> io::Result<()> {
++    /// #     let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
++    /// #     enable_freebind(&socket)
++    /// # }
++    /// ```
++    pub fn set_freebind_ipv6(&self, freebind: bool) -> io::Result<()> {
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::SOL_IPV6,
++                libc::IPV6_FREEBIND,
++                freebind as c_int,
++            )
++        }
++    }
++
++    /// Copies data between a `file` and this socket using the `sendfile(2)`
++    /// system call. Because this copying is done within the kernel,
++    /// `sendfile()` is more efficient than the combination of `read(2)` and
++    /// `write(2)`, which would require transferring data to and from user
++    /// space.
++    ///
++    /// Different OSs support different kinds of `file`s, see the OS
++    /// documentation for what kind of files are supported. Generally *regular*
++    /// files are supported by all OSs.
++    ///
++    /// The `offset` is the absolute offset into the `file` to use as starting
++    /// point.
++    ///
++    /// Depending on the OS this function *may* change the offset of `file`. For
++    /// the best results reset the offset of the file before using it again.
++    ///
++    /// The `length` determines how many bytes to send, where a length of `None`
++    /// means it will try to send all bytes.
++    pub fn sendfile<F>(
++        &self,
++        file: &F,
++        offset: usize,
++        length: Option<NonZeroUsize>,
++    ) -> io::Result<usize>
++    where
++        F: AsRawFd,
++    {
++        self._sendfile(file.as_raw_fd(), offset as _, length)
++    }
++
++    fn _sendfile(
++        &self,
++        file: RawFd,
++        offset: libc::off_t,
++        length: Option<NonZeroUsize>,
++    ) -> io::Result<usize> {
++        let count = match length {
++            Some(n) => n.get() as libc::size_t,
++            // The maximum the Linux kernel will write in a single call.
++            None => 0x7ffff000, // 2,147,479,552 bytes.
++        };
++        let mut offset = offset;
++        syscall!(sendfile(self.as_raw(), file, &mut offset, count)).map(|n| n as usize)
++    }
++
++    /// Set the value of the `TCP_USER_TIMEOUT` option on this socket.
++    ///
++    /// If set, this specifies the maximum amount of time that transmitted data may remain
++    /// unacknowledged or buffered data may remain untransmitted before TCP will forcibly close the
++    /// corresponding connection.
++    ///
++    /// Setting `timeout` to `None` or a zero duration causes the system default timeouts to
++    /// be used. If `timeout` in milliseconds is larger than `c_uint::MAX`, the timeout is clamped
++    /// to `c_uint::MAX`. For example, when `c_uint` is a 32-bit value, this limits the timeout to
++    /// approximately 49.71 days.
++    pub fn set_tcp_user_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
++        let timeout = timeout
++            .map(|to| min(to.as_millis(), libc::c_uint::MAX as u128) as libc::c_uint)
++            .unwrap_or(0);
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::IPPROTO_TCP,
++                libc::TCP_USER_TIMEOUT,
++                timeout,
++            )
++        }
++    }
++
++    /// Get the value of the `TCP_USER_TIMEOUT` option on this socket.
++    ///
++    /// For more information about this option, see [`set_tcp_user_timeout`].
++    ///
++    /// [`set_tcp_user_timeout`]: Socket::set_tcp_user_timeout
++    pub fn tcp_user_timeout(&self) -> io::Result<Option<Duration>> {
++        unsafe {
++            getsockopt::<libc::c_uint>(self.as_raw(), libc::IPPROTO_TCP, libc::TCP_USER_TIMEOUT)
++                .map(|millis| {
++                    if millis == 0 {
++                        None
++                    } else {
++                        Some(Duration::from_millis(millis as u64))
++                    }
++                })
++        }
++    }
++
++    /// Attach Berkeley Packet Filter(BPF) on this socket.
++    ///
++    /// BPF allows a user-space program to attach a filter onto any socket
++    /// and allow or disallow certain types of data to come through the socket.
++    ///
++    /// For more information about this option, see [filter](https://www.kernel.org/doc/html/v5.12/networking/filter.html)
++    pub fn attach_filter(&self, filters: &[libc::sock_filter]) -> io::Result<()> {
++        let prog = libc::sock_fprog {
++            len: filters.len() as u16,
++            filter: filters.as_ptr() as *mut _,
++        };
++
++        unsafe {
++            setsockopt(
++                self.as_raw(),
++                libc::SOL_SOCKET,
++                libc::SO_ATTACH_FILTER,
++                prog,
++            )
++        }
++    }
++
++    /// Detach Berkeley Packet Filter(BPF) from this socket.
++    ///
++    /// For more information about this option, see [`attach_filter`]
++    pub fn detach_filter(&self) -> io::Result<()> {
++        unsafe { setsockopt(self.as_raw(), libc::SOL_SOCKET, libc::SO_DETACH_FILTER, 0) }
++    }
++}
++
++impl AsFd for crate::Socket {
++    fn as_fd(&self) -> BorrowedFd<'_> {
++        // SAFETY: lifetime is bound by self.
++        unsafe { BorrowedFd::borrow_raw(self.as_raw()) }
++    }
++}
++
++impl AsRawFd for crate::Socket {
++    fn as_raw_fd(&self) -> c_int {
++        self.as_raw()
++    }
++}
++
++impl From<crate::Socket> for OwnedFd {
++    fn from(sock: crate::Socket) -> OwnedFd {
++        // SAFETY: sock.into_raw() always returns a valid fd.
++        unsafe { OwnedFd::from_raw_fd(sock.into_raw()) }
++    }
++}
++
++impl IntoRawFd for crate::Socket {
++    fn into_raw_fd(self) -> c_int {
++        self.into_raw()
++    }
++}
++
++impl From<OwnedFd> for crate::Socket {
++    fn from(fd: OwnedFd) -> crate::Socket {
++        // SAFETY: `OwnedFd` ensures the fd is valid.
++        unsafe { crate::Socket::from_raw_fd(fd.into_raw_fd()) }
++    }
++}
++
++impl FromRawFd for crate::Socket {
++    unsafe fn from_raw_fd(fd: c_int) -> crate::Socket {
++        crate::Socket::from_raw(fd)
++    }
++}
++
++#[test]
++fn in_addr_convertion() {
++    let ip = Ipv4Addr::new(127, 0, 0, 1);
++    let raw = to_in_addr(&ip);
++    // NOTE: `in_addr` is packed on NetBSD and it's unsafe to borrow.
++    let a = raw.s_addr;
++    assert_eq!(a, u32::from_ne_bytes([127, 0, 0, 1]));
++    assert_eq!(from_in_addr(raw), ip);
++
++    let ip = Ipv4Addr::new(127, 34, 4, 12);
++    let raw = to_in_addr(&ip);
++    let a = raw.s_addr;
++    assert_eq!(a, u32::from_ne_bytes([127, 34, 4, 12]));
++    assert_eq!(from_in_addr(raw), ip);
++}
++
++#[test]
++fn in6_addr_convertion() {
++    let ip = Ipv6Addr::new(0x2000, 1, 2, 3, 4, 5, 6, 7);
++    let raw = to_in6_addr(&ip);
++    let want = [32, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7];
++    assert_eq!(raw.s6_addr, want);
++    assert_eq!(from_in6_addr(raw), ip);
++}

--- a/pkgs/lib/wasix-crate-patches/socket2/edits.nix
+++ b/pkgs/lib/wasix-crate-patches/socket2/edits.nix
@@ -1,8 +1,7 @@
-# socket2: version-pinned wasi backend on the 0.6.x line, absorbed upstream at
-# 0.6.3, so 0.6.3+ is stock (a durable upstream fix) and 0.6.0-0.6.2 take the
-# floor patch. The pre-0.6 line is a different backend and builds stock (main
-# builds every 0.5.x consumer unpatched).
+# socket2: version-pinned wasi backends for Hyper 0.14's 0.5.10 and the 0.6.x
+# line. Support was absorbed upstream at 0.6.3, so newer 0.6 releases are stock.
+# Keep unseen post-0.5.10 0.5.x releases uncovered so they fail for a fresh port.
 {...}: {
-  edited = [">=0.6.0, <0.6.3"];
-  stock = [">=0.6.3" "<0.6.0"];
+  edited = ["=0.5.10" ">=0.6.0, <0.6.3"];
+  stock = [">=0.6.3" "<0.5.10"];
 }

--- a/pkgs/overlay/packages/static-web-server/package.nix
+++ b/pkgs/overlay/packages/static-web-server/package.nix
@@ -19,6 +19,29 @@ helpers.libTweaks {
       {message = "recheck or drop wasix.patch; it supplies missing WASI cfg branches for paths and signal-free shutdown";}
     ];
   };
+  # Preserve the command identity published by wasix-org/static-web-server.
+  # Edge deployments and SDK consumers address its atom explicitly as
+  # `wasmer/static-web-server:webserver`, so changing it would break existing
+  # package references even though the upstream binary has a different name.
+  passthru.wasmer = {
+    entrypoint = "webserver";
+    commands = [
+      {
+        name = "webserver";
+        module = "webserver";
+        wasm = "static-web-server.wasm";
+        output = "webserver.wasm";
+      }
+      # Also expose the upstream binary name for new consumers. Both commands
+      # use the legacy module and atom, and therefore share one module in webc.
+      {
+        name = "static-web-server";
+        module = "webserver";
+        wasm = "static-web-server.wasm";
+        output = "webserver.wasm";
+      }
+    ];
+  };
 } (prev.static-web-server.overrideAttrs (_: {
   # This wraps an existing buildRustPackage result, so set the hook variables
   # produced by buildRustPackage rather than its already-consumed arguments.

--- a/pkgs/overlay/packages/static-web-server/package.nix
+++ b/pkgs/overlay/packages/static-web-server/package.nix
@@ -13,12 +13,7 @@ helpers.libTweaks {
     substituteInPlace Cargo.toml \
       --replace-fail 'shadow-rs = "1.4.0"' 'shadow-rs = { version = "1.4.0", default-features = false, features = ["build"] }'
   '';
-  passthru.wasix = {
-    shipped = true;
-    updateNotes = [
-      {message = "recheck or drop wasix.patch; it supplies missing WASI cfg branches for paths and signal-free shutdown";}
-    ];
-  };
+  passthru.wasix.shipped = true;
   # Preserve the command identity published by wasix-org/static-web-server.
   # Edge deployments and SDK consumers address its atom explicitly as
   # `wasmer/static-web-server:webserver`, so changing it would break existing

--- a/pkgs/overlay/packages/static-web-server/package.nix
+++ b/pkgs/overlay/packages/static-web-server/package.nix
@@ -1,0 +1,36 @@
+# static-web-server's default feature set includes HTTP/2 over TLS. Wasmer Edge
+# terminates TLS before the guest, so omit http2-ring. Directory-listing downloads
+# pull async-tar's async-std/polling stack, which has no WASI backend; ordinary
+# directory listings remain enabled.
+{
+  prev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  patches = [./wasix.patch];
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'shadow-rs = "1.4.0"' 'shadow-rs = { version = "1.4.0", default-features = false, features = ["build"] }'
+  '';
+  passthru.wasix = {
+    shipped = true;
+    updateNotes = [
+      {message = "recheck or drop wasix.patch; it supplies missing WASI cfg branches for paths and signal-free shutdown";}
+    ];
+  };
+} (prev.static-web-server.overrideAttrs (_: {
+  # This wraps an existing buildRustPackage result, so set the hook variables
+  # produced by buildRustPackage rather than its already-consumed arguments.
+  cargoBuildNoDefaultFeatures = true;
+  cargoBuildFeatures = [
+    "compression"
+    "directory-listing"
+    "basic-auth"
+    "fallback-page"
+    "metrics"
+  ];
+
+  # These units launch a native binary and are not part of the webc payload.
+  postInstall = "";
+}))

--- a/pkgs/overlay/packages/static-web-server/tests/basic.nix
+++ b/pkgs/overlay/packages/static-web-server/tests/basic.nix
@@ -14,12 +14,13 @@
       mkdir -p public
       printf 'hello from WASIX\n' > 'public/hello world.txt'
 
-      static-web-server --host 0.0.0.0 --port "$port" --root "$WASIX_TEST_ROOT/public" &
+      # Exercise the legacy command identity used by existing Edge deployments.
+      webserver --host 0.0.0.0 --port "$port" --root "$WASIX_TEST_ROOT/public" &
       server_pid=$!
       trap 'kill $server_pid 2>/dev/null || true' EXIT
 
       for _ in $(seq 1 150); do
-        kill -0 $server_pid 2>/dev/null || { echo "static-web-server: server exited early" >&2; exit 1; }
+        kill -0 $server_pid 2>/dev/null || { echo "webserver: server exited early" >&2; exit 1; }
         curl -fsS "$base/hello%20world.txt" > response.txt 2>/dev/null && break
         sleep 0.2
       done

--- a/pkgs/overlay/packages/static-web-server/tests/basic.nix
+++ b/pkgs/overlay/packages/static-web-server/tests/basic.nix
@@ -1,0 +1,31 @@
+{
+  pkgs,
+  testLib,
+  wasmerPkgs,
+}: {
+  serve = testLib.mkWasixRun {
+    name = "static-web-server-serve";
+    nativePkgs = [pkgs.coreutils pkgs.curl];
+    wasixPkgs = [wasmerPkgs.static-web-server];
+    wasmerArgs = ["--net" "--enable-threads"];
+    script = ''
+      port=8732
+      base="http://127.0.0.1:$port"
+      mkdir -p public
+      printf 'hello from WASIX\n' > 'public/hello world.txt'
+
+      static-web-server --host 0.0.0.0 --port "$port" --root "$WASIX_TEST_ROOT/public" &
+      server_pid=$!
+      trap 'kill $server_pid 2>/dev/null || true' EXIT
+
+      for _ in $(seq 1 150); do
+        kill -0 $server_pid 2>/dev/null || { echo "static-web-server: server exited early" >&2; exit 1; }
+        curl -fsS "$base/hello%20world.txt" > response.txt 2>/dev/null && break
+        sleep 0.2
+      done
+
+      cmp response.txt 'public/hello world.txt'
+      echo "ok: static-web-server served a percent-encoded path over $base"
+    '';
+  };
+}

--- a/pkgs/overlay/packages/static-web-server/wasix.patch
+++ b/pkgs/overlay/packages/static-web-server/wasix.patch
@@ -1,0 +1,43 @@
+diff --git a/src/fs/path.rs b/src/fs/path.rs
+index 4dc405d..8afc0e1 100644
+--- a/src/fs/path.rs
++++ b/src/fs/path.rs
+@@ -66,6 +66,14 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+     OsStr::from_bytes(bytes).into()
+ }
+ 
++#[cfg(target_os = "wasi")]
++fn path_from_bytes(bytes: &[u8]) -> PathBuf {
++    use std::ffi::OsStr;
++    use std::os::wasi::ffi::OsStrExt;
++
++    OsStr::from_bytes(bytes).into()
++}
++
+ #[cfg(windows)]
+ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+     // This should really be OsStr::from_encoded_bytes_unchecked() but it’s
+diff --git a/src/server.rs b/src/server.rs
+index b5d98c5..f9dc9ec 100644
+--- a/src/server.rs
++++ b/src/server.rs
+@@ -10,6 +10,8 @@ use listenfd::ListenFd;
+ use std::net::{IpAddr, SocketAddr, TcpListener};
+ use std::sync::Arc;
+-use tokio::sync::{Mutex, watch::Receiver};
++use tokio::sync::watch::Receiver;
++#[cfg(any(unix, windows))]
++use tokio::sync::Mutex;
+ 
+ use crate::handler::{RequestHandler, RequestHandlerOpts};
+ 
+@@ -667,6 +669,9 @@ impl Server {
+         #[cfg(unix)]
+         http1_server.await?;
+ 
++        #[cfg(target_os = "wasi")]
++        http1_server.await?;
++
+         #[cfg(windows)]
+         let http1_server_task = tokio::spawn(async move {
+             if let Err(err) = http1_server.await {

--- a/pkgs/overlay/packages/static-web-server/wasix.patch
+++ b/pkgs/overlay/packages/static-web-server/wasix.patch
@@ -2,29 +2,28 @@ diff --git a/src/fs/path.rs b/src/fs/path.rs
 index 4dc405d..8afc0e1 100644
 --- a/src/fs/path.rs
 +++ b/src/fs/path.rs
-@@ -66,6 +66,17 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
-     OsStr::from_bytes(bytes).into()
- }
- 
-+// Rust's WASI targets do not set cfg(unix), even though WASI paths are byte-oriented.
-+// Use WASI's OsStrExt so percent-decoded, non-UTF-8 URL paths remain lossless rather
-+// than applying the Windows branch's lossy Unicode conversion.
-+#[cfg(target_os = "wasi")]
-+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
-+    use std::ffi::OsStr;
+@@ -62,7 +62,14 @@ impl<'a> PathExt for &'a Path {
+-#[cfg(unix)]
++// Unix and WASI paths are arbitrary byte sequences, so both targets must preserve
++// percent-decoded bytes instead of passing through the lossy Windows conversion.
++// WASI deliberately does not set cfg(unix), and Rust exposes the same OsStrExt API
++// through a target-specific module, hence the conditional imports in one shared body.
++#[cfg(any(unix, target_os = "wasi"))]
+ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+     use std::ffi::OsStr;
++    #[cfg(unix)]
+     use std::os::unix::ffi::OsStrExt;
+-
++    #[cfg(target_os = "wasi")]
 +    use std::os::wasi::ffi::OsStrExt;
 +
-+    OsStr::from_bytes(bytes).into()
-+}
-+
- #[cfg(windows)]
- fn path_from_bytes(bytes: &[u8]) -> PathBuf {
-     // This should really be OsStr::from_encoded_bytes_unchecked() but it’s
+     OsStr::from_bytes(bytes).into()
+ }
 diff --git a/src/server.rs b/src/server.rs
 index b5d98c5..f9dc9ec 100644
 --- a/src/server.rs
 +++ b/src/server.rs
-@@ -10,6 +10,10 @@ use listenfd::ListenFd;
+@@ -11,6 +11,10 @@ use listenfd::ListenFd;
  use std::net::{IpAddr, SocketAddr, TcpListener};
  use std::sync::Arc;
 -use tokio::sync::{Mutex, watch::Receiver};
@@ -36,17 +35,14 @@ index b5d98c5..f9dc9ec 100644
  
  use crate::handler::{RequestHandler, RequestHandlerOpts};
  
-@@ -667,6 +671,13 @@ impl Server {
-         #[cfg(unix)]
+@@ -670,2 +674,7 @@ impl Server {
+-        #[cfg(unix)]
++        // On Unix this binding contains Hyper's graceful-shutdown wrapper. WASI has
++        // no supported termination-signal source, so it remains the raw Hyper server
++        // future and runs until the host terminates it. Both targets still need the
++        // same await here; without the WASI cfg the listener future would be unused
++        // and the function would immediately return.
++        #[cfg(any(unix, target_os = "wasi"))]
          http1_server.await?;
- 
-+        // WASI has no supported termination-signal source, so it cannot use either
-+        // graceful-shutdown wrapper above. Await Hyper directly so the server keeps
-+        // accepting requests until the host terminates it; otherwise the future is
-+        // unused and the function would drop the listener and return immediately.
-+        #[cfg(target_os = "wasi")]
-+        http1_server.await?;
-+
-         #[cfg(windows)]
          let http1_server_task = tokio::spawn(async move {
              if let Err(err) = http1_server.await {

--- a/pkgs/overlay/packages/static-web-server/wasix.patch
+++ b/pkgs/overlay/packages/static-web-server/wasix.patch
@@ -2,10 +2,13 @@ diff --git a/src/fs/path.rs b/src/fs/path.rs
 index 4dc405d..8afc0e1 100644
 --- a/src/fs/path.rs
 +++ b/src/fs/path.rs
-@@ -66,6 +66,14 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+@@ -66,6 +66,17 @@ fn path_from_bytes(bytes: &[u8]) -> PathBuf {
      OsStr::from_bytes(bytes).into()
  }
  
++// Rust's WASI targets do not set cfg(unix), even though WASI paths are byte-oriented.
++// Use WASI's OsStrExt so percent-decoded, non-UTF-8 URL paths remain lossless rather
++// than applying the Windows branch's lossy Unicode conversion.
 +#[cfg(target_os = "wasi")]
 +fn path_from_bytes(bytes: &[u8]) -> PathBuf {
 +    use std::ffi::OsStr;
@@ -21,20 +24,26 @@ diff --git a/src/server.rs b/src/server.rs
 index b5d98c5..f9dc9ec 100644
 --- a/src/server.rs
 +++ b/src/server.rs
-@@ -10,6 +10,8 @@ use listenfd::ListenFd;
+@@ -10,6 +10,10 @@ use listenfd::ListenFd;
  use std::net::{IpAddr, SocketAddr, TcpListener};
  use std::sync::Arc;
 -use tokio::sync::{Mutex, watch::Receiver};
 +use tokio::sync::watch::Receiver;
++// Mutex is only used by the Unix and Windows graceful-shutdown signal paths.
++// WASI has no process-signal integration here, and deny(warnings) rejects the unused import.
 +#[cfg(any(unix, windows))]
 +use tokio::sync::Mutex;
  
  use crate::handler::{RequestHandler, RequestHandlerOpts};
  
-@@ -667,6 +669,9 @@ impl Server {
+@@ -667,6 +671,13 @@ impl Server {
          #[cfg(unix)]
          http1_server.await?;
  
++        // WASI has no supported termination-signal source, so it cannot use either
++        // graceful-shutdown wrapper above. Await Hyper directly so the server keeps
++        // accepting requests until the host terminates it; otherwise the future is
++        // unused and the function would drop the listener and return immediately.
 +        #[cfg(target_os = "wasi")]
 +        http1_server.await?;
 +


### PR DESCRIPTION
## Summary

- package upstream static-web-server 2.43.0 as a shipped WASIX command without TLS
- add WASI path and signal-free server handling
- add the socket2 0.5.10 WASIX backend required by Hyper 0.14
- add an end-to-end Wasmer HTTP serving test

## Testing

- `nix build .#wasmerPackages.static-web-server`
- `nix build .#wasmerPackages.static-web-server.webc`
- `nix build .#wasmerPackages.static-web-server.tests.serve`
- `nix build .#checks.x86_64-linux.static-web-server`
- `nix fmt`

Linear: [ECO-428](https://linear.app/wasmer/issue/ECO-428/wasinix-port-static-web-server)