### PR TITLE
docs: split AGENTS.md into agent rules and shared docs

### DIFF
--- a/.github/actions/wasmer-registry/action.yml
+++ b/.github/actions/wasmer-registry/action.yml
@@ -2,10 +2,10 @@ name: Select wasmer registry
 description: >
   Export WASMER_REGISTRY and the matching WASMER_TOKEN into the job env.
   Registries are per-environment: wasmer.io (prod), wasmer.fun (bugtopia,
-  staging), wasmer.wtf (dev). Tokens are per-registry (wasmer rejects a
-  token minted on another registry, WASIX-TODO.md); deriving the token from
-  the registry here keeps the pair from drifting at any use site. Via
-  GITHUB_ENV so later step conditions can test `env.WASMER_TOKEN != ''`.
+  staging), wasmer.wtf (dev). Tokens are per-registry (wasmer rejects a token
+  minted on another registry, WASIX-TODO.md); deriving the token from the
+  registry here keeps the pair from drifting at any use site. Via GITHUB_ENV so
+  later step conditions can test `env.WASMER_TOKEN != ''`.
 inputs:
   registry:
     description: Wasmer registry host or URL (wasmer.io, wasmer.fun, wasmer.wtf)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Context
+
+<!--
+Optional, but helpful:
+- New package: link the upstream project.
+- Update: link the release notes or changelog.
+- Explain any non-obvious design choice or compatibility concern.
+-->
+
+## Impact
+
+<!--
+If this affects existing packages, explain which dependents can change and why.
+State the evidence and uncertainty. Omit this section when there are no existing
+consumers.
+-->
+
+## Behavior checked
+
+<!--
+What behavior did you observe? Packages with a small Unix-facing surface often
+work with little adaptation, so a brief smoke check can be enough. Extensive
+proof is not expected for every change; simply report what you checked, or say
+that it was not checked manually.
+
+Prefer adding reusable behavioral coverage as a Nix test when practical.
+Toolchain and shared-infrastructure changes need broader verification than an
+isolated package change.
+
+For agents: CI builds and runs the declared tests. Do not list `nix fmt`,
+`git diff --check`, the builder used, or merely that tests ran as evidence that
+behavior works. Describe the behavior and result. Explain non-obvious test
+implementation when it matters to the coverage provided.
+-->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,9 @@ jobs:
       - name: Rebuild diff
         continue-on-error: true
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          BASE_REF:
+            ${{ github.event.pull_request.base.ref ||
+            github.event.merge_group.base_ref }}
         run: nix run .#scripts.rebuild-diff
 
       # after the eval (which realizes every input) but before the build, so a
@@ -99,7 +101,8 @@ jobs:
       # the final Post report. Fork PRs (read-only token) only get the final
       # report, via test-report.yml.
       - name: Post eval report
