### PR TITLE
pkgs: build anybuild for wasix

### DIFF
--- a/pkgs/overlay/packages/anybuild/package.nix
+++ b/pkgs/overlay/packages/anybuild/package.nix
@@ -7,7 +7,13 @@
 }:
 helpers.libTweaks {
   passthru.wasix.shipped = true;
-  passthru.wasmer.dependencies = [preferredProfilePackages.bash];
+  passthru.wasmer = {
+    dependencies = [preferredProfilePackages.bash];
+    commandEnv = {
+      anybuild.PATH = "/bin:/usr/bin";
+      shipit.PATH = "/bin:/usr/bin";
+    };
+  };
 } (toolchain.anybuild.override {
   inherit (final) rustPlatform stdenv;
   shellPath = "/bin/bash";

--- a/pkgs/overlay/packages/anybuild/package.nix
+++ b/pkgs/overlay/packages/anybuild/package.nix
@@ -1,0 +1,14 @@
+{
+  final,
+  helpers,
+  preferredProfilePackages,
+  toolchain,
+  ...
+}:
+helpers.libTweaks {
+  passthru.wasix.shipped = true;
+  passthru.wasmer.dependencies = [preferredProfilePackages.bash];
+} (toolchain.anybuild.override {
+  inherit (final) rustPlatform stdenv;
+  shellPath = "/bin/bash";
+})

--- a/pkgs/overlay/packages/anybuild/tests/basic.nix
+++ b/pkgs/overlay/packages/anybuild/tests/basic.nix
@@ -1,0 +1,11 @@
+{
+  testLib,
+  wasmerPkgs,
+  ...
+}: {
+  version = testLib.mkWasixRun {
+    name = "anybuild-version";
+    wasixPkgs = [wasmerPkgs.anybuild];
+    script = "anybuild --version";
+  };
+}

--- a/pkgs/overlay/packages/anybuild/tests/basic.nix
+++ b/pkgs/overlay/packages/anybuild/tests/basic.nix
@@ -8,4 +8,28 @@
     wasixPkgs = [wasmerPkgs.anybuild];
     script = "anybuild --version";
   };
+
+  local-build = testLib.mkWasixRun {
+    name = "anybuild-local-build";
+    wasixPkgs = [wasmerPkgs.anybuild];
+    script = ''
+      mkdir project
+      printf 'hello\n' > project/index.html
+      cat > project/Anybuild <<'EOF'
+      load("//anybuild/tools:staticfile.bzl", "staticfile_build", "staticfile_config", "staticfile_serve")
+
+      config = staticfile_config(schema = 1, sws_version = "2.38.0")
+      build = staticfile_build(config)
+      staticfile_serve(
+          config,
+          build,
+          name = "smoke",
+          build_post = [run("bash -c 'printf built > bash-ran'")],
+      )
+      EOF
+
+      anybuild build project --skip-prepare
+      test "$(cat project/.anybuild/local/build/opt/static_app/bash-ran)" = built
+    '';
+  };
 }

--- a/pkgs/toolchain/anybuild.nix
+++ b/pkgs/toolchain/anybuild.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
+  shellPath ? "${bash}/bin/bash",
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "anybuild";
@@ -21,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace crates/anybuild/src/run/local.rs \
-      --replace-fail '#!/bin/bash' '#!${bash}/bin/bash'
+      --replace-fail '#!/bin/bash' '#!${shellPath}'
   '';
 
   # The e2e harness otherwise assumes a separate target/debug build exists.


### PR DESCRIPTION
## Summary

- cross-compile the existing `anybuild` package with the WASIX Rust platform while preserving its native derivation
- package both `anybuild` and `shipit` as webc commands with the Bash runtime dependency and guest `PATH`
- add version and functional local-build tests that exercise Bash discovery and execution inside WASIX

## Testing

- `nix fmt`
- focused eval and CI-key checks
- native derivation path comparison against `main`
- `git diff --check`
- `nix build .#checks.x86_64-linux.anybuild --print-build-logs`
- independent functional `shipit` smoke test through the corrected webc

Linear: [ECO-429](https://linear.app/wasmer/issue/ECO-429/wasinix-build-anybuild-to-wasix)