### PR TITLE
pkgs: fix anybuild webc metadata

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -13,7 +13,7 @@ Lightest form that works (the loader finds all of these):
 A package file is a function over one argument set:
 
 ```nix
-{ final, prev, helpers, toolchain, preferredProfilePackages, nixpkgs, ... }: ...
+{ final, prev, helpers, toolchain, preferredProfilePackages, wasmerDependencies, nixpkgs, ... }: ...
 ```
 
 `prev.<name>` is the nixpkgs package, already compiling with the WASIX stdenv
@@ -73,6 +73,23 @@ not in nixpkgs, call `final.rustPlatform.buildRustPackage` (see
    store paths found in the wasm), `selfMounts` (paths referenced from
    scripts, which autoSelfMount can't see). See git's package.nix for a full
    example.
+
+   Runtime webc dependencies accept a derivation or an attrset containing
+   `package` and `version`. The helpers derive requirements from the package's
+   published webc version:
+
+   ```nix
+   passthru.wasmer.dependencies = [
+     preferredProfilePackages.foo
+     (wasmerDependencies.any preferredProfilePackages.bar)
+     (wasmerDependencies.exact preferredProfilePackages.baz)
+     (wasmerDependencies.compatibleMajor preferredProfilePackages.qux)
+     (wasmerDependencies.compatibleMinor preferredProfilePackages.quux)
+   ];
+   ```
+
+   A bare derivation retains the default semver-compatible requirement. Use an
+   explicit `{ package = drv; version = "..."; }` for another semver range.
 
 3. Ship an older release too (a version consumers pin): see
    [Registry history](#registry-history).

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,6 +23,7 @@
   inherit (pkgs) lib;
   nixUpdate = pkgs.nix-update;
   wasixLib = import ./lib {inherit lib;};
+  wasmerDependencies = import ./wasmer/dependencies.nix {inherit lib;};
   toolchain = import ./toolchain {inherit pkgs ghcWasm;};
 
   # Defined here, not derived from a profile, so pkgsCross can be built before the
@@ -78,7 +79,7 @@
   preferredProfilePackages = lib.genAttrs wasixPkgNames (name: nixpkgsByProfile.${preferredProfileOf name}.${name});
 
   wasixOverlay = import ./overlay {
-    inherit toolchain nixpkgs preferredProfilePackages wasixRustPlatform;
+    inherit toolchain nixpkgs preferredProfilePackages wasixRustPlatform wasmerDependencies;
     inherit (pkgs) nix-update-script;
   };
   mkWasixPkgs = import ./set/mk-pkgs.nix {inherit system nixpkgs mkWasixStdenv wasixOverlay;};
@@ -275,6 +276,7 @@
   makeWasmerPackage = pkgs.callPackage ./wasmer/make-wasmer-package.nix {
     self = makeWasmerPackage;
     wasmer = wasmerRuntime;
+    inherit wasmerDependencies;
     inherit (wasixLib) posOf;
   };
 

--- a/pkgs/overlay/default.nix
+++ b/pkgs/overlay/default.nix
@@ -3,8 +3,8 @@
 # linked deps, so each package file is just `prev.X` plus tweaks.
 #
 # Each packages/<name>.nix is a function
-# { final, prev, helpers, toolchain, preferredProfilePackages, nixpkgs,
-#   nix-update-script }
+# { final, prev, helpers, toolchain, preferredProfilePackages,
+#   wasmerDependencies, nixpkgs, nix-update-script }
 # returning the wasix derivation. Use `final.<lib>` for linked (same-profile)
 # deps and `preferredProfilePackages.<tool>` for non-linked or runtime-invoked deps.
 # `toolchain` arrives with its per-profile members resolved to this set's profile.
@@ -12,6 +12,7 @@
   toolchain,
   nixpkgs,
   preferredProfilePackages,
+  wasmerDependencies,
   wasixRustPlatform,
   # the native instance: cross buildPackages would carry a different store
   # path that the update driver's environment never realizes
@@ -139,7 +140,7 @@
     in
       lib.mapAttrs (_: applyWasixMeta) (loaded.mkPackages {
         callArgs = {
-          inherit final prev helpers preferredProfilePackages nixpkgs nix-update-script;
+          inherit final prev helpers preferredProfilePackages wasmerDependencies nixpkgs nix-update-script;
           toolchain = profileToolchain;
         };
         mkTrivial = n: helpers.libTweaks {} prev.${n};

--- a/pkgs/overlay/packages/anybuild/package.nix
+++ b/pkgs/overlay/packages/anybuild/package.nix
@@ -9,6 +9,7 @@ helpers.libTweaks {
   passthru.wasix.shipped = true;
   passthru.wasmer = {
     dependencies = [preferredProfilePackages.bash];
+    dependencyVersions."wasmer/bash" = "*";
     commandEnv = {
       anybuild.PATH = "/bin:/usr/bin";
       shipit.PATH = "/bin:/usr/bin";

--- a/pkgs/overlay/packages/anybuild/package.nix
+++ b/pkgs/overlay/packages/anybuild/package.nix
@@ -8,6 +8,7 @@
 helpers.libTweaks {
   passthru.wasix.shipped = true;
   passthru.wasmer = {
+    entrypoint = "anybuild";
     dependencies = [preferredProfilePackages.bash];
     dependencyVersions."wasmer/bash" = "*";
     commandEnv = {

--- a/pkgs/overlay/packages/anybuild/package.nix
+++ b/pkgs/overlay/packages/anybuild/package.nix
@@ -2,6 +2,7 @@
   final,
   helpers,
   preferredProfilePackages,
+  wasmerDependencies,
   toolchain,
   ...
 }:
@@ -9,8 +10,7 @@ helpers.libTweaks {
   passthru.wasix.shipped = true;
   passthru.wasmer = {
     entrypoint = "anybuild";
-    dependencies = [preferredProfilePackages.bash];
-    dependencyVersions."wasmer/bash" = "*";
+    dependencies = [(wasmerDependencies.any preferredProfilePackages.bash)];
     commandEnv = {
       anybuild.PATH = "/bin:/usr/bin";
       shipit.PATH = "/bin:/usr/bin";

--- a/pkgs/wasmer/dependencies.nix
+++ b/pkgs/wasmer/dependencies.nix
@@ -1,0 +1,27 @@
+# Constructors for passthru.wasmer.dependencies entries. Requirements are
+# derived from the published webc version, which may differ from package.version.
+{lib}: let
+  inherit (import ./ident.nix {inherit lib;}) webcIdent;
+  withVersion = requirement: package: {
+    inherit package;
+    version = requirement (webcIdent package).version;
+  };
+in {
+  any = withVersion (_: "*");
+  exact = withVersion (version: "=${version}");
+  compatibleMajor = withVersion (version: "^${version}");
+  compatibleMinor = withVersion (version: "~${version}");
+
+  # A bare derivation retains the original dependency behaviour: its published
+  # version is a semver-compatible requirement.
+  normalize = dependency:
+    if lib.isDerivation dependency
+    then withVersion (version: version) dependency
+    else if
+      dependency ? package
+      && lib.isDerivation dependency.package
+      && dependency ? version
+      && builtins.isString dependency.version
+    then dependency
+    else throw "passthru.wasmer.dependencies entries must be derivations or { package = <derivation>; version = <requirement>; }";
+}

--- a/pkgs/wasmer/make-wasmer-package.nix
+++ b/pkgs/wasmer/make-wasmer-package.nix
@@ -9,6 +9,7 @@
 #   owner       ? "wasmer"
 #   commands    ? null  => one command per bin/*.wasm (auto-globbed at build)
 #   commandEnv  ? {}     => { <command> = { ENV = "val"; }; } merged onto a command
+#   dependencyVersions ? {} => { "owner/name" = "requirement"; }
 #   fs          ? {}     => mounts, e.g. { "/etc/ssl" = "${cacert}/etc/ssl"; }
 #   selfMounts  ? []     => explicit store-path-at-itself mounts
 #   autoSelfMount ? false => also scan bin/*.wasm for embedded /nix/store paths
@@ -107,11 +108,13 @@
   # at /bin/<cmd> and /usr/bin/<cmd> in this package's fs, so e.g. /bin/bash
   # resolves from the dependency instead of a bundled copy.
   dependencies = w.dependencies or [];
+  dependencyVersions = w.dependencyVersions or {};
   dependencyLines =
     lib.concatMapStringsSep "\n" (
       dep: let
         r = webcIdent dep;
-      in "${builtins.toJSON r.fullName} = ${builtins.toJSON r.version}"
+        version = dependencyVersions.${r.fullName} or r.version;
+      in "${builtins.toJSON r.fullName} = ${builtins.toJSON version}"
     )
     dependencies;
 

--- a/pkgs/wasmer/make-wasmer-package.nix
+++ b/pkgs/wasmer/make-wasmer-package.nix
@@ -9,7 +9,7 @@
 #   owner       ? "wasmer"
 #   commands    ? null  => one command per bin/*.wasm (auto-globbed at build)
 #   commandEnv  ? {}     => { <command> = { ENV = "val"; }; } merged onto a command
-#   dependencyVersions ? {} => { "owner/name" = "requirement"; }
+#   dependencies ? [] => derivations, or { package = drv; version = requirement; }
 #   fs          ? {}     => mounts, e.g. { "/etc/ssl" = "${cacert}/etc/ssl"; }
 #   selfMounts  ? []     => explicit store-path-at-itself mounts
 #   autoSelfMount ? false => also scan bin/*.wasm for embedded /nix/store paths
@@ -21,6 +21,7 @@
   wasmer,
   # this function itself, to build dependency webcs.
   self,
+  wasmerDependencies,
   posOf,
 }: {
   package,
@@ -108,19 +109,18 @@
   # at /bin/<cmd> and /usr/bin/<cmd> in this package's fs, so e.g. /bin/bash
   # resolves from the dependency instead of a bundled copy.
   dependencies = w.dependencies or [];
-  dependencyVersions = w.dependencyVersions or {};
+  dependencySpecs = map wasmerDependencies.normalize dependencies;
   dependencyLines =
     lib.concatMapStringsSep "\n" (
       dep: let
-        r = webcIdent dep;
-        version = dependencyVersions.${r.fullName} or r.version;
-      in "${builtins.toJSON r.fullName} = ${builtins.toJSON version}"
+        r = webcIdent dep.package;
+      in "${builtins.toJSON r.fullName} = ${builtins.toJSON dep.version}"
     )
-    dependencies;
+    dependencySpecs;
 
   # Dependency webcs and their transitive closure, symlinkJoined (via each
   # .webc) into one --include-webc tree for the shim.
-  depWebcs = map (dep: self {package = dep;}) dependencies;
+  depWebcs = map (dep: self {package = dep.package;}) dependencySpecs;
   closure = webcs: lib.unique (webcs ++ lib.concatMap (w: closure w.depWebcs) webcs);
   depTree =
     if depWebcs == []


### PR DESCRIPTION
## Summary

Anybuild needs `wasmer/bash` to execute build steps, but its generated webc metadata had two problems: it pinned Bash to unpublished version `5.3.15`, blocking publication, and it did not declare a default entrypoint, causing the resolved Bash dependency to launch instead of the Anybuild CLI.

This PR:

- adds the opt-in `passthru.wasmer.dependencyVersions` map; unspecified dependencies retain their exact derived version
- sets Anybuild's `wasmer/bash` requirement to `*`
- explicitly sets the package entrypoint to `anybuild`

## Verification

- Anybuild build and runtime tests pass
- running the packed webc without `--entrypoint` prints Anybuild `0.26.4`
- generated manifest contains `"wasmer/bash" = "*"`
- production-registry dry run succeeds without publishing

Follow-up to #114 and [ECO-429](https://linear.app/wasmer/issue/ECO-429/wasinix-build-anybuild-to-wasix).