-        if: ${{ github.event_name != 'pull_request' ||
+        if:
+          ${{ github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -178,7 +181,8 @@ jobs:
       # pin bump) never fire workflow_run, and in-job is faster anyway.
       # Fork PRs have a read-only token here; test-report.yml covers them.
       - name: Post report
-        if: ${{ always() && steps.build.conclusion != 'skipped' &&
+        if:
+          ${{ always() && steps.build.conclusion != 'skipped' &&
           (github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/bump-rel.yml
+++ b/.github/workflows/bump-rel.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: Packages to bump (rels.json attr paths, unambiguous names, or fnmatch globs; prefix --all-versions to include every served history version)
+        description:
+          Packages to bump (rels.json attr paths, unambiguous names, or fnmatch
+          globs; prefix --all-versions to include every served history version)
         required: true
         type: string
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,7 +18,9 @@ on:
     types: [labeled]
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number || github.event.workflow_run.head_branch }}
+  group:
+    preview-${{ github.event.pull_request.number ||
+    github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 permissions:
@@ -52,7 +54,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          WR_HEAD_REPO:
+            ${{ github.event.workflow_run.head_repository.full_name }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |

--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Build index
         id: build-index
-        run: nix build .#pythonRegistry -o registry-result --option accept-flake-config true
+        run:
+          nix build .#pythonRegistry -o registry-result --option
+          accept-flake-config true
 
       - name: Publish wheels to the index volume
         if: env.WASMER_TOKEN != ''

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,8 @@ on:
         required: false
         default: ""
       batch:
-        description: "One combined PR (auto/update-pins) instead of one per target"
+        description:
+          "One combined PR (auto/update-pins) instead of one per target"
         required: false
         type: boolean
         default: false
@@ -122,8 +123,13 @@ jobs:
           # the end of the job, after the partial PR is opened.
           # Summary outside the checkout so create-pull-request doesn't commit it.
           summary="$RUNNER_TEMP/update-summary.md"
+          # --commit lands one commit per bumped target, so the PR reads as a
+          # list of bumps rather than one squash. It runs nix fmt before each,
+          # so there is no separate format step.
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           set +e
-          nix run .#scripts.update -- "${args[@]}" --summary-out "$summary"
+          nix run .#scripts.update -- "${args[@]}" --summary-out "$summary" --commit
           code=$?
           set -e
           {
@@ -132,10 +138,6 @@ jobs:
             cat "$summary" 2>/dev/null || echo "(the updater crashed before writing a summary)"
             echo EOF
           } >>"$GITHUB_OUTPUT"
-
-      - name: Format
-        shell: bash
-        run: nix fmt
 
       # UPDATE_PR_TOKEN: events from the default GITHUB_TOKEN don't cascade,
       # so a PR created with it never triggers CI (someone has to press
@@ -147,8 +149,15 @@ jobs:
         with:
           token: ${{ secrets.UPDATE_PR_TOKEN || github.token }}
           branch: auto/update-${{ matrix.job.name }}
-          title: "${{ matrix.job.name == 'pins' && 'pins: automated source-pin bump' || format('pins: bump {0}', matrix.job.name) }}"
-          commit-message: "${{ matrix.job.name == 'pins' && 'pins: bump repo source pins (automated)' || format('pins: bump {0} (automated)', matrix.job.name) }}"
+          title:
+            "${{ matrix.job.name == 'pins' && 'pins: automated source-pin bump'
+            || format('pins: bump {0}', matrix.job.name) }}"
+          # Fallback only: the updater has already committed each bump. This
+          # labels anything it somehow left in the tree.
+          commit-message:
+            "${{ matrix.job.name == 'pins' && 'pins: bump repo source pins
+            (automated)' || format('pins: bump {0} (automated)',
+            matrix.job.name) }}"
           body: |
             Automated source-pin bump.
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "always"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,122 +1,102 @@
-# Conventions
+# Working in this repo as an agent
 
-Rules for changes in this repo. Background: `docs/architecture.md`. How-tos:
-`docs/packaging.md`, `docs/updating.md`, `docs/spot.md`.
+`AGENTS.md` contains only guidance specific to agents and not owned by one
+topic. Put guidance that applies to humans and agents in the relevant general
+doc:
 
-This flake cross-compiles software to WASIX (`wasm32-wasix`, a POSIX-flavored
-WASI extension run by Wasmer). The toolchain (LLVM fork, wasix-libc sysroot,
-wasixcc, rustc fork + cargo-wasix) is built from source, then used to build
-C/C++, Rust, and Python packages, and CLIs are packaged as webc.
+| Read                   | For                                                 |
+| ---------------------- | --------------------------------------------------- |
+| `CONTRIBUTING.md`      | contribution and PR expectations                    |
+| `docs/architecture.md` | how the layers fit together and flake outputs       |
+| `docs/c.md`            | C/C++ toolchain, profiles, and cross stdenv         |
+| `docs/packaging.md`    | adding a package, tweaks, deps, patches, tests      |
+| `docs/registry.md`     | publishing, version history, rels, PR previews      |
+| `docs/rust.md`         | rust builds, crate patches, the cargo registry      |
+| `docs/python.md`       | CPython, package overlays, and wheels               |
+| `docs/building.md`     | where builds run, building one thing, checking work |
+| `docs/style.md`        | comments, naming, commits, fail loud, root cause    |
+| `docs/updating.md`     | the pin updater and `updateNotes`                   |
+| `docs/spot.md`         | experimenting without rebuilding the world          |
 
-```text
-pkgs/default.nix     wiring            pkgs/profiles.nix  the ABI profile table
-pkgs/lib/            helpers + passthru.wasix machinery
-pkgs/products/       recipes instantiated natively and for WASIX
-pkgs/set/            per-profile cross sets (stdenv, rustPlatform)
-pkgs/toolchain/      llvm.nix, sysroot/, rust/, wasixcc.nix, env.nix, tests/
-pkgs/overlay/        packages/, trivial.nix, python-packages/
-pkgs/wasmer/         webc packaging + test harness
-scripts/update.py    pin updater (nix run .#scripts.update)
-```
+Do not restate those rules here. Add a `## For agents` section to the owning doc
+only when the agent workflow genuinely differs from the human workflow.
 
-## Rules
+## Before you write code
 
-- Profiles (`off`, `eh`, `ehpic`, `exnrefEh` = default, `exnrefEhpic`) are
-  defined once in `pkgs/profiles.nix`; derive from the table, never restate
-  the matrix.
-- Where a package works and which variants CI covers is declared as `passthru.wasix`
-  (`supportedProfiles`, `preferredProfile`, `ciProfiles`, `broken = "reason"`; see
-  `pkgs/lib/default.nix`). Never set `meta.badPlatforms`/`meta.broken`
-  directly.
-- Package placement: name in `trivial.nix` / flat `packages/<name>.nix` /
-  `packages/<name>/package.nix` dir; a dir's `package.nix` may be
-  `{names, packages}` for version families (icu). Same in
-  `python-packages/`. Only `pkgs/lib/load-packages.nix` enumerates these
-  dirs. A package we provide both natively and for WASIX has its standard
-  recipe in `pkgs/products/<name>/package.nix`; its WASIX-only
-  tweaks and webc policy stay in the matching overlay entry.
-- Tweaks go through `helpers.libTweaks` (phases concatenate, lists append,
-  attrsets merge, scalars replace, functions get the old value). No
-  `(old.X or []) ++ ...` in package files.
-- Deps: `final.<dep>` for linking (same profile); `preferredProfilePackages.<name>`
-  for tools run at runtime. Never `nixpkgsByProfile.<profile>.<dep>` from a
-  package file.
-- All `WASIXCC_*`/`CC=wasixcc` environment comes from
-  `pkgs/toolchain/env.nix`; never write the exports by hand.
-- Patches live next to the file that applies them.
-- Pins: `nix run .#scripts.update` (`docs/updating.md`).
-- "Recheck/drop this on the next version bump" (a vendored patch, a
-  regenerated lock): `passthru.wasix.updateNotes`, which surfaces in the bump
-  PR via `scripts/update.py` and the CI report. Not a code comment or
-  `WASIX-TODO.md`.
-- We control wasmer and the wasix-org forks: root-cause their bugs and
-  quirks and suggest an upstream fix rather than only working around them.
-  Vendor pending fixes as `.patch` files (placed per the patches rule
-  above); when a workaround is needed to ship, track it in `WASIX-TODO.md`
-  with the upstream fix identified.
-- When starting a nix build, print the build logs and redirect them to a file.
-  This helps track down build issues faster without needing to wait for the full
-  build to complete, as well as to gauge the progress of long-running builds.
+Every new file, test, package, patch, or script has a sibling here that already
+does the same kind of thing. Find it and match its location, naming, and
+structure. If you cannot find one, say so before inventing a layout.
 
-## Remote builds
+Before implementing a new mechanism, state the design in one or two sentences
+and get agreement. Prioritise a single source of truth and the smallest diff
+that slots into existing machinery. Work already done is not an argument for
+keeping a shape: if the design is wrong, say so rather than defending it.
 
-The toolchain and the full `.ci` sweep are expensive; building them locally is
-painful, and a stray system-default builder (e.g. a paid `nixbuild.net`) can
-cost real money. Route expensive builds to a remote builder you control.
+## The three that get violated most
 
-That builder is machine-specific, so it lives in a gitignored `.remote-builder`
-(copy `.remote-builder.example` and fill in host, key, system, features).
-`scripts/remote-builder.sh` turns it into ready-made flags; never hardcode a
-host or key.
-Note that, as it is gitignored, new worktrees may be missing the file.
-Check in other worktrees and copy the file over in that case. Tell the user
-when you do this.
+These are in the docs, and are repeated here only because they are the ones most
+often missed:
 
-- `scripts/remote-builder.sh check`: configured and reachable?
-- Bulk: `nix-fast-build --skip-cached --flake
-.#legacyPackages.x86_64-linux.ci --store "$(scripts/remote-builder.sh
-store)"` (local eval, remote build), or `scripts/ci-build-remote.sh` for the
-  signed, cache-pushing CI set.
-- Single build: `nix build <targets> --max-jobs 0 --builders
-"$(scripts/remote-builder.sh builders)" --builders-use-substitutes`.
-  `--max-jobs 0` is required, else nix still schedules jobs onto local slots or
-  the system default.
+- **Comments.** The seven checks in `docs/style.md` are pass/fail, not matters
+  of taste. Verbose, changelog-style, context-assuming comments are the single
+  most repeated complaint about AI-authored code in this repo. Re-read them
+  against your final diff, not against your intent while writing.
+- **Never build locally.** `docs/building.md`. Heavy builds go to the remote
+  builder. `--builders ""` means "build on the user's desktop" and will thrash
+  it into swap. A wide nix-eval-jobs fan-out does the same through RAM, so cap
+  its workers. Read a failing log rather than rebuilding to see the error.
+- **Fix the root cause.** `docs/style.md`. Excluding, skipping, or marking
+  broken to go green is the user's call, never yours, and they can only make it
+  once you have said what it costs.
 
-Evals (`nix eval`, nix-eval-jobs) run fine locally. Diagnose a remote failure
-with `ssh "$(scripts/remote-builder.sh host)"` + `nix log`, not a rebuild.
+## Working with the user
 
-## Checking your work
+- A question is a request for an answer. Do not edit code in response to "why is
+  this like that".
+- Once a task is authorized, run it to completion. Stop only for a real blocker:
+  a failed prerequisite, a genuine ambiguity, or a decision that is the user's
+  to make. Do not stop with a next step already in hand.
+- Read a file immediately before overwriting it. The user hand-edits files
+  between your turns, and a stale copy in context will clobber their work.
+- Never revert, discard, or undo a change unless asked.
+- Addressing review feedback means reading the whole source, not a grep or a
+  summary, and resolving each comment individually.
+- Do not state a tool or build-system behaviour as fact without checking it. If
+  it is unverified, say so.
+- Do not attribute intent to existing code ("deliberately", "intentionally")
+  without a comment or commit backing it. If the reason is unknown, say that.
+- Use the user's exact term for a concept. `xfail` is not `broken`; `cc-wrapper`
+  (nixpkgs) is not `wasixcc` (wasix-org).
+- Sub-agents and worktrees must be synced to current HEAD before dispatch.
 
-- `git add` new files before `nix build`/`nix eval`; the flake only sees
-  tracked files.
-- `nix fmt` before committing; CI rejects unformatted files.
-- Job list: `nix eval .#legacyPackages.x86_64-linux.ci --apply
-builtins.attrNames`. For behaviour-preserving refactors, also diff
-  `--apply 'j: builtins.mapAttrs (_: d: d.drvPath) j'` before/after; meta and
-  passthru changes don't move drv paths.
-- A CI job name is a build path: `nix build .#packagesByProfile.exnrefEh.zlib`,
-  `.#wasmerPackages.git.webc`, `.#pythonWheels.py314.numpy`.
-- Toolchain suites: `.#toolchain.wasixcc.tests` (compile+link+run per
-  profile), `.#toolchain.sysroot.tests`; the Rust suite is
-  `.#checks.x86_64-linux.rust`.
-- Touching `pkgs/toolchain/` (except `llvm.nix`) rebuilds everything; use a
-  remote builder or the CI cache. To try such a change on one package first,
-  `scripts/spot.sh <profile>.<attr>` rebuilds that attr alone against a cached
-  base revision (`docs/spot.md`). Experiments only: it mixes two toolchains, so
-  confirm at the root before keeping the change.
-- The most thorough check is `nix-fast-build --flake
-.#legacyPackages.x86_64-linux.ci --no-link --skip-cached --option
-accept-flake-config true`, the same build set as CI
-  (`scripts/ci-build.sh`). `--skip-cached` only helps while the change
-  avoids mass rebuilds, and those are easy to trigger (anything under
-  `pkgs/toolchain/`, a pin bump); expect a huge build that can OOM the
-  machine. Do not run it without asking the user first.
+## Never act in the user's name
 
-## Style
+No `git push`. No opening or closing PRs or issues. No GitHub comments of any
+kind, including replies to review threads. No commits unless asked.
 
-- Commits: `<scope>: <summary>`, lowercase; scopes: `pkgs`, `toolchain`,
-  `docs`, `pins`, `tooling`.
-- Comments state constraints and reasons, tersely; no narration, no
-  em-dashes. Move comments along with code.
-- Weird runtime behaviour (exit codes, PATH, `(null):` prefixes, color when
-  piped)? Check `WASIX-TODO.md` first; it's likely known, with a workaround.
+Writing the code is not authorization to ship it. "Fix this" and "go ahead"
+authorize the edit, never the commit or the push, and approval for one push is
+not approval for the next. Do not offer a push or a PR as the next step. When
+public text is needed, draft it in chat or hand over the `gh` command.
+
+## Cleaning commit history
+
+Rewrite history only when the user asks. Review the whole PR range from its
+target-branch merge base, and check whether it is published. Never rewrite
+user-authored commits or work outside the requested range; published history
+needs explicit authorization.
+
+Make the range tell one dependency-ordered story. Each commit should introduce
+one reviewer-visible idea, fold in its later corrections, and leave an
+internally consistent tree that is useful to bisect. Preserve authorship and the
+final tree exactly, then verify both against the pre-rewrite range. Do not push
+it.
+
+## Before you report done
+
+- Comments re-read against the seven checks in `docs/style.md`, in the final
+  diff.
+- Every failing target fixed, or excluded with the user's agreement on record.
+- The claim you are about to make actually run, just now. No "should work".
+- Nothing built at scale on the user's machine.
+- Nothing pushed, posted, or committed unless asked for in this message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Contributions are welcome.
+
+Start with the [documentation](README.md#documentation). It covers the
+architecture, packaging, testing, and repository conventions. Agents must also
+read [AGENTS.md](AGENTS.md).
+
+When preparing a pull request, follow the
+[PR template](.github/pull_request_template.md) for the context, impact, and
+behavioral checks reviewers need.
+
+This project uses the [MIT License](LICENSE). Contributions are accepted under
+the same license.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WASIX Package Repository
 
 A Nix flake that builds software for WASIX (`wasm32-wasix`, a POSIX-flavored
-extension of WASI run by Wasmer): the toolchain (an LLVM fork, the wasix-libc
-sysroot, wasixcc, a Rust fork with cargo-wasix), cross-compiled C/C++, Rust and
-Python packages, and webc packages for the Wasmer registry.
+extension of WASI run by Wasmer): the LLVM, libc, wasixcc, Rust, and cargo-wasix
+toolchains; cross-compiled C/C++, Rust, and Python packages; and webc packages
+for the Wasmer registry.
 
 ## Quick start
 
@@ -12,9 +12,9 @@ nix develop                       # shell with wasixcc + cargo-wasix on PATH
 
 nix build .#wasixcc               # the C/C++ toolchain (also the default output)
 nix build .#wasix-sysroot         # the per-profile sysroots
-nix build .#wasix-llvm            # the LLVM fork (slow)
+nix build .#wasix-llvm            # WASIX LLVM (slow)
 
-# packages live under legacyPackages (the system is explicit):
+# example targets under legacyPackages (the system is explicit):
 nix build .#legacyPackages.x86_64-linux.wasmerPackages.git         # a CLI
 nix build .#legacyPackages.x86_64-linux.wasmerPackages.git.webc    # its webc
 nix build .#legacyPackages.x86_64-linux.nativePackages.anybuild   # native shared recipe
@@ -27,26 +27,31 @@ nix build .#legacyPackages.x86_64-linux.allWasmerPackages                   # al
 nix run .#scripts.update                  # bump the source pins
 ```
 
-CI builds every package as its own job (`.#legacyPackages.<system>.ci`,
-driven by `scripts/ci-build.sh`). A job's dotted name is its build path.
+CI builds every package as its own job (`.#legacyPackages.<system>.ci`, driven
+by `scripts/ci-build.sh`). A job's dotted name is its build path.
 
 ## Structure
 
 `pkgs/toolchain/` builds the toolchain from source; `pkgs/profiles.nix` +
-`pkgs/set/` turn it into five ABI profiles, each a full nixpkgs cross
-package set; `pkgs/products/` holds product recipes instantiated for both the
-native host and WASIX, while `pkgs/overlay/` holds WASIX adaptations and small
-overrides of nixpkgs packages, including a dynamic-linking CPython and wheels;
-`pkgs/wasmer/` packages CLIs as webc and tests them under Wasmer.
-Details: [`docs/architecture.md`](docs/architecture.md).
+`pkgs/set/` turn it into five ABI profiles, each a full nixpkgs cross package
+set; `pkgs/products/` holds product recipes instantiated for both the native
+host and WASIX, while `pkgs/overlay/` holds WASIX adaptations and small
+overrides of nixpkgs packages; `pkgs/wasmer/` packages CLIs as webc and tests
+them under Wasmer. Details: [`docs/architecture.md`](docs/architecture.md).
 
 ## Documentation
 
 | doc                                            | contents                                     |
 | ---------------------------------------------- | -------------------------------------------- |
-| [`AGENTS.md`](AGENTS.md)                       | conventions and rules for making changes     |
 | [`docs/architecture.md`](docs/architecture.md) | how the layers fit together                  |
+| [`docs/c.md`](docs/c.md)                       | C/C++ toolchain, profiles, and cross stdenv  |
 | [`docs/packaging.md`](docs/packaging.md)       | adding packages: C, CLI/webc, Rust, Python   |
+| [`docs/registry.md`](docs/registry.md)         | publishing, version history, rels, previews  |
+| [`docs/rust.md`](docs/rust.md)                 | rust builds, crate patches, cargo registry   |
+| [`docs/python.md`](docs/python.md)             | CPython, package overlays, and wheels        |
+| [`docs/building.md`](docs/building.md)         | where builds run, building and checking      |
+| [`docs/style.md`](docs/style.md)               | comments, naming, commits, code norms        |
 | [`docs/updating.md`](docs/updating.md)         | the pin updater                              |
 | [`docs/spot.md`](docs/spot.md)                 | experimenting without rebuilding the world   |
+| [`AGENTS.md`](AGENTS.md)                       | extra rules for agents working here          |
 | [`WASIX-TODO.md`](WASIX-TODO.md)               | known WASIX/toolchain issues and workarounds |

--- a/WASIX-TODO.md
+++ b/WASIX-TODO.md
@@ -1,11 +1,31 @@
 # WASIX quirks & issues
 
 Runtime, libc, and toolchain issues hit while packaging: a reference when a
-package breaks in a familiar way, and a worklist for upstream fixes.
-Re-verified 2026-07-02 against wasmer 7.2.0, wasix-libc v2026-06-25.1,
-binaryen 129; entries marked "not re-verified" are carried on trust.
+package breaks in a familiar way, and a worklist for upstream fixes. Re-verified
+2026-07-02 against wasmer 7.2.0, wasix-libc v2026-06-25.1, binaryen 129; entries
+marked "not re-verified" are carried on trust.
 
 Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
+
+## What belongs here
+
+A reproducible defect in the runtime, libc, or toolchain that a packager can hit
+again. Not a passing observation, not a package's own bug, and not a "recheck
+this next bump" note (that is `passthru.wasix.updateNotes`, `docs/updating.md`).
+
+An entry is `### <short symptom> <status>` plus these bullets, in order:
+
+- **Symptom**: what the packager actually sees. The error text, exit code, or
+  wrong output, so the entry is greppable from a build log.
+- **Consequence**: what it breaks, and how widely.
+- **Workaround**: what we do instead, naming the file that does it. Required for
+  🟡, omitted otherwise.
+- **Fix**: the upstream change that would remove the entry, specific enough to
+  act on. Required for 🔴 and 🟡.
+
+Say which version an entry was last checked against when you touch it. Entries
+predating this format are being triaged onto it, so verify one against the
+current toolchain before relying on it.
 
 ## Runtime / libc
 
@@ -17,127 +37,88 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
   preopen names via `fd_prestat_dir_name`).
 - Consequence: gnulib's `save_cwd` (open "." + fchdir to restore) can't work;
   its fallback made every gnulib CLI exit non-zero with ENOTDIR.
-- Workaround: `find/package.nix` patches `gl/lib/save-cwd.c` to force
-  getcwd + chdir.
+- Workaround: `find/package.nix` patches `gl/lib/save-cwd.c` to force getcwd +
+  chdir.
 - Fix: `__wasi_fchdir` in wasmer plus libc wiring. Fixes gnulib CLIs globally.
 
 ### `posix_spawn` fd passing 🟡
 
-- Non-stdio fds are not inherited by the child even with FD_CLOEXEC cleared,
-  and a dup2 file action onto the same fd (the POSIX idiom to clear CLOEXEC)
-  is a no-op. Both diverge from POSIX. A dup2 action with a distinct target
-  does inject the parent fd, and actions apply sequentially to the child
-  table (verified with pipe-passing tests on wasmer 7.2.0).
+- Non-stdio fds are not inherited by the child even with FD_CLOEXEC cleared, and
+  a dup2 file action onto the same fd (the POSIX idiom to clear CLOEXEC) is a
+  no-op. Both diverge from POSIX. A dup2 action with a distinct target does
+  inject the parent fd, and actions apply sequentially to the child table
+  (verified with pipe-passing tests on wasmer 7.2.0).
 - Consequence: anything passing pipes to a spawned child by fd number breaks
   (multiprocessing's resource tracker and spawn start method).
 - Workaround: cpython's `multiprocessing-posix-spawn-wasi.patch` bounces each
-  passed fd through a slot above all passed fds (`dup2 fd->tmp`,
-  `dup2 tmp->fd`, `close tmp`; tmp starts at `max(128, max fd + 1)` so the
-  slots never collide with the fds being placed).
-- Fix: implement POSIX inheritance semantics for `proc_spawn` in wasmer:
-  inherit non-CLOEXEC fds, honor same-fd dup2 as CLOEXEC clear.
+  passed fd through a slot above all passed fds (`dup2 fd->tmp`, `dup2 tmp->fd`,
+  `close tmp`; tmp starts at `max(128, max fd + 1)` so the slots never collide
+  with the fds being placed).
+- Fix: implement POSIX inheritance semantics for `proc_spawn` in wasmer: inherit
+  non-CLOEXEC fds, honor same-fd dup2 as CLOEXEC clear.
 
 ### signals don't interrupt blocked pipe reads 🔴
 
 - SIGTERM/SIGKILL to a process blocked in `read()` on a pipe neither kills it
-  nor errors the read; a subsequent `waitpid` blocks forever. A child blocked
-  in `sleep()` dies fine (verified with paired spawn/kill tests on wasmer
-  7.2.0). The blocked read likely parks the instance in a host-side await
-  that signal delivery never cancels.
+  nor errors the read; a subsequent `waitpid` blocks forever. A child blocked in
+  `sleep()` dies fine (verified with paired spawn/kill tests on wasmer 7.2.0).
+  The blocked read likely parks the instance in a host-side await that signal
+  delivery never cancels.
 - Consequence: `multiprocessing.Pool.terminate()` (and the `with Pool(...)`
   context manager, which calls it) hangs: idle workers sit blocked in queue
-  reads and can't be killed. `pool.close(); pool.join()` works because
-  sentinels wake the workers first. Same risk for any subprocess kill/timeout
-  pattern where the child blocks on fd reads. Also why hf-xet's SIGINT handler
-  is a no-op on wasix (hf-xet-wasi-sigint.patch): a native handler would be
-  inert until delivery is fixed, and CPython owns Ctrl-C at the Python boundary.
-- Fix: wasmer's signal delivery must cancel in-flight blocking syscalls
-  (EINTR or instance termination).
+  reads and can't be killed. `pool.close(); pool.join()` works because sentinels
+  wake the workers first. Same risk for any subprocess kill/timeout pattern
+  where the child blocks on fd reads. Also why hf-xet's SIGINT handler is a
+  no-op on wasix (hf-xet-wasi-sigint.patch): a native handler would be inert
+  until delivery is fixed, and CPython owns Ctrl-C at the Python boundary.
+- Fix: wasmer's signal delivery must cancel in-flight blocking syscalls (EINTR
+  or instance termination).
 
 ### tokio's I/O driver panics on an unexpected park errno 🟡
 
-- tokio's I/O driver parks in `mio::Poll::poll` and `panic!`s ("unexpected error
-  when polling the I/O driver") on any errno it does not explicitly tolerate.
-  Upstream tolerates only `Interrupted` and, on wasi, `InvalidInput`, the errno
-  the reference runtime returns for a poll with zero subscriptions
-  (`runtime/io/driver.rs`, arm commented "poll without subscriptions"). Under
-  panic=abort a park panic takes the process down.
-- Workaround (`tokio/1.51.0.patch`): also tolerate `Unsupported` (ENOTSUP,
-  errno 58) in that arm, treating it like the empty-poll case.
-- The ENOTSUP was originally attributed to wasmer's `poll_oneoff` rejecting a
-  zero-length subscription set. That attribution does not hold against the
-  pinned wasmer: upstream fixed the empty-subscription case in January 2026
-  (commit `350a7306`, "handle empty subscription list in poll_oneoff", with a
-  test), and `poll_oneoff` now returns `Errno::Inval` there, via both the early
-  return and `validate_poll_subscriptions_count`. Neither `poll_oneoff` nor
-  `epoll_wait` returns `Errno::Notsup` on any path in the pinned tree, and on
-  wasmer our mio uses the epoll backend (`mio/1.2.2.patch`), not `poll_oneoff`.
-- So the tolerance is kept as cheap insurance, not as a workaround for a known
-  live wasmer bug: it converts a would-be abort into the same graceful park
-  return tokio already performs for the analogous `InvalidInput`. Drop it if the
-  panic never reappears; reopen this entry with a real trace if it does.
+- Symptom: tokio panics with "unexpected error when polling the I/O driver" on
+  `Unsupported` (ENOTSUP); panic=abort terminates the process.
+- Workaround (`tokio/1.51.0.patch`): also tolerate `Unsupported` (ENOTSUP, errno
+  58), as tokio already does for the analogous empty-poll error.
+- Fix: the pinned runtime has no identified ENOTSUP path in `poll_oneoff` or
+  `epoll_wait`. Capture a trace if the panic returns; otherwise drop the patch.
 
 ### `futex_wake` lost a wakeup when a waiter was mid-registration 🟢
 
-- wasmer's `futex_wake` woke "the first waiter" by taking the first entry of the
-  futex's `wakers` map and calling its stored `Waker`. But a thread that has
-  entered `futex_wait` and inserted its id with `None` (waker not installed yet)
-  sits in that map as `Some(None)`; `futex_wake` consumed that slot, woke nobody,
-  and skipped a truly sleeping waiter that still held its installed waker. A
-  tokio worker parked on the futex then never woke: `tokio::spawn` + a task doing
-  a WASI syscall + `join_all` hung (reproduced minimally; also stalled the rustfs
-  erasure-init metadata-read fanout, blocking `rustfs server` startup entirely).
-- Fix (`patches/wasmer-futex-wake-lost-wakeup.patch`): wake the first waiter that
-  has an installed waker; if none is installed yet, increment a `pending_wakes`
-  counter on the futex that the next `futex_wait` consumes before parking, so the
-  wake survives the register race. Upstreamable to wasmer.
-- A token is scoped to the waiters it was meant for: only recorded while `wakers`
-  is non-empty, only claimable by a poller that still holds its slot, and dropped
-  with the futex once the last waiter leaves. Without those three bounds a token
-  can outlive its waiters, and since a wake then finds no sleeper in the empty
-  map it records another one, so the counter grows unbounded and the futex entry
-  is never reclaimed. The slot check also stops a poller that `futex_wake` has
-  already claimed from swallowing a token owed to a waiter still asleep.
+- Symptom: a tokio worker parked on a futex never woke, hanging `join_all` and
+  RustFS startup. `futex_wake` could select a waiter before its `Waker` was
+  installed and skip an already sleeping waiter.
+- Fix (`patches/wasmer-futex-wake-lost-wakeup.patch`): wake the first waiter
+  with an installed waker, or record a bounded pending wake for a registering
+  waiter. Upstreamable to wasmer.
 
 ### tokio's I/O driver compiles out the mio `Waker` on wasi 🟡
 
-- tokio gates its `mio::Waker` (the handle that wakes the reactor parked in
-  `epoll_wait` from another thread) behind `#[cfg(not(target_os = "wasi"))]`,
-  because stock mio's wasip1 backend has no `Waker`. Our vendored mio backend
-  (`mio/1.2.2.patch`, the wasix-org wasi backend) does implement an eventfd
-  `Waker`, but tokio still skips it, so any completion that must re-schedule a
-  task through the I/O driver (e.g. `tokio::fs`, which rustfs uses for
-  `access()`) parks the reactor forever with nothing able to wake it.
+- Symptom: completions such as `tokio::fs` cannot wake a reactor parked in
+  `epoll_wait`. Tokio compiles out `mio::Waker` on wasi even though the patched
+  mio 1.2.2 backend provides one.
 - Workaround (`tokio/1.51.0.patch`): widen those four gates to
   `any(not(target_os = "wasi"), all(target_vendor = "wasmer", tokio_wasix_waker))`,
-  and have the consumer opt in with `RUSTFLAGS = "--cfg tokio_wasix_waker"`
-  (rustfs does). With the futex_wake fix above, a spawned `tokio::fs` task +
-  `join_all` completes and rustfs storage init reaches "store ready".
-- The opt-in is load-bearing, not caution: the Waker is only sound with a mio that
-  has the wasix backend. Enabling it for all of `target_vendor = "wasmer"` broke
-  primp, which pins mio 1.2.0 (`cannot find type Waker in crate mio` -> tokio
-  fails to compile). mio only exports `Waker` off-wasi, and its 1.2.0 wasi arm is
-  the `single_threaded` `AtomicBool` waker, which by its own docs cannot wake an
-  already-blocked thread. Backporting the wasix backend to 1.2.0 is not a fix
-  either: it adds a `wasix` crate dependency, and crate-patches apply post-vendor,
-  so every consumer's lock would need it.
+  and opt consumers in with `RUSTFLAGS = "--cfg tokio_wasix_waker"`. The opt-in
+  is required because older mio versions do not export a usable wasi `Waker`.
 - Fix: once mio's upstream wasi backend ships a real `Waker` on every version in
   play, tokio can relax the blanket `not(wasi)` gate and the opt-in can go.
 
 ### `fd_datasync`/`fd_sync` deny with EACCES under mapped host dirs 🟢
 
-- wasmer's `fd_datasync`/`fd_sync` return `Errno::Access` unless the fd holds the
-  `FD_DATASYNC`/`FD_SYNC` right. But `path_open` computes a file's rights as
+- wasmer's `fd_datasync`/`fd_sync` return `Errno::Access` unless the fd holds
+  the `FD_DATASYNC`/`FD_SYNC` right. But `path_open` computes a file's rights as
   `(requested | implied_by_open_mode) & parent_dir.rights_inheriting`
   (`path_open2.rs`, whose own TODO notes "WASI isn't giving appropriate rights
   here"): the inheriting mask on a `--mapdir`/`--volume` host preopen strips the
-  implied sync rights, so files opened for writing under it cannot fsync/fdatasync.
+  implied sync rights, so files opened for writing under it cannot
+  fsync/fdatasync.
 - Symptom: rustfs object writes call `fdatasync` for durability; the EACCES maps
   (ecstore `to_file_error`: PermissionDenied -> FileAccessDenied) to a 500
   `InternalError "File access denied"` on every `PutObject`/`UploadPart`, while
   bucket/metadata ops (no data fsync) succeed. `mc mb` worked, `mc pipe` 500'd.
-- Fix (`patches/wasmer-fd-sync-rights-durability.patch`): drop the rights gate in
-  both syscalls. fsync/fdatasync are durability barriers, not security
+- Fix (`patches/wasmer-fd-sync-rights-durability.patch`): drop the rights gate
+  in both syscalls. fsync/fdatasync are durability barriers, not security
   capabilities (POSIX needs no special permission); sync any regular-file fd.
   With the fix a full `mc` put/get round-trip against `rustfs server` passes.
 - Cleaner upstream fix would stop masking implied sync rights in path_open, but
@@ -146,28 +127,30 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 ### wasix Rust std does not map wasi ENOTEMPTY to `DirectoryNotEmpty` 🟡
 
 - wasix std's error decoding returns an uncategorized `io::ErrorKind` (not
-  `DirectoryNotEmpty`) for wasi `ENOTEMPTY` (errno 55). Rust code that branches on
-  `err.kind() == ErrorKind::DirectoryNotEmpty` (the common "rmdir of a non-empty
-  dir is fine" idiom) then falls through to its error path.
+  `DirectoryNotEmpty`) for wasi `ENOTEMPTY` (errno 55). Rust code that branches
+  on `err.kind() == ErrorKind::DirectoryNotEmpty` (the common "rmdir of a
+  non-empty dir is fine" idiom) then falls through to its error path.
 - Symptom: rustfs object DELETE (`mc rm`) 500'd with "File access denied". Its
-  `delete_file` (ecstore `disk/local.rs`) tolerates NotFound + DirectoryNotEmpty on
-  `remove_dir` and treats anything else as fatal `FileAccessDenied`; the object dir
-  is legitimately non-empty (the xl versioned-delete rename dance stages old data
-  in a sub-dir), so on wasix that ENOTEMPTY aborted + rolled back the delete.
-  Traced: `path_remove_directory -> Errno::notempty` on the object dir.
+  `delete_file` (ecstore `disk/local.rs`) tolerates NotFound + DirectoryNotEmpty
+  on `remove_dir` and treats anything else as fatal `FileAccessDenied`; the
+  object dir is legitimately non-empty (the xl versioned-delete rename dance
+  stages old data in a sub-dir), so on wasix that ENOTEMPTY aborted + rolled
+  back the delete. Traced: `path_remove_directory -> Errno::notempty` on the
+  object dir.
 - Workaround (`rustfs-code.patch`): `delete_file` also tolerates
   `err.raw_os_error() == Some(55)` under `cfg(target_os = "wasi")`.
-- Fix: the wasix rust-std fork's `decode_error_kind` should map wasi ENOTEMPTY
-  (and any other missing codes) to the matching `ErrorKind`, so any package keying
-  on `DirectoryNotEmpty` works without per-crate patches. Broader than rustfs and
+- Fix: WASIX rust-std's `decode_error_kind` should map wasi ENOTEMPTY (and any
+  other missing codes) to the matching `ErrorKind`, so any package keying on
+  `DirectoryNotEmpty` works without per-crate patches. Broader than rustfs and
   touches the toolchain (expensive rebuild), hence the local workaround for now.
 
 ### `path_rename` mishandles hard links and replacement renames 🟡
 
 - Wasmer recursively rebases cached inode paths after renaming a directory and
   assumed every inode reachable from that directory had a path below it. A hard
-  link can make the same inode reachable outside the moved tree, so `adjust_path`
-  panicked when `strip_prefix` failed and poisoned the filesystem lock.
+  link can make the same inode reachable outside the moved tree, so
+  `adjust_path` panicked when `strip_prefix` failed and poisoned the filesystem
+  lock.
 - After a successful rename over an existing destination, Wasmer also retained
   the replaced destination in its inode cache instead of inserting the moved
   source entry.
@@ -214,9 +197,9 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 
 - Fixed in current wasmer: `posix_spawnp` and fork + `execvp` both resolve the
   child via the guest PATH, and the child's `argv[0]` arrives correctly
-  (verified with minimal C programs).
-  Older runtimes could not resolve by name, which is why git execs absolute
-  baked paths; that approach still works and stays.
+  (verified with minimal C programs). Older runtimes could not resolve by name,
+  which is why git execs absolute baked paths; that approach still works and
+  stays.
 - The find suite's `-exec`/xargs tests stay `broken` regardless: the spawned
   tools (cat/echo) aren't on the guest PATH at all, because the test harness
   forwards an env allowlist rather than the host PATH, so nothing exists for
@@ -246,15 +229,16 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 ### exec'ing a symlinked helper in a webc fails ENOEXEC 🟢
 
 - `WebcVolumeFileSystem::open()` read raw (non-following) metadata, so a symlink
-  resolved to `Err(NotAFile)`. Exec'ing a symlinked binary
-  (git's `libexec/git-core/git-upload-pack -> ../../bin/git.wasm`, and the other
-  git helpers) therefore failed with ENOEXEC ("cannot execute binary file"),
+  resolved to `Err(NotAFile)`. Exec'ing a symlinked binary (git's
+  `libexec/git-core/git-upload-pack -> ../../bin/git.wasm`, and the other git
+  helpers) therefore failed with ENOEXEC ("cannot execute binary file"),
   breaking every git transport test (clone/fetch/push over local/http/https/net)
   while the same tree on a real fs works.
 - Fixed: `patches/wasmer-webc-follow-symlinks.patch` resolves symlinks (relative
   targets against the link's parent, bounded loop) before opening, matching
-  real-fs semantics. Verified: `checks.git` (all transport tests) passes with it.
-  Vendored from python-pkgs; upstream to wasmerio/wasmer and drop once merged.
+  real-fs semantics. Verified: `checks.git` (all transport tests) passes with
+  it. Vendored from python-pkgs; upstream to wasmerio/wasmer and drop once
+  merged.
 
 ### `fork()` is hidden under Wasm-EH 🟡
 
@@ -283,14 +267,14 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 
 ### `getifaddrs`/`freeifaddrs` misnamed in wasix-libc 🟡
 
-- wasix-libc's `ifaddrs.h` declares the standard `getifaddrs`/`freeifaddrs`,
-  but `libc.a` only defines `getif_addrs`/`freeif_addrs` (verified with nm;
+- wasix-libc's `ifaddrs.h` declares the standard `getifaddrs`/`freeifaddrs`, but
+  `libc.a` only defines `getif_addrs`/`freeif_addrs` (verified with nm;
   python3.wasm exports only the underscored names). Callers compile, then die
   with undefined symbols at link or dylib import. `if_indextoname` and
   `if_nametoindex` are declared in `net/if.h` but not defined at all.
 - Workaround: libuv's `libuv-0013-wasix-ifaddrs-names-no-if_index.patch` maps
-  the names and stubs the `if_*` lookups. nix short-circuits its "are we
-  online" probe instead (`unsupported-posix-apis-on-wasi.patch`).
+  the names and stubs the `if_*` lookups. nix short-circuits its "are we online"
+  probe instead (`unsupported-posix-apis-on-wasi.patch`).
 - Fix: define the standard names in wasix-libc (alias or rename), and
   implement/stub `if_indextoname`/`if_nametoindex`.
 
@@ -305,9 +289,9 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
   via `libc-bottom-half/sources/`): best-effort no-ops (mlock/munlock/madvise
   return 0, sched_getcpu returns 0, sched_getaffinity fills the mask from
   `sysconf(_SC_NPROCESSORS_ONLN)`, and `__sched_cpucount`, which `CPU_COUNT()`
-  lowers to and the libc build omits, counts the mask bits). The
-  duckdb/opencv `__wasi__` guard patches are now redundant and removed. Upstream
-  this stub file into wasix-libc.
+  lowers to and the libc build omits, counts the mask bits). The duckdb/opencv
+  `__wasi__` guard patches are now redundant and removed. Upstream this stub
+  file into wasix-libc.
 
 ### `mprotect` is not linkable 🟡
 
@@ -350,15 +334,15 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
   `proc_fork`, and `proc_spawn*`, but the Wasmer WASIX ABI has no operation for
   coordinating POSIX record locks between them.
 - The vendored wasix-libc patch exposes `F_GETLK`/`F_SETLK`/`F_SETLKW`, the lock
-  types, and `struct flock` so feature-detected consumers compile. The operations
-  return `ENOSYS`; reporting success would falsely claim exclusion and risk
-  cross-process corruption.
-- Workaround: h5py's runtime test sets `HDF5_USE_FILE_LOCKING=FALSE`; DuckDB skips
-  its lock calls on WASI in `duckdb-wasi-no-file-lock.patch`.
+  types, and `struct flock` so feature-detected consumers compile. The
+  operations return `ENOSYS`; reporting success would falsely claim exclusion
+  and risk cross-process corruption.
+- Workaround: h5py's runtime test sets `HDF5_USE_FILE_LOCKING=FALSE`; DuckDB
+  skips its lock calls on WASI in `duckdb-wasi-no-file-lock.patch`.
 - Blocks the `fs2` crate, whose whole API is locking, and any crate reaching the
   filesystem through it. tantivy takes its index lock via `fs2::FileExt`, so the
   overlay registry cannot serve it from a floor patch: a port has to replace the
-  mmap directory backend, as the wasix-org 0.18 fork does, rather than widen a
+  mmap directory backend, as the wasix-org 0.18 source does, rather than widen a
   cfg gate.
 - Upstream fix: add record-lock operations and shared per-file lock state to
   Wasmer's WASIX filesystem ABI, then implement the fcntl commands in wasix-libc
@@ -376,21 +360,22 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 - Consequence: onnxruntime's `Env::GetRuntimePath` calls `dladdr` to find the
   directory of its own binary (to locate provider shared libraries beside it);
   `import onnxruntime` traps.
-- Workaround: `overlay/packages/onnxruntime/patches/onnxruntime-wasi-no-dladdr.patch`
-  guards the `dladdr` path on `__wasi__` (as onnxruntime already does for AIX),
-  taking the non-`dladdr` fallback. Fine for a static single-EP build that loads
-  no provider `.so`.
-- Fix: implement `dladdr` in wasix's dyld (fill `Dl_info` from the module table),
-  or at least export a weak stub returning 0 so consumers take their own
+- Workaround:
+  `overlay/packages/onnxruntime/patches/onnxruntime-wasi-no-dladdr.patch` guards
+  the `dladdr` path on `__wasi__` (as onnxruntime already does for AIX), taking
+  the non-`dladdr` fallback. Fine for a static single-EP build that loads no
+  provider `.so`.
+- Fix: implement `dladdr` in wasix's dyld (fill `Dl_info` from the module
+  table), or at least export a weak stub returning 0 so consumers take their own
   fallback instead of failing to import.
 
 ### `dlfcn.h` ships for `off` but not the non-PIC EH sysroots 🟡
 
-- `Makefile-eh` omits the header when PIC is off (`MUSL_OMIT_HEADERS +=
-"dlfcn.h"` under `ifeq ($(PIC), no)`), while the plain `Makefile` the `off`
-  profile uses has no such rule. So `sysroot` (off), `sysroot-ehpic` and
-  `sysroot-exnref-ehpic` carry `dlfcn.h`; `sysroot-eh` and `sysroot-exnref-eh`
-  do not (verified against the built sysroots).
+- `Makefile-eh` omits the header when PIC is off
+  (`MUSL_OMIT_HEADERS += "dlfcn.h"` under `ifeq ($(PIC), no)`), while the plain
+  `Makefile` the `off` profile uses has no such rule. So `sysroot` (off),
+  `sysroot-ehpic` and `sysroot-exnref-ehpic` carry `dlfcn.h`; `sysroot-eh` and
+  `sysroot-exnref-eh` do not (verified against the built sysroots).
 - Consequence: a package that includes `<dlfcn.h>` unconditionally compiles at
   `off` and the PIC profiles but fails at `eh`/`exnrefEh` with "'dlfcn.h' file
   not found", which reads as a missing feature rather than a header-install
@@ -446,62 +431,29 @@ Status: 🔴 needs upstream fix · 🟡 workaround in place · 🟢 fixed.
 
 ### Rust cdylib wheels ship legacy Wasm-EH from the rust `-dl` sysroot 🟡
 
-- A maturin/pyo3 wheel whose closure pulls libc++ exception code (or any legacy
-  Wasm-EH) loads with `Validate("legacy_exceptions feature required for try
-instruction")` under the pinned wasmer (7.2.0), which only accepts the new
-  (`try_table`/exnref) encoding. Hit on `tokenizers` (esaxx-rs C++ throws, which
-  links libc++'s `std::runtime_error`/`std::logic_error` ctors).
-- Root cause (disassembled `tokenizers.abi3.so` at the failing offset 0x66b5c1):
-  the legacy `try` sits in libc++'s own compiled exception helpers, NOT
-  compiler-rt SjLj. The rust toolchain's std targets link the **legacy-EH**
-  sysroots (`toolchain/rust/toolchain.nix`: `wasm32-wasmer-wasi` ->
-  `wasixSysrootEh`, `wasm32-wasmer-wasi-dl` -> `wasixSysrootEhpic`), so an
-  extension module (built on the `-dl`/PIC target) links the ehpic `libc++.a`,
-  whose `stdexcept.cpp.o` carries 6 legacy `try` (verified: the exnref-ehpic
-  `libc++.a` has 0 legacy / 15 `try_table`; the ehpic one has 6 legacy / 0).
-  This is why the legacy `try` was invariant to per-crate `--wasm-use-legacy-eh`
-  cc flags (those only reach the wheel's OWN C/C++, which came out `try_table`)
-  and to the python profile switch (the rust `-dl` sysroot is fixed regardless).
-- Why CLIs don't hit it: cargo-wasix runs `wasm-opt --translate-to-exnref` on
-  every `.wasm` it emits (lib.rs `run_wasm_opt`), converting all legacy EH to
-  exnref. A maturin cdylib is a `.so`, so that pass (keyed on the `.wasm`
-  extension) never runs on it. Pure-rust wheels (jiter, pydantic-core) import
-  fine because panic=abort leaves no EH to translate.
+- Symptom: a maturin wheel containing libc++ exception code fails validation
+  with "legacy_exceptions feature required for try instruction". The Rust `-dl`
+  target links the legacy-EH PIC sysroot, while wasmer 7.2.0 accepts the exnref
+  encoding. Cargo-wasix translates CLI `.wasm` files but not wheel `.so` files.
 - Workaround (in place): a setup hook on the shared `maturinBuildHook`
-  (`set/rust-platform.nix`, `exnrefTranslateHook`) re-applies
-  `wasm-opt --translate-to-exnref` to every wheel `.so` in `fixupOutputHooks`,
-  so EVERY maturin wheel gets the same pass cargo-wasix gives CLIs, not just
-  tokenizers. Same `toolchain.binaryen` cargo-wasix uses; a no-op on wheels with no
-  legacy EH (verified: tokenizers -> 0 legacy `try`, wasmer 7.2.0 validates +
-  imports; jiter/pydantic-core unaffected). Unblocks tokenizers -> litellm.
-- Why not routed through cargo-wasix: maturin drives `cargo rustc` and parses
-  cargo's artifact JSON itself; cargo-wasix also drives+consumes that stream and
-  has no `rustc` subcommand, so putting it in the middle hides the artifact from
-  maturin. The hook is the maturin analogue of cargo-wasix's CLI pass.
-- Proper fix (upstream): (a) point the rust std targets at the **exnref**
-  sysroots (`variants.exnrefEh`/`exnrefEhpic`) so linked libc++ is already
-  `try_table`, though that rebuilds std, and the wheels' own rust EH still needs the
-  translate pass unless panic=abort; or (b) teach cargo-wasix to post-process
-  cdylib artifacts (e.g. a standalone `opt` subcommand the hook calls), moving
-  the pass's ownership back into cargo-wasix. Then drop `exnrefTranslateHook`.
-- Not covered: setuptools-rust wheels (tiktoken) don't use `maturinBuildHook`;
-  they're fine today (pure Rust, no legacy EH) but a C++-using one would need the
-  same hook wired into that path.
+  (`exnrefTranslateHook`) runs `wasm-opt --translate-to-exnref` on wheel `.so`
+  files. Tokenizers imports; pure-Rust jiter and pydantic-core are unchanged.
+- Fix: point the Rust targets at the exnref sysroots, or make cargo-wasix expose
+  cdylib post-processing. Setuptools-rust needs the hook if a wheel containing
+  legacy EH appears there.
 
 ### asyncify can't process Wasm-EH instructions 🟡
 
-- `wasm-opt --asyncify` aborts ("unexpected expr type", Flatten.cpp) on
-  modules containing EH instructions. Under the EH profiles that means C++
-  exceptions or anything using setjmp/longjmp (lowered to Wasm-EH SjLj):
-  verified with a C++ binary, and reproduced by git's clar unit-tests binary
-  (clar uses setjmp). Plain C without setjmp asyncifies fine regardless of
-  feature flags.
+- `wasm-opt --asyncify` aborts ("unexpected expr type", Flatten.cpp) on modules
+  containing EH instructions. Under the EH profiles that means C++ exceptions or
+  anything using setjmp/longjmp (lowered to Wasm-EH SjLj): verified with a C++
+  binary, and reproduced by git's clar unit-tests binary (clar uses setjmp).
+  Plain C without setjmp asyncifies fine regardless of feature flags.
 - Workaround: fork-using C programs (git, findutils) set
   `WASIXCC_WASM_OPT_FLAGS=--asyncify:-O2`, so wasixcc's link-time wasm-opt
   applies the pass in the EH profiles like it does on its own in the off
-  profile. git additionally skips building its test binaries
-  (`TEST_PROGRAMS=`, `CLAR_TEST_PROG=`), which contain setjmp and can never
-  run in a cross build.
+  profile. git additionally skips building its test binaries (`TEST_PROGRAMS=`,
+  `CLAR_TEST_PROG=`), which contain setjmp and can never run in a cross build.
 - Fix: binaryen asyncify support for EH; upstream the wasixcc setting.
 
 ### `wasm-opt` corrupts autoconf/cmake feature detection 🟡
@@ -509,38 +461,38 @@ instruction")` under the pinned wasmer (7.2.0), which only accepts the new
 - A failing wasm-opt run on a throwaway conftest makes `configure`
   false-negative a feature (sqlite: "Cannot find libm functions").
 - Root cause (re-verified 2026-07-13, thrift at eh): function-exists probes
-  declare wrong signatures (`char strerror_r();`); wasm-ld silently links
-  that into invalid wasm, and wasm-opt fatals parsing it. Only eh is hit:
-  wasixcc always appends `--emit-exnref` there, so wasm-opt runs even for
-  -O0 probes; the other profiles skip it (no passes at -O0).
+  declare wrong signatures (`char strerror_r();`); wasm-ld silently links that
+  into invalid wasm, and wasm-opt fatals parsing it. Only eh is hit: wasixcc
+  always appends `--emit-exnref` there, so wasm-opt runs even for -O0 probes;
+  the other profiles skip it (no passes at -O0).
 - Workaround: `disableWasmOptInConfigureHook`, opt-in per package (sqlite,
   libzip, thrift).
-- Fix: wasm-ld should reject signature-mismatched direct calls (LLVM fork),
-  or wasixcc's autoconf workarounds mode skips post-link wasm-opt.
+- Fix: wasm-ld should reject signature-mismatched direct calls (WASIX LLVM), or
+  wasixcc's autoconf workarounds mode skips post-link wasm-opt.
 
 ### non-default python splices a wasm `pyproject-build` in nativeBuildInputs 🟡
 
 - The default python is py314. A package that runs `pyproject-build` directly
   (from `build` in nativeBuildInputs, as the C++ onnx does in preBuild, rather
-  than via `pypaBuildHook`) builds fine on py314 but on py313 (non-default) `build`
-  splices to the wasm target: its `.pyproject-build-wrapped` is a python script,
-  and bash runs it and chokes on the `lambda` in the site-init line. The
+  than via `pypaBuildHook`) builds fine on py314 but on py313 (non-default)
+  `build` splices to the wasm target: its `.pyproject-build-wrapped` is a python
+  script, and bash runs it and chokes on the `lambda` in the site-init line. The
   pythonOnBuildForHost native `build` exists; the nativeBuildInputs splice just
   does not pick it in the non-default python's package set.
-- Consequence: the C++ onnx re-instantiated in the python313 set fails; and it is
-  re-instantiated per interpreter because the python onnx wheel pulls `onnx`
+- Consequence: the C++ onnx re-instantiated in the python313 set fails; and it
+  is re-instantiated per interpreter because the python onnx wheel pulls `onnx`
   (C++) through its own set. (An earlier abi3-dist `.override` that forced the
   py314 C++ onnx worked for py314 but dragged its py314 python + protobuf onto
   the py313 wheel's PYTHONPATH, which shadowed py313's build tools, so the
   `packaging`/`installer` failures seen then were that pollution, not a real
   py313 provisioning gap.)
 - Workaround: `overlay/python-packages/onnx.nix` repackages only the abi3 wheel
-  FILE from the top-level (native) py314 C++ onnx and drops the onnx package from
-  build/propagated inputs, so no per-interpreter C++ onnx is built and no py314
-  python leaks. Both py313 and py314 wheels import green.
+  FILE from the top-level (native) py314 C++ onnx and drops the onnx package
+  from build/propagated inputs, so no per-interpreter C++ onnx is built and no
+  py314 python leaks. Both py313 and py314 wheels import green.
 - Fix: make the non-default python's package set splice `build` (and peer pypa
-  tools) to `pythonOnBuildForHost` in nativeBuildInputs, matching the default, so
-  a package that must genuinely build a wheel on py313 works.
+  tools) to `pythonOnBuildForHost` in nativeBuildInputs, matching the default,
+  so a package that must genuinely build a wheel on py313 works.
 
 ### flang cross-compiles wasm32 with the host ABI 🟡
 
@@ -576,51 +528,18 @@ instruction")` under the pinned wasmer (7.2.0), which only accepts the new
 
 ### scipy calls the flang reference BLAS/LAPACK without F77 hidden CHARACTER lengths 🟢
 
-- Reference BLAS/LAPACK routines take `CHARACTER*1` flags (`TRANSA`, `UPLO`, …).
-  flang emits them with the standard F77 hidden-string-length ABI: each character
-  argument adds a trailing `size_t` length parameter (i32 on wasm32), appended
-  after all explicit args. Much of scipy's C/Cython glue declares the Fortran
-  symbols WITHOUT those hidden lengths, calling e.g. `dgemm_(char*, char*,
-int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x86
-  harmless (the extra slots are ignored), but wasm `call_indirect` is strictly
-  typed: wasm-ld emits a trapping stub and the call dies at runtime
-  (`signature_mismatch:dgemm_`). f2py's wrappers (`_fblas`/`_flapack`) already
-  pass the hidden lengths, so the f2py path (`scipy.linalg.solve/lstsq/eig`, so
-  `LinearRegression`) is fine; 15-arg is the correct target everywhere. Never an
-  OpenMP issue (libomp runs; the trap is in the BLAS call).
-- Fixed: the `cython_blas`/`cython_lapack` path. `scipy-cython-blas-fortran-charlen.patch`
-  (in `scipy.nix`) patches scipy's `_generate_pyx.py` so the generated
-  `_fortran_<name>` externs and calls carry the hidden lengths (value 1: every
-  wrapped char arg is CHARACTER\*1 and LSAME ignores the length; ilaenv/xerbla are
-  not wrapped). Only the internal Fortran calls change; the public `cdef` wrapper
-  signatures are untouched, so downstream `cython_blas`/`cython_lapack` consumers
-  stay ABI-compatible. Verified by scikit-learn's fit check (direct
-  `cython_blas._test_dgemm` + `KMeans.fit`). This is what scikit-learn /
-  statsmodels reach, so the downstream story is green.
-- Also fixed: scipy's OWN hand-C/C++ modules (which declare the Fortran symbols
-  themselves and called 13-arg) via `scipy-hand-c-blas-fortran-charlen.patch`,
-  covering `_lbfgsb`/`_slsqplib` (optimize.minimize L-BFGS-B/SLSQP),
-  `_odepack`/`_vode` (integrate.odeint/ode), `_batched_linalg`,
-  `_internal_matfuncs` (expm/sqrtm), and the three vendored solvers that ship
-  their own BLAS decls: `_propack`, arpack (arnaud), and SuperLU. 10 header files.
-  Same shape as the cython patch, plus one extra class: `?getrf`/`?getri` are
-  declared CBLAS_INT-returning but flang's subroutines return void (a return-type
-  mismatch). Technique: bind the true flang symbol to a private name via an
-  `__asm__` label (with the hidden `size_t` lengths), define a DISTINCT-named
-  `static inline` wrapper that appends `1` per char arg, and `#(re)define` the
-  mangled name to the wrapper. The distinct name matters: a wrapper reusing the
-  true symbol name makes the asm label bind the call back into the wrapper
-  (verified self-recursion under wasm-ld). All gated on `__wasi__`/`__wasm__`;
-  lengths/void-returns verified against the reference lib arities. Warnings
-  426 -> 1. Verified by `scipy/tests/basic.nix` under wasmer (optimize L-BFGS-B/
-  SLSQP, integrate odeint/LSODA, expm/sqrtm, batched svd/lu/qr/cholesky/eig,
-  PROPACK svds).
-- Left: `chla_transtype_` in `cython_lapack` (the last warning), a
-  CHARACTER-returning helper with a distinct hidden-result-buffer ABI that scipy
-  never calls directly.
-- Upstream: a latent scipy portability bug where the glue relies on a lax C ABI that
-  strict targets (wasm) reject. Upstream scipy could pass the hidden lengths
-  unconditionally, as its own f2py wrappers already do.
+- Symptom: scipy's C and Cython BLAS/LAPACK wrappers omit the hidden `size_t`
+  length for each Fortran `CHARACTER*1` argument. Wasm's strict call signatures
+  turn that mismatch into traps such as `signature_mismatch:dgemm_`.
+- Fix: `scipy-cython-blas-fortran-charlen.patch` corrects the generated
+  `cython_blas` and `cython_lapack` calls without changing their public API.
+  `scipy-hand-c-blas-fortran-charlen.patch` wraps scipy's hand-written calls and
+  corrects the `?getrf`/`?getri` return type. `scipy/tests/basic.nix` covers the
+  affected optimize, integrate, matrix-function, batched-linalg, and solver
+  paths; scikit-learn covers the Cython path.
+- Upstream: scipy should pass the hidden lengths unconditionally, as its f2py
+  wrappers already do. `chla_transtype_`, which scipy does not call directly,
+  still has its separate character-return ABI warning.
 
 ### `clang-scan-deps` breaks cmake try-compiles 🟡
 
@@ -633,10 +552,10 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
   the sysroot/target flags the shim injects), and cmake reads every failed scan
   as "the probe did not compile."
 - Consequence: a package whose configure does try-compiles aborts with a
-  misleading message. rapidfuzz's LLVM-style atomic check fatals with "No
-  native support for std::atomic<int>" though the probes compile fine with
-  scanning off (all HAVE*CXX_ATOMICS*\* pass). duckdb and pyzmq have no such
-  probe and build with scanning on.
+  misleading message. rapidfuzz's LLVM-style atomic check fatals with "No native
+  support for std::atomic<int>" though the probes compile fine with scanning off
+  (all HAVE*CXX_ATOMICS*\* pass). duckdb and pyzmq have no such probe and build
+  with scanning on.
 - Workaround: a set-wide setup hook in `set/stdenv.nix` defaults
   `-DCMAKE_CXX_SCAN_FOR_MODULES=OFF` for every cmake build (harmless where cmake
   never scans; no per-package opt-out needed).
@@ -648,12 +567,12 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
 ## Packages that don't cross-build
 
 - **tzdata** 🟡: `localtime.c` needs getresuid/tzname/…, absent on WASIX.
-  Dependents use build-platform tzdata (zoneinfo is platform-independent
-  data): jq, python3.
-- **libffi** 🟡: nixpkgs libffi has no wasm32-wasi port; the
-  `wasix-org/libffi` fork adds one.
-- **pcre2grep callout-fork** 🟡: uses fork();
-  `--disable-pcre2grep-callout-fork` (the library is unaffected).
+  Dependents use build-platform tzdata (zoneinfo is platform-independent data):
+  jq, python3.
+- **libffi** 🟡: nixpkgs libffi has no wasm32-wasi port; `wasix-org/libffi` adds
+  one.
+- **pcre2grep callout-fork** 🟡: uses fork(); `--disable-pcre2grep-callout-fork`
+  (the library is unaffected).
 - **glib** 🟡: never built on wasix. Its bundled gnulib builds broken math
   replacements (meson `cc.links` fails wholesale on this cross-static stdenv, so
   every math fn is "missing"; `isinf.c` is Visual-Studio-only) and GIO needs
@@ -667,10 +586,10 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
   cross-instantiates and fails to compile on wasix (`--ld-path` unused, then
   `-Werror`). Only pulled by harfbuzz's Graphite shaping, which libraqm doesn't
   use; `packages/harfbuzz.nix` sets `withGraphite2 = false`.
-- **boost** 🟡: Boost.Build (b2) rejects `architecture=wasm` ("not a known
-  value of feature <architecture>"), so nixpkgs' cross boost never configures.
-  Its only wasix consumer so far is scipy, which needs the header-only
-  boost.math; `python-packages/scipy.nix` uses the build-host boost's headers
+- **boost** 🟡: Boost.Build (b2) rejects `architecture=wasm` ("not a known value
+  of feature <architecture>"), so nixpkgs' cross boost never configures. Its
+  only wasix consumer so far is scipy, which needs the header-only boost.math;
+  `python-packages/scipy.nix` uses the build-host boost's headers
   (`BOOST_INCLUDEDIR`/`BOOST_LIBRARYDIR`, both required by meson's boost
   detection) instead of cross-building. Fix (for a real wasix boost): teach b2 a
   `wasm`/`wasm32` architecture value (or map it to a no-op), then build
@@ -684,15 +603,15 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
 
 ### library/Cargo.lock pins libc 0.2.183 from two sources 🟡
 
-- std depends on the libc fork via a direct git dependency while the other
-  library crates (dlmalloc, panic_unwind, std_detect, test, unwind) stay on
-  registry libc. Since the fork's port matches the version the workspace
-  resolves (both 0.2.183 as of v2026-07-07.2+rust-1.96), the lockfile carries
-  the same name+version from two sources: importCargoLock keys vendor dirs by
+- std depends on WASIX libc via a direct git dependency while the other library
+  crates (dlmalloc, panic_unwind, std_detect, test, unwind) stay on registry
+  libc. Since the WASIX port matches the version the workspace resolves (both
+  0.2.183 as of v2026-07-07.2+rust-1.96), the lockfile carries the same
+  name+version from two sources: importCargoLock keys vendor dirs by
   name+version, the second symlink collides, and the toolchain cannot be
   vendored. Wasix std also mixes crates built against two different libcs.
-- Workaround: `toolchain/rust/libc-patch-crates-io.patch` routes crates-io
-  libc to the fork via `[patch.crates-io]` (applied in postPatch);
+- Workaround: `toolchain/rust/libc-patch-crates-io.patch` routes crates-io libc
+  to the WASIX source via `[patch.crates-io]` (applied in postPatch);
   `library.Cargo.lock` is the matching regenerated lock for vendor.nix.
 - Fix: merge the patch into wasix-org/rust; drop both files (and the
   rust-toolchain update note) with the first tag that includes it.
@@ -709,25 +628,27 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
 
 - "Unknown version of WASI" on `wasm32-wasmer-wasi`. CLI crates built through
   cargo-wasix need no workaround. Some python wheels pulling getrandom 0.3
-  (bcrypt, pydantic-core) still pin the `wasix-org/getrandom` fork; its
-  backend adds a dependency on the `wasix` crate, which a vendor patch can't
-  introduce (see `overlay/python-packages/lib/rust.nix`). The fork-free vendor
-  patch below is preferred and has replaced the fork for jiter.
+  (bcrypt, pydantic-core) still pin `wasix-org/getrandom`; its backend adds a
+  dependency on the `wasix` crate, which a vendor patch can't introduce (see
+  `overlay/python-packages/lib/rust.nix`). The dependency-free vendor patch
+  below is preferred and has replaced that source override for jiter.
 
-### getrandom 0.3/0.4 fixed fork-free by selecting the p1 backend 🟡
+### getrandom 0.3/0.4 fixed by selecting the p1 backend 🟡
 
 - Both getrandom 0.3.4 and 0.4.3 ship a `wasi_p1` backend that is a raw
   `extern "C" random_get` from `wasi_snapshot_preview1` (which wasix libc
-  provides) with **no crate dependency**, but their `backends.rs` only picks
-  it under `#[cfg(target_env = "p1")]`, and our target's env isn't p1, so they
-  fall to the component-model backend and `compile_error!` ("Unknown version of
-  WASI"). No fork or `wasix` crate is needed; just reroute the selection.
+  provides) with **no crate dependency**, but their `backends.rs` only picks it
+  under `#[cfg(target_env = "p1")]`, and our target's env isn't p1, so they fall
+  to the component-model backend and `compile_error!` ("Unknown version of
+  WASI"). No alternate source or `wasix` crate is needed; just reroute the
+  selection.
 - Workaround: `lib/vendor-getrandom-wasi.nix` (helper
   `rust.patchVendoredGetrandomWasi`) patches vendored getrandom 0.3/0.4
   `backends.rs` to use `wasi_p1` for anything that isn't p2/p3, and refreshes
   the checksum. Used by `jiter.nix`/`uuid-utils.nix`/`fastuuid.nix` with no
-  `[patch.crates-io]` fork and no shipped lock. This is simpler than the
-  getrandom-0.3 fork above and should replace it for bcrypt/pydantic-core too.
+  `[patch.crates-io]` source override and no shipped lock. This is simpler than
+  the getrandom-0.3 override above and should replace it for bcrypt and
+  pydantic-core too.
 - Fix: our wasix rust target should report `target_env = "p1"` in its target
   spec; then getrandom (and any preview1 crate) picks the right backend with no
   patch at all.
@@ -741,11 +662,11 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
   and dependency cutouts in `libdd-data-pipeline` and `libdd-trace-stats`. The
   consumers are not cut out with them, so the v35 graph does not compile for
   wasm32 at all: `libdd-capabilities-impl`, `datadog-remote-config` and
-  `libdd-telemetry` use the removed items unconditionally. v24 (ddtrace 3.x)
-  had no wasm32 gating and built stock.
-- Consequence: ddtrace 4.x does not build. Its `_native` module only ever
-  builds `NativeCapabilities` (hyper), so the host-provided-HTTP path upstream
-  added for browser wasm is not an option for it either.
+  `libdd-telemetry` use the removed items unconditionally. v24 (ddtrace 3.x) had
+  no wasm32 gating and built stock.
+- Consequence: ddtrace 4.x does not build. Its `_native` module only ever builds
+  `NativeCapabilities` (hyper), so the host-provided-HTTP path upstream added
+  for browser wasm is not an option for it either.
 - Workaround: `pkgs/lib/wasix-crate-patches/libdd-*` narrow every cutout to
   non-wasmer wasm32 (`not(wasm32)` becomes
   `any(not(wasm32), target_vendor = "wasmer")`, `wasm32` becomes
@@ -757,60 +678,23 @@ int*, …)` with 13 args, while flang's `dgemm_` is a 15-arg wasm function. On x
 
 ### `select()` with exceptfds returns ENOSYS; callers spin 🟢
 
-- wasix-libc's `select()`/`pselect()` returned `-1`/`ENOSYS` (errno 52) whenever
-  `exceptfds` was non-empty. The bug was purely in libc, not the runtime:
-  `libc-bottom-half/cloudlibc/src/libc/sys/select/pselect.c` hardcoded
-  `if (errorfds && errorfds->__nfds > 0) { errno = ENOSYS; return -1; }` BEFORE
-  it built any subscriptions or called `__wasi_poll_oneoff` (that is why the WASI
-  trace showed no `poll_oneoff`). `poll_oneoff` genuinely has no exceptional-
-  condition event type, so TRUE exceptfds semantics (TCP OOB) would need runtime
-  support, but callers like rsync only pass exceptfds defensively.
-- This is what stalled `rsync`'s transfer (NOT a fork/pipe IPC deadlock, which
-  all works). rsync's one IO multiplexer `perform_io()` (io.c) always passes an
-  exceptfds set (`FD_SET(iobuf.in_fd, &e_fds)`), and its error handling only
-  special-cases `EBADF`; the ENOSYS was treated as transient, so it zeroed the
-  fd sets and looped into a pure-compute 100% CPU spin with ZERO syscalls (verified
-  via strace + WASI trace), hanging on the first IO (the version exchange).
-- Fixed: `sysroot/libc-select-exceptfds.patch` makes `pselect()` ignore
-  exceptfds (and `FD_ZERO` it) instead of failing. Verified: `rsync -rv src/
-dst/` now transfers all files correctly (`diff -rq src dst` clean, incl. nested
-  dirs). Fixes every select+exceptfds caller, not just rsync. Upstream this to
-  wasix-org/wasix-libc and drop the patch once merged.
+- Symptom: wasix-libc returned ENOSYS whenever `select()` or `pselect()`
+  received non-empty `exceptfds`. Rsync treated it as transient and spun before
+  its first transfer.
+- Fix: `sysroot/libc-select-exceptfds.patch` clears and ignores `exceptfds`,
+  which is sufficient for defensive callers such as rsync. True exceptional-fd
+  semantics still require runtime support. The rsync copy test passes; upstream
+  the libc patch and drop it once merged.
 
 ### rsync copies files but hangs at exit: SIGUSR2 ignored for forked children 🟢
 
-- With the select fix, rsync completes the whole transfer (files land correctly)
-  but never exits. Root cause: rsync's shutdown is signal-driven, so the sender /
-  generator processes only terminate when they receive SIGUSR2 (`main.c`
-  `sigusr2_handler` -> `_exit(0)`), and the receiver does `kill(pid, SIGUSR2)`
-  then `wait_process`. Under wasix the runtime logs `state::env: Signal ignored
-pid=3 sig=Sigusr2` for the forked children, so nobody exits and all three
-  processes (pid1 -> waits pid2 -> waits pid3) spin in a `proc_join` poll-loop
-  (verified: 1073 `proc_join` + a 21ms-timeout `poll_oneoff` clock loop, no
-  `proc_exit`).
-- Precise mechanism (two layers, both in the wasix-org forks):
-  - wasmer `lib/wasix/src/state/env.rs` `process_signals_and_exit` only invokes
-    the guest handler when `inner.signal_set` is true; otherwise a non-fatal
-    signal is "ignored". `signal_set`/`signal` (the `__wasm_signal` export) are
-    set ONLY by the `callback_signal` syscall (`syscalls/wasix/callback_signal.rs`).
-    `WasiEnv::fork()` builds the child with `inner: Default::default()`
-    (`signal_set=false`, `signal=None`) and `proc_fork` never re-propagates them
-    so a forked child's instance has no signal callback.
-  - wasix-libc `libc-top-half/musl/src/signal/sigaction.c` calls
-    `__wasi_callback_signal("__wasm_signal")` exactly once, guarded by the static
-    `__eintr_callback_registered` (CAS 0->1). fork copies that static into the
-    child's memory as already-set, so the child's libc never re-registers. rsync
-    forks via the raw `__wasi_proc_fork` shim (no libc `fork()` wrapper), so
-    there is no atfork hook to reset it either.
-- Fixed: `patches/wasmer-signal-inherit-on-fork.patch` makes `proc_fork` inherit
-  the signal disposition. It captures the parent's `signal_set` before forking, and
-  in the child (proc_fork.rs `run`, once the instance is live) re-resolves
-  `__wasm_signal` and sets `inner.signal`/`inner.signal_set` when the parent had
-  it. Matches POSIX (fork inherits handlers); fixes every fork+signal program.
-  Layered onto the wasmer input via the flake's `overrideAttrs` patch list.
-  Verified: under the patched wasmer `rsync -a src/ dst/` exits 0 (was 124/hang)
-  with files copied and the final stats summary printed; stock wasmer still hangs
-  (control). Upstream to wasmerio/wasmer and drop the patch once merged.
+- Symptom: rsync copied every file but hung at exit because SIGUSR2 was ignored
+  by its forked sender and generator. `proc_fork` did not propagate the guest
+  signal callback, while libc's copied registration flag prevented the child
+  from registering it again.
+- Fix: `patches/wasmer-signal-inherit-on-fork.patch` makes `proc_fork` inherit
+  and re-resolve the callback. `rsync -a` now copies and exits successfully.
+  Upstream to wasmer and drop the patch once merged.
 
 ## Registry
 
@@ -821,28 +705,28 @@ embeds neither the version nor `[package.metadata]`: `wasmer package build`
 emits byte-identical webcs for `x`, `x+meta`, `x-pre`, and any
 `package.metadata` contents (verified with kilyanni/crabsay), and publishing
 `x+meta` over an existing `x` exits 0 without tagging anything (verified on
-wasmer.wtf). Prereleases would tag as distinct versions but never resolve
-(see below). So a changed webc at an unchanged upstream version cannot be
+wasmer.wtf). Prereleases would tag as distinct versions but never resolve (see
+below). So a changed webc at an unchanged upstream version cannot be
 republished, and the `wasix-rel` recorded in `[package.metadata]` is
-source-manifest plumbing only; a rel bump does not change the published
-artifact at all yet. Needs a registry-side decision: treat build metadata as
-version identity, or bless the CLI's `--bump` patch-bump convention (and
-ideally stop stripping `package.metadata`). Wheels are unaffected (PEP 440
-`+wasix.N`, own index).
+source-manifest plumbing only; a rel bump does not change the published artifact
+at all yet. Needs a registry-side decision: treat build metadata as version
+identity, or bless the CLI's `--bump` patch-bump convention (and ideally stop
+stripping `package.metadata`). Wheels are unaffected (PEP 440 `+wasix.N`, own
+index).
 
 Also: `wasmer publish` retries a `permission denied` GraphQL failure
 indefinitely (one attempt every ~2s until killed); a hard auth error should
-abort. Hit with a wasmer.io token against wasmer.wtf; tokens are
-per-registry.
+abort. Hit with a wasmer.io token against wasmer.wtf; tokens are per-registry.
 
 ### a prerelease-only package never resolves 🔴
 
 `wasmer run <owner>/<pkg>` with no version cannot reach a package whose only
 published versions are prereleases, so `1.2.4-unstable.2026.7.6` for a VCS
 snapshot is unusable today. This is client-side, not a registry decision: the
-resolver fetches every version (`lib/wasix/src/runtime/resolver/
-backend_source.rs`, the `getPackage { versions { ... } }` query, so not the
-API's `lastVersion`), an absent version becomes `VersionReq::STAR`, and
+resolver fetches every version
+(`lib/wasix/src/runtime/resolver/ backend_source.rs`, the
+`getPackage { versions { ... } }` query, so not the API's `lastVersion`), an
+absent version becomes `VersionReq::STAR`, and
 `version_constraint.matches(&version)` filters locally. The `semver` crate
 deliberately excludes prereleases from a comparator that names none, which is
 cargo's rule, so `*` matches nothing here. `local_registry_source.rs` and
@@ -864,51 +748,27 @@ that is a prerelease. Bare `0-unstable-<date>` is encodable as `0.0.YYYYMMDD`
 
 ### upstream versions with more than three numeric components 🟡
 
-Semver has three fields and pandoc's PVP `3.7.0.2` has four. Truncating
-collides (`3.7.0.2` and `3.7.0.3` both land on `3.7.0`), and any fold that
-avoids the collision has to cover the package's whole version history to stay
-monotone: transforming only the 4-component releases puts `3.7.0.2` above
-`3.7.1`. That makes it per-package knowledge, so `toSemver` now refuses and
-the package declares a rule in `passthru.wasmer.version` (a function of the
-upstream version, so it survives bumps). pandoc folds the PVP tail base-100,
-giving `3.7.0.2` -> `3.7.2` and `3.7.1` -> `3.7.100`.
+Semver has three fields and pandoc's PVP `3.7.0.2` has four. Truncating collides
+(`3.7.0.2` and `3.7.0.3` both land on `3.7.0`), and any fold that avoids the
+collision has to cover the package's whole version history to stay monotone:
+transforming only the 4-component releases puts `3.7.0.2` above `3.7.1`. That
+makes it per-package knowledge, so `toSemver` now refuses and the package
+declares a rule in `passthru.wasmer.version` (a function of the upstream
+version, so it survives bumps). pandoc folds the PVP tail base-100, giving
+`3.7.0.2` -> `3.7.2` and `3.7.1` -> `3.7.100`.
 
-Nothing to fix upstream; noted because the next four-component package will
-hit the throw and needs to know why truncating is not the answer.
+Nothing to fix upstream; noted because the next four-component package will hit
+the throw and needs to know why truncating is not the answer.
 
 ### anybuild pins a python runtime our wheels cannot load 🟡
 
-`crates/anybuild/src/run/wasmer.rs` maps a `python@3.13` dependency onto
-`python/python@=3.13.5`. An app built against our wheel index installs cp313
-`wasix_wasm32` wheels, and that runtime cannot load them: a FastAPI app dies at
-startup with `ModuleNotFoundError: No module named
-'pydantic_core._pydantic_core'`, while the identical `site-packages` imports
-fine under this repo's own `python313` webc.
-
-The published interpreter is built without threads, so its import machinery
-accepts `['.cpython-313-wasm32-wasi.so', '.abi3.so', '.so']`. Ours has threads,
-puts `-threads` in the platform triple, and its wheels ship
-`_pydantic_core.cpython-313-wasm32-wasi-threads.so`, which is on neither list.
-The file is simply never a candidate; nothing is dlopened and no ABI error is
-raised, hence the bare "no module named". abi3 extensions (`.abi3.so`) carry no
-triple and do load on both, so a wheel set is only partly broken.
-
-Substituting ours needed two shapes our webcs did not have, both since fixed in
-`overlay/packages/python3`: a wasmer manifest rejects a dependency whose name
-carries a dot, so the versioned interpreters are `wasmer/python313` and
-`wasmer/python314` rather than `wasmer/python3.13`; and a consumer's manifest
-refers to an interpreter as `<package>:python`, so the module (and therefore the
-atom) is `python` while the command keeps its version.
-
+- Symptom: an anybuild app using our cp313 wheels fails to import native
+  modules, for example `pydantic_core._pydantic_core`. The published
+  `python/python@=3.13.5` runtime does not recognize the `-threads` extension
+  suffix used by our wheels; abi3 modules still load.
+- Consequence: anybuild cannot run apps containing interpreter-specific wheels
+  from this repository with its pinned Python runtime.
 - Workaround: the serve check substitutes our own interpreter through the
   vendored `ANYBUILD_WASMER_PACKAGE_<DEP>` knob plus `--include-webc`.
 - Fix: republish `python/python` from a threads-enabled interpreter (this
-  repo's), or point anybuild's mapper at the package we publish. Not a wheel
-  fix: the `-threads` triple is what the wheels are built for, and a wheel set
-  is only usable on an interpreter whose `EXT_SUFFIX` matches.
-
-Both anybuild knobs the tests lean on are vendored patches, not upstream:
-`python_index_url` (`ANYBUILD_PYTHON_INDEX_URL`), because the cross-wheel steps
-hardcode `--index-url=https://pypi.org/simple` and bake it into
-`cross-requirements.txt`, and `ANYBUILD_WASMER_PACKAGE_<DEP>` above. Both live
-in `pkgs/products/anybuild/` and should go upstream to wasmerio/anybuild.
+  repo's), or point anybuild at the versioned interpreter package we publish.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,251 +1,77 @@
 # Architecture
 
-`pkgs/default.nix` wires five layers together, bottom to top.
+`pkgs/default.nix` composes the repository from toolchains, profile package
+sets, overlays, products, and publishable outputs.
 
-## 1. Toolchain (`pkgs/toolchain/`)
+## Toolchains and package sets
 
-All built from source, following the upstream projects' own build scripts.
+`pkgs/toolchain/` builds the language toolchains. `pkgs/profiles.nix` defines
+the ABI profiles, and `pkgs/set/mk-pkgs.nix` imports nixpkgs once per profile
+with the corresponding WASIX stdenv and language builders.
 
-- `llvm.nix`: the `wasix-org/llvm-project` fork, built with nixpkgs' LLVM
-  machinery. Two version numbers: the fork's release tag (the pin) and
-  `llvmVersion`, the base version nixpkgs uses to pick its patches (see
-  `docs/updating.md`).
-- `sysroot/`: per profile, wasix-libc, then compiler-rt, then
-  libc++/libc++abi/libunwind, each staged against the previous parts
-  (mirrors wasix-libc's `build32-general.sh`). Per-profile compiler flags
-  come from cmake toolchain files committed in wasix-libc, not duplicated
-  here. Result: one sysroot dir per profile; wasixcc picks at compile time.
-- `wasixcc.nix`: the WASIX compiler driver (invokes clang, wasm-ld,
-  wasm-opt), one wrapper per tool name since the binary dispatches on
-  `argv[0]`.
-- `rust/`: the `wasix-org/rust` fork built with `x.py`, including its bundled
-  LLVM (the fork's wasm patches aren't in stock LLVM). `vendor.nix` builds
-  the offline cargo registry from the fork's lockfiles; `cargo-wasix.nix` is
-  the cargo subcommand that drives WASIX builds.
-- `env.nix`: all `WASIXCC_*` variables as data; every consumer (wrappers,
-  stdenv, dev shell) renders from it.
+Each profile is a complete nixpkgs package set. Overriding a dependency there
+therefore affects everything in that profile that consumes it. The language
+details live in:
 
-## 2. Profiles and cross sets (`pkgs/profiles.nix`, `pkgs/set/`)
+- [`c.md`](c.md): LLVM, sysroots, wasixcc, profiles, and the cross stdenv
+- [`rust.md`](rust.md): the Rust toolchain, cargo-wasix, crate edits, and the
+  cargo registry
+- [`python.md`](python.md): CPython, Python package overlays, and wheels
 
-A profile is one ABI configuration: wasm exception-handling mode plus PIC or
-not. Five exist: `eh`, `ehpic`, `exnrefEh` (default), `exnrefEhpic`, `off`.
-`off` has no wasm EH; setjmp/longjmp and fork go through asyncify instead
-(bash needs this). PIC is what dynamic linking (Python extensions) requires.
-`profiles.nix` is the single definition; platform attributes, sysroot flag
-encodings, directory names, and the platform-to-name lookup all derive from
-it.
+## Products and overlays
 
-`set/mk-pkgs.nix` imports nixpkgs once per profile with a wasixcc stdenv
-swapped in (`config.replaceCrossStdenv`, `set/stdenv.nix`). Each profile is a
-real nixpkgs package set, so overriding `zlib` fixes everything that links
-zlib. `set/rust-platform.nix` does the same for Rust: `cargo build` is routed
-through cargo-wasix, `buildRustPackage` gets WASIX defaults, and a maturin
-hook covers Python wheels with Rust extensions. Rust only has a std for `eh`
-and `ehpic`.
+`pkgs/products/<name>/package.nix` is the shared recipe for a product built both
+natively and with a WASIX host. Its overlay is applied to the native set and,
+before the WASIX overlay, to every profile set. The same recipe receives the
+appropriate `stdenv`, `rustPlatform`, and dependency splice from its scope.
 
-## 3. Product recipes and the package overlay
+WASIX-specific policy lives in `pkgs/overlay/`: patches, flags, runtime
+dependencies, wasm command names, webc configuration, and tests. An entry
+normally adapts `prev.<name>` rather than duplicating its recipe. Entries are
+loaded from `trivial.nix`, a flat `<name>.nix`, or `<name>/package.nix` by
+`pkgs/lib/load-packages.nix`.
 
-`pkgs/products/<name>/package.nix` contains the standard recipe for each product
-provided both natively and with a WASIX host. Its overlay is applied to the
-native package set and, before the WASIX overlay, to every profile set. The
-same recipe therefore receives the native or WASIX `stdenv`, `rustPlatform`,
-and dependency splice from its package-set scope. The native result is an
-independent product, never `buildPackages` taken from a cross set.
+Packages declare support through `passthru.wasix`:
 
-Target-specific product policy remains in `pkgs/overlay/packages/`: WASIX
-patches and flags, `passthru.wasix`, runtime dependencies, wasm command names,
-webc configuration, and WASIX tests. These entries are adapters, not duplicate
-recipes. A product's overlay entry derives from
-`prev.<name>`, the shared recipe instantiated by the preceding overlay.
+- `supportedProfiles`: profiles the package supports
+- `preferredProfile`: its default profile
+- `ciProfiles`: the supported subset built continuously
+- `broken`: a defect and its reason
 
-`packagesByProfile` exposes every package under every supported profile.
-`passthru.wasix.ciProfiles` narrows only continuous-build coverage; it never
-hides a supported build. It defaults to the explicit `preferredProfile` when
-one is declared, to the effective preferred profile for shipped products, and
-otherwise to all supported profiles. The transposed `ciPackagesByProfile` set
-is internal CI wiring, not another public package taxonomy.
+`packagesByProfile` exposes every supported build. CI uses the transposed
+`ciPackagesByProfile`; it does not define another package taxonomy.
+`preferredProfilePackages.<name>` supplies the canonical WASIX build for runtime
+dependencies that may use another profile.
 
-`pkgs/overlay/` otherwise holds all WASIX package adaptations. Each overrides
-its nixpkgs or product counterpart (`prev.<name>`). Entries are found by
-`pkgs/lib/load-packages.nix`: a name in `trivial.nix`, a flat `<name>.nix`,
-or a `<name>/package.nix` dir. The same loader produces the package name list
-used elsewhere.
+## Webc packaging
 
-Packages declare where they work in `passthru.wasix`: `supportedProfiles`
-(default all five; unsupported profiles skip the package silently),
-`preferredProfile` (default `exnrefEh`, else the first supported), and
-`broken = "reason"` for defects (usage in `docs/packaging.md`).
-
-`applyWasixMeta` translates this into `meta.badPlatforms`/`meta.broken`;
-nothing else sets those. `preferredProfilePackages.<name>` is each package at its
-preferred profile, used for cross-profile runtime dependencies: git runs
-bash, bash only builds in `off`, so git references `preferredProfilePackages.bash`
-(`nixpkgsByProfile.exnrefEh.bash` fails on purpose).
-
-## 4. Python (`overlay/packages/python3/`, `overlay/python-packages/`)
-
-CPython is built with dynamic linking so it can load C extensions, which
-needs PIC, so python3 is `ehpic`-only. Per-package fixes live in
-`overlay/python-packages/` (same conventions, plus `pyfinal`/`pyprev`).
-`wheels.nix` lists the shipped wheels; `pkgs/python-wheels.nix` turns it into
-build targets with import tests run under Wasmer.
-
-## 5. Webc packaging (`pkgs/wasmer/`)
-
-webc is Wasmer's package format. CLIs in `shippedCommands`
-(`pkgs/default.nix`) get a webc generated from the package (name from
-`meta.mainProgram`, commands from `bin/*.wasm`); deviations go in
-`passthru.wasmer`. `test-lib.nix` runs tests under Wasmer, usually diffing
-against the native tool.
-
-## 6. Cargo overlay registry (`pkgs/cargo-registry/`)
-
-The wasix rust builds carry their fork content as source patches
-(`pkgs/lib/wasix-crate-patches/`). Every rust build, `buildRustPackage` CLI or
-maturin/setuptools-rust wheel, gets its crates through
-`fetchCargoVendor`/`importCargoLock`, so the wasix `rustPlatform`
-(`set/rust-platform.nix`) wraps those to bake the patches into the vendored
-tree at vendor time (`apply-vendor-patches.sh`), one mechanism for every builder
-instead of a build-time hook. Each wrapper reads its vendor's crate set at eval
-(an IFD) and materializes only the patches for crates present, so editing one
-crate's patch only rebuilds vendors that contain it. Each package's own
-vendoring choice is kept (converting `fetchCargoVendor` to the granular
-`importCargoLock` form for cross-package crate sharing was tried and dropped:
-its per-crate structure is deeper to evaluate and overflowed nix's eval stack on
-the full python-registry closure). Two vendor shapes:
-
-- `importCargoLock` fetches each crate as its own `fetchCrate` derivation
-  (shared across the whole rust set); `patchFarm` mirrors that as a symlink
-  farm, materializing only the forked crates, so unpatched crates stay shared
-  store paths.
-- `fetchCargoVendor`'s one monolithic tree is patched by `patchInPlace`, which
-  appends the patch step to the vendor's OWN `buildCommand` rather than wrapping
-  it. That keeps `fetchCargoVendor`'s inner re-pointable `vendorStaging` FOD,
-  which two things reach into: the versioned-history rebase (`load-packages.nix`,
-  via the `wasixRebuildVendor` passthru) and packages that relocate a non-root
-  lock (cryptography/ddtrace override `vendorStaging.cargoRoot = "src/rust"`). A
-  package that re-points `cargoRoot` post-hoc leaves its root vendor unbuildable,
-  so it can't be IFD-scoped -- the full patch tree is applied at build time to
-  the re-pointed vendor instead.
-
-The wrappers are `lib.makeOverridable` so they keep the functor shape the
-cross-splice recurses on.
-
-A fork can add a _new_ crate dependency the consumer's lock lacks (the mio fork
-pulls in the `wasix` crate). The fork declares it in its `wasix.nix` `adds`
-(collected into `cratePatches.adds`), and injecting it is part of applying the
-fork -- the same `apply-vendor-patches.sh`
-pass that rewrites the crate's sources also drops the added crate into the vendor
-(fetched by its crates.io checksum, with its own `.cargo-checksum.json`) and
-writes the line into the vendor `Cargo.lock` via `amend-lock.py`. No package
-names it and nothing is wired per-package; every patched vendor gets its declared
-deps. Because that pass runs post-FOD (it extends the vendor's `buildCommand`),
-the `cargoHash` is untouched -- a fork-carrying wheel keeps nixpkgs' hash. The
-lock exists on two sides that nixpkgs' `cargoSetupPostPatchHook` cross-validates
--- the vendor's and the source lock the build's cargo actually reads -- so the
-source side is amended by `wasixLockAmendHook` (the vendor is a separate
-derivation from the build). Both use the same `amend-lock.py`, a no-op unless a
-declared adder crate is present, so they match and run on every build harmlessly.
-
-The overlay cargo registry
-(`cargo-registry.wasix.org`) serves the same forks to plain `cargo`, as
-`<upstream>+wasix.N` builds, so a project resolves forks by version instead
-of `[patch.crates-io]`. `pkgs/cargo-registry/` closes the loop from the
-patch tree, so the two can't drift:
-
-- **Mint** (`default.nix` -> `.#cargoRegistry`): the mint publishes one `.crate`
-  per version in `crates.json` (upstream crate + floor-selected patch + version
-  restamp, repacked deterministically). Versions are the unit; the patch a
-  version gets is floor-selected (patches are the fix mechanism, not the mint
-  unit). `crates.json` is the version set plus the hashes, generated by
-  `nix run .#scripts.crate-pins`, which resolves the crates.io releases matching
-  each crate's `edits.nix` `edited` constraint (a semver range: comparator terms,
-  comma-AND per element, the array OR-ed, e.g. `libc` `[">=0.2.177, <0.2.189"]`).
-  So the registry serves the range the vendor floor-covers; floor-selection fails
-  loud where no patch fits, and a resolved version in neither `edited` nor
-  `stock` hard-fails, so the coverage is self-checking. A version outside `edited`
-  is served stock from crates.io (no shadow limits); git-sourced crates
-  (`libdd-*`) are excluded and recorded, since the overlay only shadows crates.io.
-  `+wasix.N` numbers come from `rels.json` (shared with the python registry).
-- **Server**: the registry server (`wasix-org/cargo-registry`) is a normal
-  wasix package -- `overlay/packages/cargo-registry` ->
-  `wasmerPackages.wasix-cargo-registry`, cross-built and shipped as a webc, the
-  wasm it actually deploys as on Edge (never a native binary). Its dep tree
-  builds stock except `reqwest`, which needs the `browserWasm` transform to take
-  the native hyper backend instead of browser-fetch. Only its `Cargo.lock` is
-  ours: upstream's dogfoods the overlay, resolving every fork as
-  `<crate>+wasix.N` from cargo-registry.wasix.org, which `fetchCargoVendor`
-  (crates.io) can't fetch. `derive-lock.py` strips the `+wasix.N` suffix off
-  every version and dep ref and restores the crates.io checksum, giving
-  upstream's exact versions (not re-resolved forward); the vendor-time patches
-  re-apply the fork content, so the patch tree must cover those versions
-  (`derive-lock.py` prints the `+wasix` crate set to check coverage).
-- **Checks** (`.#checks.cargo-registry`): the mint's tarballs are well-formed
-  (manifest), cargo resolves a minted `+wasix.N` fork from a directory source
-  (consume), and no shadow limit collides with a fork build (shadowLimits). The
-  end-to-end serving path is checked with the server package, not here (below).
-- **Serve check** (`overlay/packages/cargo-registry/tests/serve.nix`, a test of
-  `wasmerPackages.wasix-cargo-registry`): the cross-built wasm server runs under
-  wasmer (`--net --volume`), a crate is published through its real publish API,
-  and native cargo resolves and compiles it from the server's live sparse index
-  over loopback HTTP -- the same wasmer `--net` + loopback pattern the git/curl
-  webc tests use, inverted (wasm server, native cargo client). Being a test of
-  the server, it fabricates its own minimal one-crate payload (like the git
-  test builds a tiny repo) rather than depending on the mint, so it needs no
-  wiring beyond the harness (wasmer + the run-by-name shim).
-- **Serve** (`.#scripts.cargo-registry-serve`): runs the wasm under wasmer
-  (`--net --enable-threads --volume`; `--volume` keeps the fsync rights
-  `--mapdir` denies), seeds it from the fresh mint via the real publish API
-  (`publish-crate.py`), and leaves it live with crates.io passthrough, for
-  building your own projects against the local forks instead of the public
-  deployment.
+`pkgs/wasmer/` turns shipped CLIs into webc packages. The default manifest uses
+`meta.mainProgram` and the package's `bin/*.wasm`; deviations belong in
+`passthru.wasmer`. Tests run under Wasmer through `pkgs/wasmer/test-lib.nix`.
 
 ## Flake outputs
 
-- `packages.<system>`: `wasixcc` (default), `cargo-wasix`, `anybuild`,
-  `wasix-rust-toolchain`, `wasmer-bin`, `wasix-{libc,llvm,compiler-rt,libcxx,sysroot}`.
-- `checks.<system>`: every `passthru.tests`: behavioural suites, toolchain
-  suites (`sysroot`, `wasixcc`, `rust`), wheel imports (`wheel-<attr>`),
-  per-profile ABI checks (`abi-<profile>`: built artifacts carry the
-  profile's EH feature, PIC relocation flavor, and module kind; see
-  `pkgs/toolchain/tests/abi-check.nix`), `treefmt`.
-- `apps.<system>.update`: the pin updater.
-- `legacyPackages.<system>`: the buildable trees, attr path = build target:
-  `toolchain.<part>`, `packagesByProfile.<profile>.<name>`,
-  `nativePackages.<name>`,
-  `wasmerPackages.<name>` (with `.pkg`, `.webc`, `.tests`),
-  `pythonWheels.<py>.<attr>`;
-  plus `nixpkgsByProfile`, `toolchainByProfile`, `pkgsCross`,
-  `allWasmerPackages`.
-- `ci`: the same trees flattened to dotted names, so a job name is a build
-  path. Unsupported/broken packages are filtered out before becoming jobs.
-  `scripts/ci-build.sh` runs it with nix-fast-build and incremental cache
-  upload. `scripts/eval-diff.py` diffs the eval (attr to drvPath) against the
-  base branch to surface what a PR rebuilds; maps are published to the cache
-  bucket (`eval-maps/<rev>.json`) on pushes to main. `scripts/content-diff.py`
-  then splits rebuilt outputs into bit-identical vs actually changed
-  (narinfo narHash compare; self-referential paths get normalized with `nix
-store make-content-addressed`). `scripts/ci-report.py` folds all that and
-  the JUnit results into the "Per-package status" check run and a sticky PR
-  comment (scripts/post-report.js): posted in-job for same-repo events (the
-  bot's pin-bump PRs never fire workflow_run), via test-report.yml for fork
-  PRs, where the in-job token is read-only.
+- `packages.<system>`: convenient development outputs; `wasixcc` is the default
+- `checks.<system>`: package tests plus generated ABI, wheel, and formatting
+  checks
+- `legacyPackages.<system>`: the complete build trees
 
-CA derivations were considered (early cutoff would show which rebuilds
-actually change outputs) and rejected for now: binary caches cannot serve
-the realisations layer, so CA outputs are unsubstitutable from R2
-([nix#11748](https://github.com/NixOS/nix/issues/11748), and no third-party
-cache server implements it either), `nix copy` does not reliably upload
-realisations ([nix#6623](https://github.com/NixOS/nix/issues/6623)),
-realisation signatures are not checked on registration
-([nix#11393](https://github.com/NixOS/nix/issues/11393)), and non-determinism
-produces conflicting realisations across builders while `--check` cannot
-detect it in CA mode ([nix#5336](https://github.com/NixOS/nix/issues/5336)).
-Revisit when 11748 and 11393 close (milestone:
-[ca-derivations stabilisation](https://github.com/NixOS/nix/milestone/35))
-and the toolchain is measured reproducible.
+The main legacy trees are `toolchain`, `packagesByProfile`, `nativePackages`,
+`wasmerPackages`, `pythonWheels`, `pythonRegistry`, `allWasmerPackages`,
+`scripts`, and `ci`. `flake.nix` is the exact inventory.
 
-## passthru namespaces
+`legacyPackages.<system>.ci` flattens the build trees to dotted job names.
+Unsupported and broken packages are filtered before becoming jobs.
+`scripts/ci-build.sh` builds and uploads them incrementally.
 
-`passthru.wasix.*` where it works · `passthru.wasmer.*` webc config ·
-`passthru.tests` standard nixpkgs · `passthru.pkg` the wasmer package · `passthru.webc` the built webc.
+CA derivations are not used because caches cannot reliably distribute or
+authenticate realisations
+([nix#11748](https://github.com/NixOS/nix/issues/11748),
+[nix#11393](https://github.com/NixOS/nix/issues/11393)).
+
+## Passthru namespaces
+
+- `passthru.wasix`: profile support and WASIX package policy
+- `passthru.wasmer`: webc configuration
+- `passthru.tests`: standard nixpkgs tests
+- `passthru.pkg` and `passthru.webc`: built Wasmer package outputs

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,196 @@
+# Building and checking
+
+Where builds run, how to build one thing, and how to check a change before it
+goes to CI.
+
+## Where builds run
+
+The toolchain and the full `.ci` sweep are expensive: local builds at that scale
+drive the machine into swap, and a stray system-default builder (a paid
+`nixbuild.net`) costs real money. Expensive builds go to a remote builder you
+control.
+
+`--builders ""` is not remote. It suppresses the configured default and then
+builds locally, which is the easiest failure mode to walk into.
+
+The builder is machine-specific, so it lives in a gitignored `.remote-builder`
+(copy `.remote-builder.example`). `scripts/remote-builder.sh` turns it into
+ready-made flags; never hardcode a host or key. Being gitignored it is missing
+in fresh worktrees, so copy it over from another one.
+
+```sh
+scripts/remote-builder.sh check     # configured and reachable?
+
+nix build <targets> --max-jobs 0 \
+  --builders "$(scripts/remote-builder.sh builders)" --builders-use-substitutes
+```
+
+`--max-jobs 0` is required, else nix still schedules jobs onto local slots or
+the system default.
+
+## Iterate with Spot first
+
+For a toolchain or low-level dependency change, start with
+`scripts/spot.sh <profile>.<attr>`. Spot rebuilds only the targets you name and
+the working-tree inputs you choose, while taking the rest from a cached base.
+This can turn a world-rebuilding change into a short compile-and-link check.
+
+Use `--dry-run` to see the cost before building. A green Spot build is useful
+iteration evidence, not final verification, because its output mixes the base
+and working-tree toolchains. See `docs/spot.md` for choosing the rebuild cut and
+the required full-build follow-up.
+
+## The cache and the full sweep
+
+```sh
+scripts/ci-build-remote.sh                     # signed, cache-pushing CI set; offloads eval too
+
+nix-fast-build --flake .#legacyPackages.x86_64-linux.ci --skip-cached \
+  --no-link --option accept-flake-config true \
+  --store "$(scripts/remote-builder.sh store)"
+```
+
+This is the same build set as CI (`scripts/ci-build.sh`).
+
+`--skip-cached` is what makes it survivable. It drops any job already in the
+binary cache, so those cost neither a build nor a download, where a plain
+`nix build` of the same target would substitute the whole closure into the local
+store. On a warm cache the sweep is an eval plus whatever the change genuinely
+rebuilds.
+
+That only holds while the change avoids mass rebuilds, and those are easy to
+trigger: anything under `pkgs/toolchain/` (except `llvm.nix`) rebuilds
+everything, as does a pin bump.
+
+## Let CI build it
+
+`build.yml` runs on every pull request and builds the whole package set, each
+package as its own job. So opening a PR is a legitimate way to build something
+you cannot build locally, and often the cheapest one.
+
+Results come back as a "Per-package status" check run and a sticky comment on
+the PR, upserted in place by `scripts/post-report.js`, so the report stays at
+one comment across pushes. Read that rather than rebuilding to find out what
+broke.
+
+## Eval is cheaper than building, not free
+
+`nix fmt` costs nothing and a single `nix eval` is moderate, both fine locally
+but not worth firing off in a loop.
+
+nix-eval-jobs is the one to watch. It fans out `--workers` evaluators, each with
+its own heap allowance (`--max-memory-size`, 4 GiB per worker by default), so
+the ceiling is workers times that allowance. One worker per core over the full
+`ci` set puts that in the tens of gigabytes, enough to swap or OOM a desktop.
+Size workers against free RAM rather than core count, and lower the allowance
+with them:
+
+```sh
+nix-eval-jobs --flake .#legacyPackages.x86_64-linux.ci --workers 4 --max-memory-size 2048
+EVAL_WORKERS=4 scripts/ci-build.sh
+```
+
+`scripts/ci-build.sh` reads `EVAL_WORKERS` (default `$(nproc)`) and passes it to
+both nix-eval-jobs and nix-fast-build. `ci-build-remote.sh` pins it to 8 for a
+separate reason: on a shared builder the workers contend on the one nix-daemon.
+
+## Build one thing
+
+A CI job name is a build path. These are example targets; the final command
+lists the complete set:
+
+```sh
+nix build .#packagesByProfile.exnrefEh.zlib
+nix build .#wasmerPackages.git.webc
+nix build .#pythonWheels.py314.numpy
+
+nix eval .#legacyPackages.x86_64-linux.ci --apply builtins.attrNames
+```
+
+For example, toolchain suites are available at `.#toolchain.wasixcc.tests`,
+`.#toolchain.sysroot.tests`, and `.#checks.x86_64-linux.rust`. Use
+`nix flake show` for the current check set.
+
+## Before you commit
+
+- New files must be tracked. Nix reads the working tree, so uncommitted edits to
+  tracked files are picked up as they are, but an untracked file does not exist
+  as far as the flake is concerned. `git add -N <file>` is enough: it registers
+  the path without staging its contents.
+- `nix fmt`. CI rejects unformatted files, and prettier covers markdown as well
+  as Nix.
+- For a behaviour-preserving refactor, diff the derivations. Semantic
+  equivalence is the bar, not identical drv paths, and meta or passthru changes
+  do not move them at all.
+
+  ```sh
+  nix eval .#legacyPackages.x86_64-linux.ci \
+    --apply 'j: builtins.mapAttrs (_: d: d.drvPath) j'
+  ```
+
+- A regression test must fail with the fix reverted. Run it both ways.
+- A build that compiles is not a working package. Check the artifact does what
+  it is for, and that it targets wasix.
+
+## Diagnosing a failure
+
+Read the log, do not rebuild to see the error again.
+
+```sh
+ssh "$(scripts/remote-builder.sh host)"
+nix log <drv>
+```
+
+A failed CI job is read from the CI report. nixbuild.net returns a cached
+failure link rather than a log; use the EC2 builder or
+`--option reuse-build-failures false` instead of falling back to a local build.
+
+When you do start a long build, print the logs and tee them to a file, so a
+failure is diagnosable without waiting for the whole build.
+
+## For agents
+
+The rest of this page assumes a person at a terminal. Three things work
+differently without one.
+
+**Ask where to build before you build, once, and remember the answer.** This
+page gives the general policy, but the right route depends on hardware you
+cannot see: how much they want built, and whether that goes to a local machine,
+a remote builder, one of several, or a PR so CI does it. Ask, then save the
+answer to memory so later sessions do not ask again or guess wrong. Re-ask only
+when the answer stops fitting, such as a builder that is no longer reachable.
+
+**A long build cannot live inside a single tool call.** It will outlast the
+call's timeout, and a truncated or interleaved transcript is not a log. Start it
+detached, tee the full output to a stable path, and say where that path is so
+the user can `tail -f` it:
+
+```sh
+nix build <targets> --max-jobs 0 \
+  --builders "$(scripts/remote-builder.sh builders)" --builders-use-substitutes \
+  -L > /tmp/wasinix-<what>.log 2>&1 &
+```
+
+Then poll the log rather than restarting the build. If you lose the handle, read
+the log to find out where it got to; never relaunch on the assumption it died.
+Watch for stalls too: judge progress by new output, and report "no output for N
+minutes on <phase>" instead of waiting silently or calling it finished.
+
+**A cached-failure link is a browser page.** nixbuild.net returns a link instead
+of a log, `nix log --store ssh://...` cannot retrieve it, and WebFetch gets
+nothing because the page loads its log by JS. The link nix prints already
+carries a read token, and the log itself is plain HTTP at `/builds/<id>/log`:
+
+```sh
+curl -s "https://nixbuild.net/builds/<id>/log?t=<token>" | python3 -c "
+import sys,re,html
+s = re.sub(r'<(style|script)\b.*?</\1>', '', sys.stdin.read(), flags=re.S|re.I)
+print(html.unescape(re.sub(r'<[^>]+>', '\n', s)))"
+```
+
+Strip `<style>`/`<script>` first or the page CSS lands in the output looking
+like log text. This is for diagnosing without an edit in hand; a drv that
+changed since the failure just builds normally.
+
+Cap `--workers` deliberately. You cannot feel the machine swapping, but the user
+can.

--- a/docs/c.md
+++ b/docs/c.md
@@ -1,0 +1,40 @@
+# C and C++
+
+How the C/C++ toolchain becomes the WASIX stdenv used by each profile. Package
+authoring is covered by [`packaging.md`](packaging.md).
+
+## Toolchain
+
+`pkgs/toolchain/` builds:
+
+- `llvm.nix`: WASIX's LLVM sources through nixpkgs' LLVM machinery
+- `sysroot/`: wasix-libc, compiler-rt, libc++, libc++abi, and libunwind, staged
+  into one sysroot per profile
+- `wasixcc.nix`: the compiler driver around clang, wasm-ld, and wasm-opt
+- `env.nix`: the canonical `WASIXCC_*` environment
+
+wasixcc selects the profile sysroot at compile time. Its executable dispatches
+on `argv[0]`, so the package installs one wrapper per tool name. Package files
+must use the environment rendered from `env.nix` instead of exporting
+`WASIXCC_*` or `CC=wasixcc` themselves.
+
+## Profiles
+
+A profile combines an exception-handling encoding with PIC or non-PIC output.
+For example, `exnrefEh` uses exnref EH, `ehpic` uses legacy Wasm EH with PIC,
+and `off` has no Wasm EH. PIC is required for dynamic linking. `fork()` requires
+asyncify in every profile; `off` also uses it for `setjmp` and `longjmp`.
+
+`pkgs/profiles.nix` is the profile inventory and derives platform attributes,
+sysroot flags, directory names, and name lookup from it.
+
+## Cross package sets
+
+`pkgs/set/mk-pkgs.nix` imports nixpkgs once per profile and replaces its cross
+stdenv with `pkgs/set/stdenv.nix`. Packages therefore keep ordinary nixpkgs
+build conventions while compiling through wasixcc. Override dependencies in the
+profile set rather than constructing a parallel package graph.
+
+Profile support and selection are described in
+[`packaging.md`](packaging.md#a-library). Known libc, runtime, and toolchain
+limitations are tracked in [`../WASIX-TODO.md`](../WASIX-TODO.md).

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,13 +1,15 @@
 # Adding a package
 
+Writing the recipe and its tests. Getting the result out to consumers, and
+keeping older versions rebuildable, is `docs/registry.md`.
+
 ## A package provided natively and for WASIX
 
-Put its standard nixpkgs-style recipe in
-`pkgs/products/<name>/package.nix`. The directory is enumerated
-automatically and the recipe is called in both the native package set and every
-WASIX profile set. Use ordinary function arguments such as `stdenv`,
-`rustPlatform`, and named dependencies; do not take a native build from a cross
-set's `buildPackages`.
+Put its standard nixpkgs-style recipe in `pkgs/products/<name>/package.nix`. The
+directory is enumerated automatically and the recipe is called in both the
+native package set and every WASIX profile set. Use ordinary function arguments
+such as `stdenv`, `rustPlatform`, and named dependencies; do not take a native
+build from a cross set's `buildPackages`.
 
 Keep the matching overlay entry. Put only WASIX-specific adaptation in
 `pkgs/overlay/packages/<name>/package.nix`, deriving from the preceding shared
@@ -20,11 +22,9 @@ helpers.libTweaks {
 } prev.foo
 ```
 
-Small source-build differences may derive from
-`stdenv.hostPlatform.isWasix` in the shared recipe. Bootstrap-sensitive
-compiler families instead share their source/version bundle between explicit
-native build-tool and WASIX-hosted builders; a hosted compiler must depend on
-the build toolchain, never the reverse.
+Where the native and WASIX builds differ in something small, branch on
+`stdenv.hostPlatform.isWasix` inside the shared recipe rather than forking it
+into two.
 
 The results are `nativePackages.<name>` and
 `packagesByProfile.<profile>.<name>`. `preferredProfilePackages.<name>` remains
@@ -36,11 +36,12 @@ Lightest form that works (the loader finds all of these):
 
 - No changes: name in `pkgs/overlay/trivial.nix`.
 - Changes, no extra files: `pkgs/overlay/packages/<name>.nix`.
-- Patches/tests: `pkgs/overlay/packages/<name>/` with `package.nix`,
-  `patches/`, `tests/`.
-- Version families (icu, icu-data): one dir whose `package.nix` evaluates to
-  `{names, packages}` instead of a function; `names` is the static attr list
-  it provides, `packages = callArgs: {<name> = drv;}`.
+- Patches/tests: `pkgs/overlay/packages/<name>/` with `package.nix`, `patches/`,
+  `tests/`.
+- Version families: one dir whose `package.nix` evaluates to `{names, packages}`
+  instead of a function; `names` is the static attr list it provides,
+  `packages = callArgs: {<name> = drv;}`. See `pkgs/overlay/packages/icu/` for
+  an example.
 
 A package file is a function over one argument set:
 
@@ -51,7 +52,18 @@ A package file is a function over one argument set:
 `prev.<name>` is the nixpkgs package, already compiling with the WASIX stdenv
 and resolving deps within the profile. `final.<dep>` names a same-profile dep
 explicitly. `preferredProfilePackages.<tool>` is for tools executed at runtime,
-which may need another profile (bash only builds in `off`).
+which may need another profile.
+
+Those two are the only ways a package file names a dependency. Reaching for
+`nixpkgsByProfile.<profile>.<dep>` from a package file pins a profile the
+package does not control; use `final` for linking and `preferredProfilePackages`
+for runtime tools.
+
+Patches live next to the file that applies them, so a package's patches belong
+in its own `patches/` directory and toolchain patches under `pkgs/toolchain/`.
+Do not vendor a file, lockfile, or bindist without stating the reason in the
+commit. Prefer nixpkgs plus a vendored patch over maintaining separate sources,
+and a version tag over a pinned hash.
 
 ## Tweaks
 
@@ -74,8 +86,8 @@ passthru.wasix.supportedProfiles = helpers.profiles.withoutPic;
 passthru.wasix.broken = "reason + upstream link";   # defect, not a limit
 ```
 
-CI coverage is separate from support. It defaults to every supported profile,
-or to the singleton explicit `preferredProfile` when one is declared. Shipped
+CI coverage is separate from support. It defaults to every supported profile, or
+to the singleton explicit `preferredProfile` when one is declared. Shipped
 products likewise default to their effective preferred profile. Override it
 without hiding the other supported builds:
 
@@ -94,14 +106,13 @@ matrix using the package declaration.
 ## A Rust CLI
 
 Usually `{ prev, ... }: prev.foo`; the WASIX rustPlatform builds it through
-cargo-wasix, installs the `.wasm`s, and limits it to `eh`/`ehpic`. For crates
-not in nixpkgs, call `final.rustPlatform.buildRustPackage` (see
-`packages/crabsay.nix`).
+cargo-wasix, installs the `.wasm`s, and limits it to `eh`/`ehpic`. Crates not in
+nixpkgs, crate edits, and the overlay registry: `docs/rust.md`.
 
 ## A CLI shipped as webc
 
-1. Rename the binary to `<name>.wasm` and declare it shipped
-   (`shippedCommands` in `pkgs/default.nix` is derived from the flag):
+1. Rename the binary to `<name>.wasm` and declare it shipped (`shippedCommands`
+   in `pkgs/default.nix` is derived from the flag):
 
    ```nix
    { prev, helpers, ... }:
@@ -110,15 +121,16 @@ not in nixpkgs, call `final.rustPlatform.buildRustPackage` (see
    } prev.foo)
    ```
 
-   Programs needing fork/setjmp set `env.WASIXCC_WASM_OPT_FLAGS =
-"--asyncify:-O2"` so wasixcc asyncifies at link (see `find`, `gitMinimal`).
+   Programs needing `fork()` or `setjmp` set
+   `env.WASIXCC_WASM_OPT_FLAGS = "--asyncify:-O2"` so wasixcc asyncifies at link
+   time.
 
-2. The webc manifest is generated; most packages need zero config. Deviations
-   go in `passthru.wasmer`: `name`, `version`, `commands` (aliases),
+2. The webc manifest is generated; most packages need zero config. Deviations go
+   in `passthru.wasmer`: `name`, `version`, `commands` (aliases),
    `fs."<path>" = <store path>`, `commandEnv.<cmd>`, `autoSelfMount` (mount
-   store paths found in the wasm), `selfMounts` (paths referenced from
-   scripts, which autoSelfMount can't see). See git's package.nix for a full
-   example.
+   store paths found in the wasm), `selfMounts` (paths referenced from scripts,
+   which autoSelfMount can't see). See git's package.nix for an example with
+   several deviations.
 
    Runtime webc dependencies accept a derivation or an attrset containing
    `package` and `version`. The helpers derive requirements from the package's
@@ -138,174 +150,31 @@ not in nixpkgs, call `final.rustPlatform.buildRustPackage` (see
    explicit `{ package = drv; version = "..."; }` for another semver range.
 
 3. Ship an older release too (a version consumers pin): see
-   [Registry history](#registry-history).
-
-## Publishing to the registry
-
-`nix run .#scripts.publish-webc -- --registry wasmer.io [name...]` builds the
-named webcs (none = all shipped) and publishes those the registry does not
-already have (`--dry-run` previews). Existing versions are hash-verified
-against the registry, so a changed webc under an unchanged version fails
-loudly; republishing one needs a rel encoding the registry supports, which
-does not exist yet (WASIX-TODO.md). Auth: `wasmer login` or `WASMER_TOKEN`.
-Packages publish in dependency
-order; a webc dependency that is neither published nor part of the run is an
-error. Failures are isolated per package and reported at the end. Webcs publish under `wasmer/` on
-wasmer.io (the owner default in `make-wasmer-package.nix`). The `publish-webc`
-workflow runs the same script, manual dispatch only, with the `WASMER_TOKEN`
-secret. Provenance rides the package README on the registry: the generated
-README carries the attr and rel, and the publish step appends the source rev
-and a rebuild command. Verification restages the local build with the
-recorded rev to reproduce the published bytes, then compares registry hashes
-(`wasmer publish` can exit 0 without tagging, WASIX-TODO.md).
-
-## Registry history
-
-Both registries are append-only and never delete, so a version we publish stays
-installable forever; a history entry keeps an older version REBUILDABLE too (for
-a version consumers still pin, so a regenerated lockfile resolves to it, or to
-rel-bump it against a toolchain fix). It works the same for every package set,
-one shared table shape, one file per set:
-
-- wheels: `overlay/python-packages/history.json`
-- CLIs / libraries: `overlay/packages/history.json`
-
-Keyed `{<attr>: {<version>: <spec>}}`. The spec re-points the package's OWN src
-fetcher at that version (its real fetcher, never an imposed one): `{version,
-hash}` for `fetchPypi`, `{tag|rev, hash}` for `fetchFromGitHub`, `{url, hash}`
-for a `fetchurl` release tarball, plus `cargoHash` when the package vendors
-rust crates (they come from the Cargo.lock in that src, so the vendor follows
-it; `scripts/history.py` derives the hash); plus optional `note` and `variants` (the
-set-neutral gate: the build variants an entry is limited to; for wheels a
-variant is an interpreter, e.g. `["py313"]`; a single-variant set like CLIs
-omits it).
-
-The loader (`load-packages.nix`) mints a `<attr>_<version>` attr in the same
-set by re-importing the package file with the src rebased, so the package's own
-`lib.version*` conditionals carry the per-version drift (see `numpy.nix`,
-`jq/package.nix`). Drift the generic rebase can't cover is corrected in the
-package file, which reads the entry back off
-`passthru.wasix.historySpec` (see `cryptography.nix`, which drops nixpkgs'
-patches on any version they weren't written for). Wheels build at `.#pythonWheels.py313."numpy-2.1.3"`; a
-webc keys `wasmerPackages` as `<name>-<semver>` (`jq-1.6.0`) and publishes
-under the same webc name. The run-by-name stubs are keyed the same way, so a
-test asks for an older build by key: `wasmerPkgs."jq-1.6.0"`.
-
-Maintain the tables with `nix run .#scripts.history`: `add <attr>==<version>`,
-or `--per-major`/`--per-minor` where the source has a version index (PyPI, or
-github tags for a `fetchFromGitHub` package); `--set wheel|cli` disambiguates a
-name in both sets (jq). A nixpkgs bump that crosses a major auto-appends the
-outgoing version, for both sets (`scripts/update.py`). A package tunes this with
-`passthru.wasix.retention`: `minor` retains latest-per-minor, `none` opts out
-(icu-data, whose majors are already first-class attrs). Keep history to what
-consumers actually pin: latest per major, occasionally latest per minor.
-
-(icu-style `{names, packages}` families are only for packages nixpkgs itself
-carries at multiple versions, not for minting historical ones. Their major list
-tracks nixpkgs: icu declares `passthru.wasix.retentionHook =
-["…/sync-versions.py"]`, which `scripts/update.py` runs after a bump to
-regenerate `icu/versions.nix` from the majors the pinned nixpkgs actually
-carries.)
-
-## PR previews
-
-Label a same-repo PR `preview`: after its Build goes green (the CI cache
-then serves every artifact; labeling an already-green PR triggers
-immediately), `preview.yml` diffs it against its base at the drvPath level
-(`scripts/preview-diff.py`) and publishes what changed.
-Webcs go to the dev registry as `<version>-pr<N>.g<sha7>` prereleases:
-distinct versions per iteration, hidden from `latest`, not deletable (they
-accumulate on wasmer.wtf). Changed wheels become an ephemeral per-PR Edge
-app serving an overlay index; `pip install --index-url <preview>/simple
---extra-index-url <prod>/simple` prefers the preview wheels by their longer
-local version. The app is deleted when the PR closes or drops the label
-(`preview-cleanup.yml`), and the PR gets a comment with the URLs.
+   [Registry history](registry.md#registry-history).
 
 ## A Python package or wheel
 
 - Ship a wheel: add `{attr = "<python3.pkgs name>";}` to
-  `overlay/python-packages/wheels.nix` (`pyImport` if the module name
+  `pkgs/overlay/python-packages/wheels.nix` (`pyImport` if the module name
   differs). Most need nothing else; test phases are already skipped by cross.
-- Fix a build: `overlay/python-packages/<attr>.nix`, same form as top-level
-  plus `pyfinal`/`pyprev` for Python-set deps. Patches in
-  `python-packages/patches/`, Rust-wheel helpers in `python-packages/lib/`.
+- Fix a build: `pkgs/overlay/python-packages/<attr>.nix`, same form as top-level
+  plus `pyfinal`/`pyprev` for Python-set deps. Patches live in
+  `pkgs/overlay/python-packages/patches/`; Rust-wheel helpers live in
+  `pkgs/overlay/python-packages/lib/`.
 - Ship an older release too (a version consumers pin): see
-  [Registry history](#registry-history).
+  [Registry history](registry.md#registry-history).
 - Which wheel to add next, and what it unblocks: `python-coverage.md`.
-
-All shipped wheels (plus their transitive python deps) are also published as a
-static PEP 503 "simple" index: `.#pythonRegistry` (`pkgs/python-registry/`).
-Serve the output from any static file host, or install directly:
-`pip install --index-url file://$(readlink -f result)/simple <pkg>`. A new
-wheels.nix entry lands in the registry automatically. Its test suite
-(`checks.python-registry`) walks the index for hash/metadata integrity and
-pip-installs representative packages (deps resolved from the index too), then
-imports them under wasmer.
-
-The index is also what anybuild resolves an app's wasix wheels from, as its
-overlay index over PyPI. `checks.anybuild` builds anybuild's own example
-templates against it: the wasix build plans all of them and builds the static
-ones, and native anybuild builds the python ones for real, with the registry
-and a pinned PyPI mirror both served over loopback so nothing leaves the
-sandbox. One built app is then booted under wasmer and asked for a page, on each
-interpreter the registry serves wheels for, with its serve-time packages
-supplied from the store since anybuild's own pinned interpreter cannot load
-these wheels (WASIX-TODO.md). The template sweep itself stays on 3.13, the
-version anybuild's provider pins: the templates' own requirements decide what
-can resolve, and python-flask pins a MarkupSafe with no cp314 wheel.
-
-The mirror is `pkgs/overlay/packages/anybuild/tests/mirror-lock.json`,
-regenerated by `nix run .#scripts.anybuild-mirror` (one version per project, so
-the resolution inside the test has no choice left to make); add a template to
-its `templates` list and re-run to cover it. It is also anybuild's
-`retentionHook`, so an anybuild bump re-resolves the pins against that release's
-`examples/`, and a template whose dependencies moved past what the wheel index
-serves fails on the bump PR.
-
-Every wheel is published as `<version>+wasix.<rel>` (PEP 440 local version):
-`rel` counts our builds of one upstream version and comes from the root
-`rels.json`, keyed by attr path (`pythonRegistry.wheels.<pname>`,
-`wasmerPackages.<name>` for webcs) then version, default 1, shared across
-python versions (the cp tag keeps filenames distinct). Bump it to republish a
-changed build, with `nix run .#scripts.bump-rel` or the manual `bump-rel.yml`
-workflow (takes a list of packages, opens a PR); an upstream version bump
-resets it by key miss (`nix run .#scripts.update` drops the stale key).
-For a deliberate whole-registry rebuild, use `nix run .#scripts.bump-rel --
---all-versions 'pythonRegistry.wheels.*'`; the flag also bumps every served
-history version, so it remains explicit.
-Published filenames are immutable and accumulate. A normal registry rebuild can
-change the bytes of an existing filename through a nixpkgs, toolchain, or
-runtime update; the volume keeps its original artifact in that case. Bump the
-rel only when that rebuilt wheel is itself a release. GitHub Pages is different:
-it is always deployed from the fresh `.#pythonRegistry` result, so it is a
-bleeding-edge snapshot and may serve new bytes under an existing filename. Use
-the volume-backed index for immutable, reproducible installs. Webc rels land in
-`[package.metadata] wasix-rel` only for now: the registry has no version
-encoding for republishing (WASIX-TODO.md), so a bumped webc still cannot
-republish. The `publish-index` workflow (on a green Build of
-main) builds the patched wasmer, fetches the volume's S3 credentials with the
-`WASMER_TOKEN` secret (provisioning them on the first run via the vendored
-`rotateS3Credentials` fix), pushes only new wheel filenames with `publish.py`,
-and deploys the fresh snapshot to GitHub Pages even if volume publication
-fails. The Edge app serving the volume is
-`python-registry/app.yaml` (static-web-server, deployed once by hand).
-
-Each wheel's `manifests/<wheel>.json` (served from the volume) records its
-build provenance: `wasinix_rev`, `attr`, and `drv_path`. So any wheel is
-reproducible with `nix build github:wasix-org/wasinix/<wasinix_rev>#<attr>`
-(e.g. `#pythonRegistry.wheels.numpy^dist`); every closure wheel, transitive
-deps included, is exposed under `pythonRegistry.wheels`.
 
 ## Tests
 
 `pkgs/overlay/packages/<name>/tests/*.nix`, each returning an attrset of
 derivations built with `pkgs/wasmer/test-lib.nix` (a `helpers.nix` is shared
-setup). They attach as `passthru.tests` and appear under `checks.<name>`.
-Besides `pkgs`/`testLib`/`wasmerPkgs`, test files can take `crossPkgs` (the
-default-profile cross set) and `makeWasmerPackage` to cross-build and package
-a consumer program (see icu-data's smoke test).
-`mkScriptComparison` diffs against the native tool; `expectFail` marks a
-must-fail test; `broken "reason"` tolerates a known failure and fails loudly
+setup). They attach as `passthru.tests` and appear under
+`checks.<system>.<name>`. Besides `pkgs`/`testLib`/`wasmerPkgs`, test files can
+take `crossPkgs` (the default-profile cross set) and `makeWasmerPackage` to
+cross-build and package a consumer program. See icu-data's smoke test for an
+example. `mkScriptComparison` diffs against the native tool; `expectFail` marks
+a must-fail test; `broken "reason"` tolerates a known failure and fails loudly
 once it starts passing.
 
 To run tests against a locally built runtime instead of the pinned one:
@@ -313,9 +182,14 @@ To run tests against a locally built runtime instead of the pinned one:
 
 ## Pitfalls
 
-- `nix build` reads the git-tracked tree; `git add` new files first.
+- Nix only sees git-tracked files, so `git add -N` a new one before building
+  (`docs/building.md`).
 - Off-only packages fail in other profiles on purpose; use
   `preferredProfilePackages`.
 - `configure` misdetecting features can be wasm-opt failing on test programs:
   add `disableWasmOptInConfigureHook` to `nativeBuildInputs`.
-- Check `WASIX-TODO.md` before debugging odd runtime behaviour.
+- Odd runtime behaviour, such as unexpected exit codes or output formatting, is
+  usually a known WASIX quirk rather than a bug in the package, so check
+  `WASIX-TODO.md` first. Older entries are still being triaged onto its entry
+  format, so verify one against the current toolchain before relying on it.
+  Adding an entry follows the format in that file's header.

--- a/docs/python-coverage.md
+++ b/docs/python-coverage.md
@@ -34,11 +34,10 @@ closure is published. Against the current registry closure (215 wheels):
 
 Out-of-scope packages are excluded from the denominator; see below.
 
-The shipped native set is the registry closure, not `wheels.nix`: transitively
-pulled deps (pyyaml, fonttools, wrapt, websockets, brotli) publish without a
-worklist entry. Per-package build details live in each
-`overlay/packages/<pkg>.nix` / `overlay/python-packages/<pkg>.nix` and the
-commit that added it.
+The shipped native set is the registry closure, not `wheels.nix`: transitive
+dependencies publish without a worklist entry. Per-package build details live in
+each `pkgs/overlay/packages/<pkg>.nix` /
+`pkgs/overlay/python-packages/<pkg>.nix` and the commit that added it.
 
 ## Recompute
 
@@ -69,25 +68,18 @@ more than the next six combined.
 
 ## Out of scope
 
-Declared, not attempted. Roughly 3% of the top-10k.
-
-- GPU and CUDA: `torch`, `triton`, `nvidia-*`, `cuda-*`, `jaxlib`,
-  `torchvision`, `torchaudio`, `onnxruntime` (GPU), `tensorflow`, `vllm`,
-  `sglang`, `flash-attn`, `xformers`, `deepspeed`. No GPU under wasmer, and
-  these publish binary-only wheels regardless.
-- macOS frameworks: all `pyobjc-*`. Never pulled on a wasix target anyway;
-  they appear in the survey only because it evaluates markers for linux.
-- Runtime JIT: `llvmlite` and `numba` (49 and 47) need an LLVM JIT at runtime.
-- `libclang` (22), `playwright` (17): bundled toolchain or browser payloads.
+Declared, not attempted. Roughly 3% of the top-10k. Categories include GPU and
+CUDA packages, macOS frameworks, runtime JITs, and bundled toolchain or browser
+payloads. The survey data owns the package inventory.
 
 ## Demand side
 
-Unblocking a native package does not by itself publish the packages it
-unblocks. They reach the registry only as the closure of something in
-`wheels.nix`. Two ways to close that gap:
+Unblocking a native package does not by itself publish the packages it unblocks.
+They reach the registry only as the closure of something in `wheels.nix`. Two
+ways to close that gap:
 
-- Curated apps, the current model: add top-level packages, deps ride along.
-  Good signal per entry, uneven coverage.
+- Curated apps, the current model: add top-level packages, deps ride along. Good
+  signal per entry, uneven coverage.
 - Survey-driven worklist: generate `wheels.nix` pure entries for every top-N
   package whose native closure is already satisfied. Pure builds are cheap, so
   this is what turns the coverage percentage into an actually populated

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,26 @@
+# Python
+
+How CPython, extension modules, and wheels are built for WASIX. General package
+authoring is covered by
+[`packaging.md`](packaging.md#a-python-package-or-wheel).
+
+## CPython and its package set
+
+CPython needs dynamic linking for extension modules, so it is built only in the
+`ehpic` profile. Its overlay lives in `pkgs/overlay/packages/python3/`.
+
+Python package adaptations live in `pkgs/overlay/python-packages/`. They follow
+the normal overlay conventions, with `pyfinal` and `pyprev` for dependencies in
+the Python package set. Rust extension modules use the shared Rust wheel hooks
+described in [`rust.md`](rust.md).
+
+## Wheels
+
+`pkgs/overlay/python-packages/wheels.nix` declares the shipped wheels.
+`pkgs/python-wheels.nix` turns those declarations into build targets and runs
+their import tests under Wasmer. The wheel index and publication flow are
+described in [`registry.md`](registry.md#the-python-wheel-index).
+
+For package selection and coverage, see
+[`python-coverage.md`](python-coverage.md). The survey data behind that work is
+in [`../pypi-survey/`](../pypi-survey/).

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,147 @@
+# Registry and publishing
+
+Getting a built package out to consumers: webcs on the wasmer registry, wheels
+on the Python index, the older versions we keep rebuildable, and PR previews.
+Authoring the package itself is `docs/packaging.md`.
+
+## Publishing webcs
+
+```sh
+nix run .#scripts.publish-webc -- --registry wasmer.io [name...]
+```
+
+Builds the named webcs (none = all shipped) and publishes those the registry
+does not already have. `--dry-run` previews.
+
+- **Auth**: `wasmer login`, or `WASMER_TOKEN`.
+- **Order**: packages publish in dependency order. A webc dependency that is
+  neither already published nor part of this run is an error.
+- **Existing versions** are hash-verified against the registry, so a changed
+  webc under an unchanged version fails loudly. Republishing one needs a rel
+  encoding the registry supports, which does not exist yet (`WASIX-TODO.md`).
+- **Failures** are isolated per package and reported at the end.
+- **Owner**: webcs publish under `wasmer/` on wasmer.io, the default in
+  `pkgs/wasmer/make-wasmer-package.nix`.
+- **Provenance** rides the package README: the generated README carries the attr
+  and rel, and the publish step appends the source rev and a rebuild command.
+  Verification restages the local build with the recorded rev to reproduce the
+  published bytes, then compares registry hashes (`wasmer publish` can exit 0
+  without tagging, `WASIX-TODO.md`).
+
+The `publish-webc` workflow runs the same script, manual dispatch only, with the
+`WASMER_TOKEN` secret.
+
+## Registry history
+
+Both registries are append-only. History entries also keep selected older
+versions rebuildable, using one table per package set:
+
+- wheels: `pkgs/overlay/python-packages/history.json`
+- CLIs / libraries: `pkgs/overlay/packages/history.json`
+
+Tables are keyed `{<attr>: {<version>: <spec>}}`. A spec contains the fields for
+the package's existing source fetcher: `{version, hash}`, `{tag|rev, hash}`, or
+`{url, hash}`. Rust packages may add `cargoHash`; `note` and `variants` are
+optional. A wheel uses `variants`, such as `["py313"]`, when an entry applies to
+only some interpreters.
+
+`pkgs/lib/load-packages.nix` re-imports the package with its source rebased and
+creates `<attr>_<version>`. Package files handle version-specific differences;
+`passthru.wasix.historySpec` exposes the history entry when needed.
+
+Keys differ per set, and webcs are normalised:
+
+- wheels: `.#pythonWheels.py313."numpy-2.1.3"`
+- webcs: `wasmerPackages` and the run-by-name stubs use `<name>-<semver>`, so a
+  test asks for `wasmerPkgs."jq-1.6.0"`.
+
+Webc attrs use full MAJOR.MINOR.PATCH while `history.json` keeps the upstream
+version as written. For example, jq `"1.6"` becomes `jq-1.6.0`.
+
+Maintain the tables with `nix run .#scripts.history`. Use
+`add <attr>==<version>`, `--per-major`, or `--per-minor`; `--set wheel|cli`
+disambiguates shared names. Pin updates retain outgoing major versions by
+default. `passthru.wasix.retention = "minor"` keeps each minor, while `"none"`
+opts out. Keep only versions consumers are likely to pin.
+
+A `{names, packages}` family is only for a package nixpkgs itself carries at
+multiple versions, not for minting historical ones. Its version list should
+derive from nixpkgs. For example, icu uses a `retentionHook` to regenerate its
+list after a pin bump.
+
+## The Python wheel index
+
+All shipped wheels, plus their transitive python deps, are published as a static
+PEP 503 "simple" index: `.#pythonRegistry` (`pkgs/python-registry/`). Serve the
+output from any static file host, or install directly:
+
+```sh
+pip install --index-url file://$(readlink -f result)/simple <pkg>
+```
+
+A new `wheels.nix` entry lands in the registry automatically. Its test suite
+(`checks.<system>.python-registry`) walks the index for hash and metadata
+integrity and pip-installs representative packages, resolving their deps from
+the index too, then imports them under wasmer.
+
+## Rels
+
+Every wheel is published as `<version>+wasix.<rel>`, a PEP 440 local version.
+`rel` counts our builds of one upstream version and comes from the root
+`rels.json`, keyed by attr path (`pythonRegistry.wheels.<pname>`, or
+`wasmerPackages.<name>` for webcs) then version, default 1. It is shared across
+python versions, since the cp tag already keeps filenames distinct.
+
+Bump it to republish a changed build, with `nix run .#scripts.bump-rel` or the
+manual `bump-rel.yml` workflow, which takes a list of packages and opens a PR.
+An upstream version bump resets it by key miss, as `nix run .#scripts.update`
+drops the stale key. For a deliberate whole-registry rebuild:
+
+```sh
+nix run .#scripts.bump-rel -- --all-versions 'pythonRegistry.wheels.*'
+```
+
+That flag also bumps every served history version, so it stays explicit.
+
+Webc rels land in `[package.metadata] wasix-rel` only, for now: the registry has
+no version encoding for republishing (`WASIX-TODO.md`), so a bumped webc still
+cannot republish.
+
+## Immutability, and the two indexes
+
+Published filenames are immutable and accumulate. A normal registry rebuild can
+change the bytes behind an existing filename through a nixpkgs, toolchain, or
+runtime update, and the volume keeps its original artifact in that case. Bump
+the rel only when that rebuilt wheel is itself a release.
+
+GitHub Pages behaves differently: it is always deployed from the fresh
+`.#pythonRegistry` result, so it is a bleeding-edge snapshot and may serve new
+bytes under an existing filename. Use the volume-backed index for immutable,
+reproducible installs.
+
+After a green build of main, `publish-index` uploads new filenames to the volume
+and deploys the fresh snapshot to GitHub Pages. The volume service is defined by
+`python-registry/app.yaml`.
+
+Each `manifests/<wheel>.json` records `wasinix_rev`, `attr`, and `drv_path`.
+Rebuild it with `nix build github:wasix-org/wasinix/<wasinix_rev>#<attr>`.
+
+## PR previews
+
+Label a same-repo PR `preview`. After its Build goes green, so the CI cache
+serves every artifact (labeling an already-green PR triggers immediately),
+`preview.yml` diffs it against its base at the drvPath level
+(`scripts/preview-diff.py`) and publishes what changed.
+
+Webcs go to the dev registry as `<version>-pr<N>.g<sha7>` prereleases: distinct
+versions per iteration, hidden from `latest`, not deletable, so they accumulate
+on wasmer.wtf. Changed wheels become an ephemeral per-PR Edge app serving an
+overlay index:
+
+```sh
+pip install --index-url <preview>/simple --extra-index-url <prod>/simple
+```
+
+which prefers the preview wheels by their longer local version. The app is
+deleted when the PR closes or drops the label (`preview-cleanup.yml`), and the
+PR gets a comment with the URLs.

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -1,0 +1,40 @@
+# Rust
+
+How Rust builds reach WASIX and how patched crates are shared with plain cargo.
+Adding a package is covered by [`packaging.md`](packaging.md#a-rust-cli).
+
+## Building for WASIX
+
+`pkgs/toolchain/rust/` builds the WASIX Rust sources and cargo-wasix.
+`pkgs/set/rust-platform.nix` routes `buildRustPackage` through cargo-wasix and
+provides the WASIX defaults. Rust has a standard library for `eh` and `ehpic`,
+so Rust packages are limited to those profiles.
+
+A nixpkgs CLI usually needs only `{ prev, ... }: prev.foo`. For a crate nixpkgs
+does not carry, use `final.rustPlatform.buildRustPackage`; see
+`pkgs/overlay/packages/crabsay.nix`. Python wheels use the shared maturin and
+setuptools-rust hooks.
+
+## Crate edits
+
+Every WASIX Rust builder applies matching edits from
+`pkgs/lib/wasix-crate-patches/` to its vendored crates. The same edit
+definitions feed the overlay registry, so package builds and published crates
+cannot drift.
+
+The edit format, version coverage, dependency additions, and source rewriters
+are documented in
+[`pkgs/lib/wasix-crate-patches/README.md`](../pkgs/lib/wasix-crate-patches/README.md).
+
+## Cargo registry
+
+`cargo-registry.wasix.org` publishes edited crates as `<upstream>+wasix.N`,
+allowing plain cargo projects to select them by version.
+
+- `nix run .#scripts.crate-pins` updates the resolved versions and hashes.
+- `.#cargoRegistry` builds the registry contents.
+- `.#checks.x86_64-linux.cargo-registry` checks the mint and resolution.
+- `nix run .#scripts.cargo-registry-serve` serves a fresh local registry under
+  Wasmer.
+
+The server package is `wasmerPackages.wasix-cargo-registry`.

--- a/docs/spot.md
+++ b/docs/spot.md
@@ -18,12 +18,12 @@ scripts/spot.sh --local exnrefEh.zlib exnrefEh.git   # several targets, one spli
 ```
 
 A target is a dotted path into `nixpkgsByProfile`, written `<profile>.<attr>`
-such as `exnrefEh.zlib`. There is nothing to author: edit whatever files you want
-(a wasixcc patch, a sysroot flag, a package definition), name the attrs to build
-from them, and everything else comes from the base revision. One caveat: the
-splice reads the working tree as a flake, so a brand new file (a fresh `.patch`,
-say) has to be `git add`ed first, or it is invisible and the target comes out
-identical to base.
+such as `exnrefEh.zlib`. There is nothing to author: edit whatever files you
+want (a wasixcc patch, a sysroot flag, a package definition), name the attrs to
+build from them, and everything else comes from the base revision. One caveat:
+the splice reads the working tree as a flake, so a brand new file (a fresh
+`.patch`, say) has to be `git add`ed first, or it is invisible and the target
+comes out identical to base.
 
 ## The model
 
@@ -53,22 +53,22 @@ You build up from what you add. A removal only pares down a base you named, so
 `all,-rust` and `toolchain,-rust` are valid but `-rust` on its own is an error.
 The default is `toolchain`, so a plain toolchain experiment needs no flags.
 
-- `exnrefEh.zlib` with no flag keeps the toolchains, so a wasixcc, sysroot, rustc,
-  or ghc edit reaches the target with nothing to configure.
-- `--keep toolchain,zlib exnrefEh.curl` keeps the toolchains and a zlib edit, the
-  "edit a common dependency, test one package" case.
+- `exnrefEh.zlib` with no flag keeps the toolchains, so a wasixcc, sysroot,
+  rustc, or ghc edit reaches the target with nothing to configure.
+- `--keep toolchain,zlib exnrefEh.curl` keeps the toolchains and a zlib edit,
+  the "edit a common dependency, test one package" case.
 - `--keep zlib exnrefEh.curl` keeps only zlib, so the toolchains come from base
   too; this isolates the zlib edit from any toolchain difference on your branch.
-- `--keep toolchain,-rust exnrefEh.ripgrep` keeps the C and Haskell toolchains but
-  takes rust from base, so ripgrep builds against the base rust toolchain.
+- `--keep toolchain,-rust exnrefEh.ripgrep` keeps the C and Haskell toolchains
+  but takes rust from base, so ripgrep builds against the base rust toolchain.
 
 An unknown name, or a keep of only removals, is an error, not a silent no-op.
 
 ## --base and cost
 
-`--base` is the pristine revision everything pins to; it defaults to HEAD. Pick a
-revision CI has actually built, because anything uncached there gets built too,
-which is expensive and has nothing to do with your change.
+`--base` is the pristine revision everything pins to; it defaults to HEAD. Pick
+a revision CI has actually built, because anything uncached there gets built
+too, which is expensive and has nothing to do with your change.
 
 A dry run prints two build counts. A count is how many derivations that side
 would have to compile; cached ones download instead and do not count.
@@ -78,14 +78,14 @@ spot: base rev   0 to build   (want 0; nonzero = --base not cached)
 spot: this run   8 to build
 ```
 
-`this run` is the experiment's cost: the targets rebuilt from your tree, plus any
-kept dependency whose output your change moved. `base rev` checks `--base`; it is
-the same targets built at the base commit, and should be 0, because a CI-built
-base is entirely fetchable. A nonzero `base rev` means much of `this run` is just
-rebuilding base, so pick a better revision.
+`this run` is the experiment's cost: the targets rebuilt from your tree, plus
+any kept dependency whose output your change moved. `base rev` checks `--base`;
+it is the same targets built at the base commit, and should be 0, because a
+CI-built base is entirely fetchable. A nonzero `base rev` means much of
+`this run` is just rebuilding base, so pick a better revision.
 
-The splice refuses to build when every target already equals base, since a change
-that never reaches a target would look green while testing nothing.
+The splice refuses to build when every target already equals base, since a
+change that never reaches a target would look green while testing nothing.
 
 ## Several targets
 
@@ -104,49 +104,26 @@ cheap.
 
 ## How the pin is built
 
-The splice lives in `pkgs/spot.nix` and pins in two layers, because a dependency
-reaches a package by two routes.
+The splice in `pkgs/spot.nix` pins dependencies reached through two routes:
 
-1. The overlay fixpoint, for `final.<dep>` references. This is the convention for
-   linked dependencies, and is out of reach of `.override`.
-2. The target's own function arguments, for dependencies that are plain nixpkgs
-   packages with no overlay entry (the shell tools a CLI reaches for, such as
-   coreutils, gawk, or gnugrep). The fixpoint pin does not cover those, so
-   without this layer a target like git would drag its whole tool closure onto
-   the work toolchain. This layer pins only arguments that are themselves wasix
-   builds, so a natively taken argument (an interpreter's `tzdata` or `bash`) is
-   left alone rather than swapped for a wasm build.
+1. The overlay fixpoint, for `final.<dep>` references. This is the convention
+   for linked dependencies, and is out of reach of `.override`.
+2. The target's function arguments, for WASIX dependencies without overlay
+   entries. Native arguments remain native.
 
-Three constraints shape the fixpoint pin, each of which leaks packages into the
-rebuild if ignored.
-
-- It covers the overlay's package names plus the three toolchain attrs (stdenv,
-  rustPlatform, haskellPackages), which enter outside those names (stdenv via
-  `replaceCrossStdenv`, the other two as overlay attrs) and so must be listed to
-  be reachable. It does not cover the whole set: blanket-pinning every attr trips
-  nixpkgs' stdenv bootstrap assertions, because the lower bootstrap stages read
-  attrs out of the same fixpoint. Pinning `final.stdenv` alone is safe, since the
-  bootstrap does not read it back.
-- It is guarded on `isWasix`. An overlay applies to every stage, and these names
-  are cross builds, so replacing them in `buildPackages` would swap native build
-  tools for wasm ones and pull in a native bootstrap.
-- It is injected through `pkgs/default.nix` (the `spotOverlays` argument) rather
-  than by extending one set from outside, because profile sets reference each
-  other through `preferredProfilePackages`; pinning one profile alone still leaks
-  the runtime-invoked dependencies that resolve in another.
+The fixpoint pin covers overlay packages and the three toolchain attrs, applies
+only to WASIX sets, and enters through `pkgs/default.nix` so cross-profile
+runtime dependencies remain pinned. It does not pin the whole nixpkgs set, which
+would interfere with stdenv bootstrap.
 
 `spotOverlays` is empty in every normal evaluation, and the seam moves no drv
 path. Nothing that ships may set it.
 
 ## Nested python targets
 
-`exnrefEhpic.python314.pkgs.numpy` is a valid target, and the interpreter stays
-pinned. A python extension's compiler comes from `buildPythonPackage`, which
-takes it from the interpreter's passthru (nixpkgs `python-packages-base.nix`), so
-it is reachable neither through the package's own `stdenv` argument (inert) nor
-through the scope's `stdenv`. The splice overrides `buildPythonPackage` with one
-built against the working-tree stdenv, which moves the wheel and nothing else:
-the interpreter, hooks, and python dependencies all stay on base.
+`exnrefEhpic.python314.pkgs.numpy` is a valid target. The splice replaces its
+`buildPythonPackage` with one using the working-tree stdenv while keeping the
+interpreter, hooks, and Python dependencies on base.
 
 Two cases fall back to rebuilding the interpreter, still correct but larger: a
 base revision whose `buildPythonPackage` has no `.override`, and a target kept
@@ -155,10 +132,7 @@ definition, since the pinned base scope would not have it.
 
 ## Limits
 
-- The output mixes objects built by two toolchains. A green spot build is
-  evidence that a change compiles and links, not proof that it is correct. Verify
-  at the root before keeping the change.
-- Never a CI job. `spot.nix` is deliberately not a flake output, because the base
-  revision is an evaluation-time input.
-- Targets are cross-set attrs. The layers above them (webc, `passthru.tests`, the
-  python registry) are not spliced.
+- Never a CI job. `spot.nix` is deliberately not a flake output, because the
+  base revision is an evaluation-time input.
+- Targets are cross-set attrs. The layers above them (webc, `passthru.tests`,
+  the python registry) are not spliced.

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,220 @@
+# Code style
+
+How code in this repo is expected to read. Packaging mechanics are
+`docs/packaging.md`; build and check commands are `docs/building.md`.
+
+## nixpkgs conventions are the default
+
+This flake is a set of nixpkgs overlays, so nixpkgs conventions are the default:
+argument style, phases, `meta`, update scripts, and existing language package
+sets. Override those mechanisms instead of building parallel machinery. The
+[nixpkgs contributing guide](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
+and the manual's
+[coding conventions](https://nixos.org/manual/nixpkgs/stable/#chap-conventions)
+are the reference.
+
+Deviate where WASIX genuinely forces it, and say why at the point of divergence.
+"Upstream nixpkgs does X" is a sufficient reason to do X; "our version is
+neater" is not.
+
+## Comments
+
+Write a comment only when it carries a constraint or a reason the code cannot
+show. If it restates the line below it, or narrates what changed, delete it:
+change narration belongs in the commit message.
+
+Explain the mechanism, not the incident. The error text, the flag, or the
+constraint still means something to someone who was not there; a named past
+debugging session does not.
+
+Match the comment density of the surrounding file.
+
+`#` comments inside a build-script string (`postPatch`, `buildPhase`, `''...''`)
+are part of the derivation, so editing one changes the drv hash and forces a
+rebuild. Keep build strings comment-free and put the rationale in a nix-level
+comment above the attribute, which the parser strips.
+
+## Naming
+
+Name things after what they concretely do. If a name needs a comment to explain
+it, rename it instead.
+
+Package attrs follow nixpkgs naming. For example, override `gnused` and `gawk`,
+not parallel `sed` and `awk` attrs. A differently named attr does not replace
+nixpkgs' dependency edge, so existing consumers keep the unmodified package.
+
+## Commits
+
+`<scope>: <summary>`, lowercase, as in nixpkgs. The scope is the thing that
+changed, not a category of work: either a package attr name or the subsystem
+that owns the change.
+
+```text
+wasixcc: 0.4.4 -> 0.4.5
+tokio: cover 1.35.1, drop the false pre-1.47 stock range
+toolchain: preserve relocatable links in wasixcc
+docs: explain ci profile selection
+```
+
+The examples are illustrative, not an inventory of valid scopes.
+
+One change touching a few related things takes a brace-expansion scope, and one
+sweeping the repo takes `treewide:`:
+
+```text
+python{,3-pkgs}: drop the setuptools pin
+tests/{curl,git}: cover the proxy path
+treewide: reformat with prettier
+```
+
+Two nixpkgs summary idioms carry real meaning; use them literally:
+
+- `foo: init at <version>` for a new package that pins its own version. Plain
+  `foo: init` is right for an overlay entry that takes its version from nixpkgs,
+  since there is no version here to name.
+- `foo: <old> -> <new>` for a version bump, and nothing else in the summary.
+
+Do not use conventional-commits prefixes. `feat:` and `fix:` name a kind of
+change rather than a component, which is the opposite of what the scope is for.
+
+Pin bumps are generated: `scripts/update.py --commit` lands one commit per
+target, already in `<name>: <old> -> <new>` form, plus a separate commit for
+each repo-wide step a bump implies (history retention, rels pruning, a package's
+retention hook). Let it write those rather than hand-rolling a variant.
+
+A meaningful title is enough when the diff explains the change. Use a short body
+for rationale the diff cannot show, not to narrate what changed.
+
+A commit written with AI assistance says so with an `Assisted-by:` trailer
+naming the harness and the model:
+
+```text
+Assisted-by: <harness>:<model>
+```
+
+Do not use `Co-authored-by:`, which credits a person. Add no email or URL. Name
+the model the tool reports; if it is hidden, use `<harness>:auto`.
+
+Keep a change's diff to what it needs. Drive-by refactors, silently dropped
+code, and unexplained commit splits all cost a reviewer time.
+
+## Fail loud
+
+No guarding, no silent fallbacks, no defaults that paper over a missing input.
+
+- Do not add an existence check before using a path that should exist. Let it
+  fail.
+- Do not return success for a missing or invalid input.
+- Do not drop a check (`outputChecks`, a test, a lint) to make something pass.
+  If the check is right and the output is wrong, fix the output.
+- Do not silently substitute a reduced variant for the thing asked for. `bash`
+  means bash, not `bashNonInteractive`.
+
+If removing a guard makes the code longer, the guard is still there.
+
+## Root cause, not cosmetics
+
+- A failing target gets fixed, not excluded, skipped, or marked broken.
+  Shrinking the build set to go green needs the user's explicit agreement, and
+  they can only give it once you have said what stops being covered and why the
+  fix is untenable rather than merely expensive. Accepting a regression is
+  occasionally right. It is never the first move, and never a silent one.
+- Fix a bug at the scope it exists at. If it affects every test, fix it for
+  every test.
+- When you fix one instance, grep for structurally identical ones and fix them
+  together.
+- "It is not reproducible" is not a finding. If a real program hits the bug,
+  start from that program and strip it down until the failure is isolated.
+- wasmer and the WASIX toolchains are ours to diagnose, not third-party black
+  boxes. Name the root fix, vendor it as a patch when possible, and record any
+  shipping workaround in `WASIX-TODO.md`. Upstreaming the fix is welcome but
+  does not gate a change here.
+- Describe a regression as a regression. An approving adjective ("honest",
+  "cleaner", "pragmatic") on a tradeoff hides the decision the reader needs to
+  make.
+
+## Import from derivation
+
+IFD is allowed and strongly discouraged. It serialises eval behind a build, so
+it slows every consumer of the attribute and turns an eval-time error into a
+build-time one.
+
+Reach for it only when the alternative is worse, and say which alternative in a
+comment at the site. The rust vendor patching is the standing example: it reads
+each vendor's crate set at eval so that editing one crate's patch rebuilds only
+the vendors containing it (`docs/rust.md`).
+
+## Single source of truth
+
+- If a comment says two pieces of code must "agree" or "stay in sync", extract
+  the shared implementation instead of writing the comment.
+- Never hardcode a value already available from a canonical source: the version
+  comes from the derivation, toolchain flags from the surrounding profile, the
+  owner from the shared default.
+- Reference well-known store paths and declared inputs directly. Do not `find`
+  or PATH-search for something whose location is known at eval time.
+- Never search `/nix/store` itself. A match is usually the wrong answer: the
+  store keeps every version ever built, including results from other worktrees
+  and older revisions, so a glob happily returns a path the current tree does
+  not evaluate to. It is also slow, at a few hundred thousand top-level entries
+  whose contents a recursive walk (`find`, `grep -r`, `**`) descends into. Ask
+  nix where something is: `nix path-info`, `nix-store -q --references`, or eval
+  the attr.
+- A feature spanning package types (wheels, CLI packages, libraries) is
+  implemented once and driven by data, not copied per type.
+- A list in documentation is exhaustive only when that document owns the
+  inventory. Otherwise link to the source of truth. Keep a named example only
+  when it explains the mechanism, and introduce it as an example; adding another
+  consumer does not require updating the example.
+- When you replace a pattern, migrate every consumer in the same change.
+
+## Dogfood wasmer
+
+Anything here that needs to run wasm runs it under wasmer: the test harness, a
+build step, a throwaway reproduction. We ship a wasm runtime, so reaching for
+another one to build our own packages is a smell, and it forfeits the bugs that
+using our own is how we find. Use something else only with a stated reason.
+
+## Scope
+
+Build the full package. Do not narrow features, profiles, targets, or
+optimisation to match the only consumer that exists today; "nothing else uses it
+yet" is not a reason. Narrow against a named technical blocker, and name it in
+the commit.
+
+## For agents
+
+Default to a title and the `Assisted-by` trailer, with no body. Add at most a
+short paragraph when the rationale is necessary. Do not summarize the diff,
+recount the debugging process, or fill a template for its own sake.
+
+Comment volume is the most repeated complaint about AI-authored code here, and
+asking for fewer has produced cosmetic trims rather than deletions. Run every
+comment in your final diff through these. Failing one check means it goes.
+
+1. Does it restate the line below it? Delete.
+2. Does it narrate a change ("bumped because", "no longer needed", "now uses",
+   "we used to")? Delete. That belongs in the commit message.
+3. Does it name an incident, bug, or session the file never introduces? Rewrite
+   as the generic mechanism: the error text, the flag, the constraint.
+4. Would a reader who has not seen the change understand every term? If it uses
+   a word coined nowhere, delete or define it.
+5. Is it longer than three lines inline, or four in a file header? Cut it, or
+   move the bulk to the commit message.
+6. Does identical code elsewhere in the same change have a different comment?
+   Make them identical.
+7. Is it true of the code below it, in the right causal direction? A
+   technically-true-but-misleading comment is a bug.
+
+Measure density against human-authored neighbours, not code you generated
+earlier; matching your own output is circular.
+
+Leave other people's comments alone unless your change falsified them. Rewording
+untouched code's comments is diff churn a reviewer has to audit for meaning
+drift. A comment you move or rewrite is yours, and gets the checks above.
+
+No metaphors or cryptic abbreviations in names. A name that needs decoding costs
+every later reader.
+
+No em dashes in code, comments, commits, PR text, or chat. Fold a necessary
+clause into the sentence and delete an aside.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -7,31 +7,27 @@ nix run .#scripts.update -- --only llvm wasix-libc
 ```
 
 How a pin bumps is declared next to it (`passthru.updateScript`, the standard
-nixpkgs convention); its constraints and quirks are comments in the same file.
-That includes a pin _derived_ from another pin: the rust fork's stage0
-bootstrap and cargo vendor hash, and wasix-libc's witx submodules are
-re-derived by `pkgs/toolchain/rust/update.py` and
-`pkgs/toolchain/sysroot/update.py`, which the package's `updateScript` runs
-after its own bump (the `nix-update-script` command is passed through as their
-argv, so the bump is declared once).
+nixpkgs convention); its constraints and quirks are comments in the same file. A
+derived pin is recalculated by the package's `updateScript`, so the bump is
+declared once. For example, `pkgs/toolchain/rust/update.py` recalculates the
+bootstrap and vendor inputs after moving the Rust source pin.
 
 `scripts/update.py` is only the driver: flake-input targets, per-target
 isolation, the repo-wide steps a bump implies, and the summary. Those are
 registry-history retention (keep the outgoing version rebuildable when a bump
 crosses a major, or per `passthru.wasix.retention`: `minor` for
 latest-per-minor, `none` to opt out), the rels.json prune (drop keys nothing
-serves), and finally the `passthru.wasix.retentionHook`s: a per-package command
-that re-syncs a listing derived from the pins (icu regenerates its
-`versions.nix` from the nixpkgs majors, so a dropped or added major tracks
-automatically; anybuild re-resolves the PyPI pins its template tests build
-against, which come from that release's `examples/`). They run in that order,
-for every target rather than any one of them, because either can move a served
-version. A hook that would otherwise redo expensive work on an unrelated bump
-gates itself: anybuild's compares the version recorded in its lock. Retention fetches and hashes the
-outgoing release, so a bump run can do network work beyond the pins themselves
-(see "Registry history" in `docs/packaging.md`). The `update.yml` workflow runs
-it weekly with one PR per moved target; a manual dispatch with `only` bundles
-targets into one combined PR.
+serves), and finally the `passthru.wasix.retentionHook`s, which re-sync listings
+derived from pins. Hooks that would repeat expensive work on unrelated bumps
+must gate themselves.
+
+These steps run in order for every target because each can move a served
+version. Retention fetches and hashes the outgoing release, so a bump may do
+network work beyond the pins themselves; see
+[Registry history](registry.md#registry-history). The `update.yml` workflow runs
+weekly with one PR per moved target; a manual dispatch with `only` bundles
+targets into one PR.
+
 Things to check on a bump are declared as `passthru.wasix.updateNotes`
-(`pkgs/lib/default.nix`) and surface in the PR body. Toolchain and nixpkgs
-bumps rebuild the world.
+(`pkgs/lib/default.nix`) and surface in the PR body. Toolchain and nixpkgs bumps
+rebuild the world.

--- a/pkgs/lib/wasix-crate-patches/README.md
+++ b/pkgs/lib/wasix-crate-patches/README.md
@@ -1,68 +1,49 @@
 # wasix-crate-patches
 
-The wasix edits for upstream Rust crates, applied at vendor time by
-`patchVendor` (set/rust-platform.nix) and republished by the cargo-registry
-mint. Both resolve the same spec through `crate-edits.nix`, so an edit is
-defined once. Packages stay plain `buildRustPackage { cargoHash = ...; }`; the
-edits are baked into the vendored sources before `cargo build` sees them.
+Crate edits applied at vendor time and published by the cargo registry. Both
+paths read `edits.nix` through `crate-edits.nix`, so each edit is defined once.
 
 ## Layout
 
-```
-<crate>/edits.nix        the spec (below)
-<crate>/<version>.patch  floor patches, named by the version authored against
-helpers.nix              eval-time patchPhase helpers
-rewriters/<name>.nix     reusable source rewriters, one script drv each
+```text
+<crate>/edits.nix        edit specification
+<crate>/<version>.patch  floor patch authored against that version
+helpers.nix              patchPhase helpers
+rewriters/<name>.nix     reusable source rewriters
 ```
 
 ## `edits.nix`
 
 ```nix
 { lib, helpers, rewriters, adds }: {
-  edited     = [ ">=1.0.3" ];            # versions we patch (floored)
-  stock      = [ ">=1.2.2" ];            # optional: versions known good unpatched
-  notMinted  = null;                     # optional reason to skip the registry
+  edited = [ ">=1.0.3" ];
+  stock = [ ">=1.2.2" ];
+  notMinted = null;
   forVersion = { version, floorPatch }: {
-    patches    = [ ./thread-id.patch ] ++ lib.optional (floorPatch != null) floorPatch;
+    patches = [ ./thread-id.patch ]
+      ++ lib.optional (floorPatch != null) floorPatch;
     patchPhase = ''${rewriters.wasmerAsNative}'';
-    adds       = [ adds.wasix ];
+    adds = [ adds.wasix ];
   };
 }
 ```
 
-Each resolved version of an edited crate is `edited`, `stock`, or `unsupported`;
-the last hard-fails the vendor, so a version drifting past its coverage surfaces
-loudly instead of miscompiling downstream.
+| field        | meaning                                                                                                               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `edited`     | Patched version ranges. Prefer an open floor such as `>=1.0.3`; the highest applicable `<version>.patch` is selected. |
+| `stock`      | Optional ranges verified to work without edits.                                                                       |
+| `notMinted`  | Optional reason the crate is not published.                                                                           |
+| `forVersion` | Per-version patches, rewrite phase, and dependencies absent upstream.                                                 |
 
-- `edited` (constant): the versions we patch, a semver constraint (comparator
-  terms `>= <= < > =`, comma-AND per element, the array OR-ed). Prefer an
-  open-ended floor range (`>=X`): `floorFor` applies the highest `<version>.patch`
-  at or below the resolved version, and a version the patch no longer fits
-  hard-fails for a fresh patch. It is the coverage the vendor patches and the
-  registry publishes.
-- `stock` (constant, optional): versions deliberately left as upstream ships
-  them. Set it only for versions known good unpatched: a durable upstream fix (a
-  boundary like `>=0.6.3`), or one you have built green. Never an optimistic
-  range.
-- `notMinted` (constant): keep a crate off the registry (git-sourced libdd,
-  vendor-only rewrites) with a reason.
-- `forVersion`: per-version, may branch on `version`. `patches` is the stack
-  (residuals prepend, the engine-selected `floorPatch` last; all compose).
-  `patchPhase` is postPatch shell that runs the `rewriters` drvs. `adds` are deps
-  the edit pulls in that upstream lacks (declared once in `adds.nix`).
-
-A crate with only `<version>.patch` files needs just `{ edited = [...]; }`.
+Ranges use semver comparators, comma-separated AND terms, and one OR branch per
+list element. A resolved version outside both `edited` and `stock` fails. A
+crate needing only floor patches can use `{ edited = [ ">=1.0.3" ]; }`.
 
 ## Rewriters
 
-`rewriters/<name>.nix` is a script derivation run against the crate dir (`$PWD`),
-failing loud if its target or expected source shape is gone. A `patchPhase` runs
-one by interpolating its store path (`${rewriters.wasmerAsNative}`), so editing
-a rewriter rebuilds only the crates that use it and adding one rebuilds nothing.
+A rewriter is a script derivation run from the crate directory. It must fail if
+the expected source shape is absent. Invoke it from `patchPhase` by
+interpolating its store path, for example `${rewriters.wasmerAsNative}`.
 
-Large files that are mostly stable across releases can live next to the crate's
-`edits.nix` and be copied explicitly from its `patchPhase`. Keep only upstream
-integration hunks in floor patches, and overlay payload variants at explicit
-API boundaries from that phase. Use
-`helpers.addFile ./payload.rs "src/sys/payload.rs"` to copy a new file and fail
-if upstream already supplies the destination.
+Use `helpers.addFile ./payload.rs "src/sys/payload.rs"` for a new source file;
+it fails if the destination already exists.

--- a/pypi-survey/README.md
+++ b/pypi-survey/README.md
@@ -1,8 +1,9 @@
 # PyPI top-10k native-dependency survey
 
-**Survey date: 2026-07-16.** How many of the top 100 / 1,000 / 10,000 PyPI packages
-(by 30-day downloads) are pure Python vs ship native code, what the native ones are
-built from, and how native packages get pulled into dependency closures.
+**Survey date: 2026-07-16.** How many of the top 100 / 1,000 / 10,000 PyPI
+packages (by 30-day downloads) are pure Python vs ship native code, what the
+native ones are built from, and how native packages get pulled into dependency
+closures.
 
 Motivation: sizing the native-code problem for WASIX Python packaging (wasinix).
 
@@ -14,8 +15,8 @@ Motivation: sizing the native-code problem for WASIX Python packaging (wasinix).
 | top 1,000  | 79.2% | 20.8%         | 53.5%                                |
 | top 10,000 | 85.4% | 14.6%         | ~58.5%                               |
 
-Full numbers, per-cutoff breakdowns (languages, build backends, ABI kinds, bundled
-shared libraries) and the reach ranking: **[findings.md](findings.md)**.
+Full numbers, per-cutoff breakdowns (languages, build backends, ABI kinds,
+bundled shared libraries) and the reach ranking: **[findings.md](findings.md)**.
 
 The reproduce pipeline also emits `flame.html`, an interactive
 reverse-dependency chart: roots are native packages sized by how much they're
@@ -45,7 +46,8 @@ generated, not vendored in this copy; regenerate them with the reproduce steps.
 
 ## Reproducing
 
-Needs python3 (stdlib + `packaging`), ~55 MB of PyPI JSON metadata cache, ~15 min:
+Needs python3 (stdlib + `packaging`), ~55 MB of PyPI JSON metadata cache, ~15
+min:
 
 ```
 python3 scripts/fetch_meta.py 10000        # PyPI JSON metadata -> cache/
@@ -62,22 +64,24 @@ python3 scripts/gen_page.py OUT            # flame.html from template.html
 
 ## Method notes & caveats
 
-- **Native** = latest release publishes a platform-specific wheel, or its sdist builds
-  compiled code (`ext_modules` / Cython / Cargo / CMake / meson signals). Packages whose
-  compiled part is optional but which ship a pure fallback wheel still count as native
-  (tracked separately in `native_optional.json`). `pyspark` counts as pure (JARs, not
-  CPython extensions). Two junk packages (`aaaaaaaaa`, `timedelta`) excluded.
-- **Closure**: `requires_dist` of latest releases, markers evaluated for CPython 3.12 /
-  linux / x86_64, no extras. Extras and version-range back-solving are not modeled, so
-  transitive numbers slightly undercount.
-- **Flame attribution**: each (package, native dep) pair contributes once, along the
-  package's shortest dependency path, so a package reaching numpy both directly and via
-  pandas is counted on the direct edge only. Most pulls of big libraries are direct,
-  which is why "(other)" (folded one-off dependents) dominates under the roots.
-- **Language** is a single primary label per package (source-file majority + toolchain
-  signals). Vendored sources are the main hazard (numpy vendors `.rs` files; Eigen
-  vendors Fortran LAPACK), so Rust requires a toolchain signal, not just
-  sources. ~29% of native packages publish no sdist (binary-only: torch, CUDA wheels,
-  repackaged CLIs) and stay unattributed.
+- **Native** = latest release publishes a platform-specific wheel, or its sdist
+  builds compiled code (`ext_modules` / Cython / Cargo / CMake / meson signals).
+  Packages whose compiled part is optional but which ship a pure fallback wheel
+  still count as native (tracked separately in `native_optional.json`).
+  `pyspark` counts as pure (JARs, not CPython extensions). Two junk packages
+  (`aaaaaaaaa`, `timedelta`) excluded.
+- **Closure**: `requires_dist` of latest releases, markers evaluated for CPython
+  3.12 / linux / x86_64, no extras. Extras and version-range back-solving are
+  not modeled, so transitive numbers slightly undercount.
+- **Flame attribution**: each (package, native dep) pair contributes once, along
+  the package's shortest dependency path, so a package reaching numpy both
+  directly and via pandas is counted on the direct edge only. Most pulls of big
+  libraries are direct, which is why "(other)" (folded one-off dependents)
+  dominates under the roots.
+- **Language** is a single primary label per package (source-file majority +
+  toolchain signals). Vendored sources are the main hazard (numpy vendors `.rs`
+  files; Eigen vendors Fortran LAPACK), so Rust requires a toolchain signal, not
+  just sources. ~29% of native packages publish no sdist (binary-only: torch,
+  CUDA wheels, repackaged CLIs) and stay unattributed.
 - Downloads are the ranking snapshot's 30-day counts; mirrors/CI dominate PyPI
   download stats, as always.

--- a/pypi-survey/findings.md
+++ b/pypi-survey/findings.md
@@ -1,6 +1,9 @@
 # PyPI top-10k native-dependency survey: detailed findings
 
-Survey date: **2026-07-16**, ranking by 30-day downloads ([hugovk/top-pypi-packages](https://hugovk.github.io/top-pypi-packages/), snapshot 2026-07-01, ClickHouse source). See README.md for methodology and reproduction steps.
+Survey date: **2026-07-16**, ranking by 30-day downloads
+([hugovk/top-pypi-packages](https://hugovk.github.io/top-pypi-packages/),
+snapshot 2026-07-01, ClickHouse source). See README.md for methodology and
+reproduction steps.
 
 ## 1. Pure Python vs native (the package itself)
 
@@ -10,7 +13,11 @@ Survey date: **2026-07-16**, ranking by 30-day downloads ([hugovk/top-pypi-packa
 | top 1,000  | 792   | 208    | 20.8%    | 28                            |
 | top 10,000 | 8,538 | 1,460  | 14.6%    | 73                            |
 
-“Native” = the latest release publishes at least one platform-specific wheel, or its sdist builds compiled code (`ext_modules`, Cython, Cargo, CMake/meson, …). Two placeholder packages (`aaaaaaaaa`, `timedelta`) are 404/fileless and excluded from top-10k percentages. `pyspark` counts as pure: its 450 MB payload is JVM jars, not compiled CPython extensions.
+“Native” = the latest release publishes at least one platform-specific wheel, or
+its sdist builds compiled code (`ext_modules`, Cython, Cargo, CMake/meson, …).
+Two placeholder packages (`aaaaaaaaa`, `timedelta`) are 404/fileless and
+excluded from top-10k percentages. `pyspark` counts as pure: its 450 MB payload
+is JVM jars, not compiled CPython extensions.
 
 ## 2. Transitive: does the runtime dependency closure contain native code?
 
@@ -22,7 +29,8 @@ Markers evaluated for CPython 3.12 / linux / x86_64, default extras only.
 | top 1,000  | 465          | 327                   | 208           | 535 (53.5%)           |
 | top 10,000 | 4,147        | 4,390                 | 1,460         | 5,850 (58.5%)         |
 
-Most common _direct_ native dependencies among pure packages that pull native code:
+Most common _direct_ native dependencies among pure packages that pull native
+code:
 
 | top 1,000    | count | top 10,000   | count |
 | ------------ | ----- | ------------ | ----- |
@@ -54,7 +62,8 @@ Most common _direct_ native dependencies among pure packages that pull native co
 | bazel         | 1   |     |             |     |     | binary/unknown   | 1   |
 | scikit-build  | 1   |     |             |     |     | c++              | 1   |
 
-cffi runtime users: 1. Most-bundled shared libraries (auditwheel-vendored in manylinux wheels):
+cffi runtime users: 1. Most-bundled shared libraries (auditwheel-vendored in
+manylinux wheels):
 
 | lib           | pkgs | lib           | pkgs | lib         | pkgs |
 | ------------- | ---- | ------------- | ---- | ----------- | ---- |
@@ -77,7 +86,8 @@ cffi runtime users: 1. Most-bundled shared libraries (auditwheel-vendored in man
 | pipcl         | 2   |     |                 |     |     |                  |     |
 | bazel         | 1   |     |                 |     |     |                  |     |
 
-cffi runtime users: 8. Most-bundled shared libraries (auditwheel-vendored in manylinux wheels):
+cffi runtime users: 8. Most-bundled shared libraries (auditwheel-vendored in
+manylinux wheels):
 
 | lib         | pkgs | lib              | pkgs | lib           | pkgs |
 | ----------- | ---- | ---------------- | ---- | ------------- | ---- |
@@ -121,7 +131,8 @@ cffi runtime users: 8. Most-bundled shared libraries (auditwheel-vendored in man
 | nuitka                             | 1   |     |                 |     |     |                  |     |
 | makepanda                          | 1   |     |                 |     |     |                  |     |
 
-cffi runtime users: 42. Most-bundled shared libraries (auditwheel-vendored in manylinux wheels):
+cffi runtime users: 42. Most-bundled shared libraries (auditwheel-vendored in
+manylinux wheels):
 
 | lib           | pkgs | lib        | pkgs | lib        | pkgs |
 | ------------- | ---- | ---------- | ---- | ---------- | ---- |
@@ -166,7 +177,9 @@ cffi runtime users: 42. Most-bundled shared libraries (auditwheel-vendored in ma
 
 ## 5. Native reach: how much each native package is pulled
 
-For every top-10k package, its runtime closure was computed; a native package's _reach_ is how many top-10k packages contain it. Download-weighting sums the dependents' 30-day downloads.
+For every top-10k package, its runtime closure was computed; a native package's
+_reach_ is how many top-10k packages contain it. Download-weighting sums the
+dependents' 30-day downloads.
 
 | native package         | own rank | pulled by (pkgs) | dl-weighted (30d) | own downloads (30d) | language       |
 | ---------------------- | -------- | ---------------- | ----------------- | ------------------- | -------------- |
@@ -221,4 +234,6 @@ For every top-10k package, its runtime closure was computed; a native package's 
 | pendulum               | 437      | 139              | 0.51 B            | 75 M                | rust           |
 | msgspec                | 625      | 134              | 0.99 B            | 44 M                | c              |
 
-The interactive flame chart (`flame.html`) shows the same data subdivided by _route_: under each native package, the direct dependents through which the pulls flow.
+The interactive flame chart (`flame.html`) shows the same data subdivided by
+_route_: under each native package, the direct dependents through which the
+pulls flow.

--- a/scripts/eval-diff.py
+++ b/scripts/eval-diff.py
@@ -6,7 +6,7 @@
 # thing costs one eval per run.
 #
 # Only the drv-level view: meta/passthru-only changes do not move drvPaths and
-# stay invisible here (that is the point; see CLAUDE.md "Checking your work").
+# stay invisible here (that is the point; see docs/building.md "Before you commit").
 #
 # Usage:
 #   eval-diff.py --jobs-out eval-jobs.jsonl --map-out eval-map.json \

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -360,6 +360,28 @@ def run_update_script(t):
     return None
 
 
+def commit_step(message):
+    # nix fmt first: an update script may write an unformatted pin and CI
+    # rejects unformatted files, so each commit has to stand on its own.
+    run(["nix", "fmt"], cwd=REPO)
+    run(["git", "-C", str(REPO), "add", "-A"])
+    clean = subprocess.run(
+        ["git", "-C", str(REPO), "diff", "--cached", "--quiet"]
+    ).returncode
+    if clean == 0:
+        return
+    run(["git", "-C", str(REPO), "commit", "-m", message])
+    print(f"  committed: {message}")
+
+
+def commit_summary(name, outcome):
+    # The backends already return "<old> -> <new>" for a real bump, which is
+    # the nixpkgs summary for a version bump (docs/style.md).
+    if outcome and re.fullmatch(r"\S+ -> \S+", outcome.strip()):
+        return f"{name}: {outcome.strip()}"
+    return f"{name}: update"
+
+
 def flake_input_rev(name):
     node = json.loads((REPO / "flake.lock").read_text())["nodes"][name]["locked"]
     return node.get("rev") or node.get("ref") or ""
@@ -404,6 +426,11 @@ def main():
         "--summary-out",
         metavar="FILE",
         help="write a markdown summary (the auto-update PR body)",
+    )
+    ap.add_argument(
+        "--commit",
+        action="store_true",
+        help="commit each target and repo-wide step separately (the update workflow)",
     )
     args = ap.parse_args()
 
@@ -471,6 +498,8 @@ def main():
         if outcome is None:
             outcome = "updated" if changed else "up to date"
         results.append((t.name, normalize_outcome(t, outcome, changed)))
+        if args.commit and changed:
+            commit_step(commit_summary(t.name, outcome))
 
     # Retain before pruning: prune_rels drops the rel key of any version no
     # longer served, which is exactly the version retention just brought back.
@@ -479,6 +508,8 @@ def main():
             retained = regen_history()
             if retained:
                 results.append(("history", retained))
+                if args.commit:
+                    commit_step("pkgs: retain outgoing versions in registry history")
         except Exception as e:
             failures.append("history retention")
             results.append(("history", f"FAILED: {failure_line(e)}"))
@@ -487,6 +518,8 @@ def main():
         pruned = prune_rels()
         if pruned:
             results.append(("rels", pruned))
+            if args.commit:
+                commit_step("pkgs: prune rels keys nothing serves")
     except Exception as e:
         failures.append("rels prune")
         results.append(("rels", f"FAILED: {failure_line(e)}"))
@@ -509,6 +542,8 @@ def main():
             # noise in the summary on every PR, unlike history/rels above.
             if repo_status() != before:
                 results.append((name, outcome or "re-synced"))
+                if args.commit:
+                    commit_step(f"{name}: re-sync generated listing")
 
     notes = fired_notes(priors)
     for n in notes:


### PR DESCRIPTION
AGENTS.md restated conventions that humans need too, so the same rules lived in two places and could drift apart. It now holds only what is specific to working here as an agent, and points at the docs that own each rule.

docs/building.md and docs/style.md are new: the remote-builder policy, the build and check commands, and the code norms had no home outside AGENTS.md. Three rules existed only there and would have been lost in the move, so they land in the doc that owns them: the nixpkgsByProfile prohibition and the patch/vendoring placement in packaging, the WASIXCC_*/CC=wasixcc rule in architecture.