### PR TITLE
wasix-sendmail: init at 0.1.10

### DIFF
--- a/pkgs/overlay/packages/wasix-sendmail/dependencies.patch
+++ b/pkgs/overlay/packages/wasix-sendmail/dependencies.patch
@@ -1,0 +1,454 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index f473d04..0dff42e 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2,21 +2,6 @@
+ # It is not intended for manual editing.
+ version = 4
+
+-[[package]]
+-name = "addr2line"
+-version = "0.25.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+-dependencies = [
+- "gimli",
+-]
+-
+-[[package]]
+-name = "adler2"
+-version = "2.0.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+-
+ [[package]]
+ name = "ahash"
+ version = "0.8.12"
+@@ -100,7 +85,7 @@ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+ dependencies = [
+- "object 0.32.2",
++ "object",
+ ]
+
+ [[package]]
+@@ -109,33 +94,12 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+-[[package]]
+-name = "backtrace"
+-version = "0.3.76"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+-dependencies = [
+- "addr2line",
+- "cfg-if",
+- "libc 0.2.169",
+- "miniz_oxide",
+- "object 0.37.3",
+- "rustc-demangle",
+- "windows-link",
+-]
+-
+ [[package]]
+ name = "base64"
+ version = "0.22.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+-[[package]]
+-name = "bitflags"
+-version = "2.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+-
+ [[package]]
+ name = "cc"
+ version = "1.2.54"
+@@ -298,16 +262,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+ dependencies = [
+  "cfg-if",
+- "libc 0.2.169",
++ "libc",
+  "wasi",
+ ]
+
+-[[package]]
+-name = "gimli"
+-version = "0.32.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+-
+ [[package]]
+ name = "hashbrown"
+ version = "0.14.5"
+@@ -448,17 +406,6 @@ dependencies = [
+  "hashbrown 0.16.1",
+ ]
+
+-[[package]]
+-name = "io-uring"
+-version = "0.7.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+-dependencies = [
+- "bitflags",
+- "cfg-if",
+- "libc 0.2.169",
+-]
+-
+ [[package]]
+ name = "is_terminal_polyfill"
+ version = "1.70.2"
+@@ -507,7 +454,7 @@ dependencies = [
+  "percent-encoding",
+  "quoted_printable",
+  "rustls",
+- "socket2",
++ "socket2 0.5.10",
+  "tokio",
+  "url",
+  "webpki-roots 1.0.5",
+@@ -515,13 +462,9 @@ dependencies = [
+
+ [[package]]
+ name = "libc"
+-version = "0.2.152"
+-source = "git+https://github.com/wasix-org/libc.git?branch=v0.2.152#4c7fa6d827b1ac54b6077295d0599fb6125a7bed"
+-
+-[[package]]
+-name = "libc"
+-version = "0.2.169"
+-source = "git+https://github.com/wasix-org/libc.git?branch=wasix-0.2.169#a42a2c2eedfe171581b4850a6be439da6a72aa01"
++version = "0.2.189"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+ [[package]]
+ name = "litemap"
+@@ -547,22 +490,13 @@ version = "0.3.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+-[[package]]
+-name = "miniz_oxide"
+-version = "0.8.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+-dependencies = [
+- "adler2",
+-]
+-
+ [[package]]
+ name = "mio"
+-version = "1.1.0"
++version = "1.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
++checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+ dependencies = [
+- "libc 0.2.169",
++ "libc",
+  "wasi",
+  "windows-sys 0.61.2",
+ ]
+@@ -585,15 +519,6 @@ dependencies = [
+  "memchr",
+ ]
+
+-[[package]]
+-name = "object"
+-version = "0.37.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+-dependencies = [
+- "memchr",
+-]
+-
+ [[package]]
+ name = "once_cell"
+ version = "1.21.3"
+@@ -714,7 +639,7 @@ dependencies = [
+  "cc",
+  "cfg-if",
+  "getrandom",
+- "libc 0.2.169",
++ "libc",
+  "untrusted",
+  "windows-sys 0.52.0",
+ ]
+@@ -741,12 +666,6 @@ dependencies = [
+  "triomphe",
+ ]
+
+-[[package]]
+-name = "rustc-demangle"
+-version = "0.1.27"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+-
+ [[package]]
+ name = "rustc-hash"
+ version = "2.1.1"
+@@ -823,12 +742,6 @@ version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+-[[package]]
+-name = "slab"
+-version = "0.4.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+-
+ [[package]]
+ name = "smallvec"
+ version = "1.15.1"
+@@ -837,11 +750,22 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+ [[package]]
+ name = "socket2"
+-version = "0.5.5"
+-source = "git+https://github.com/wasix-org/socket2.git?branch=v0.5.5#93a7a4fb09f3bdd285a3c1c205173ddc7eb47028"
++version = "0.5.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+ dependencies = [
+- "libc 0.2.152",
+- "windows-sys 0.48.0",
++ "libc",
++ "windows-sys 0.52.0",
++]
++
++[[package]]
++name = "socket2"
++version = "0.6.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
++dependencies = [
++ "libc",
++ "windows-sys 0.61.2",
+ ]
+
+ [[package]]
+@@ -858,7 +782,7 @@ checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+ dependencies = [
+  "cc",
+  "cfg-if",
+- "libc 0.2.169",
++ "libc",
+  "psm",
+  "windows-sys 0.59.0",
+ ]
+@@ -921,18 +845,15 @@ dependencies = [
+
+ [[package]]
+ name = "tokio"
+-version = "1.46.1"
++version = "1.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
++checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+ dependencies = [
+- "backtrace",
+- "io-uring",
+- "libc 0.2.169",
++ "libc",
+  "mio",
+  "pin-project-lite",
+- "slab",
+- "socket2",
+- "windows-sys 0.52.0",
++ "socket2 0.6.5",
++ "windows-sys 0.61.2",
+ ]
+
+ [[package]]
+@@ -1020,10 +941,8 @@ dependencies = [
+  "clap",
+  "env_logger",
+  "lettre",
+- "libc 0.2.169",
+  "log",
+  "rootcause",
+- "socket2",
+  "tiny_http",
+  "ureq",
+  "url",
+@@ -1054,22 +973,13 @@ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+-[[package]]
+-name = "windows-sys"
+-version = "0.48.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+-dependencies = [
+- "windows-targets 0.48.5",
+-]
+-
+ [[package]]
+ name = "windows-sys"
+ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+ dependencies = [
+- "windows-targets 0.52.6",
++ "windows-targets",
+ ]
+
+ [[package]]
+@@ -1078,7 +988,7 @@ version = "0.59.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+ dependencies = [
+- "windows-targets 0.52.6",
++ "windows-targets",
+ ]
+
+ [[package]]
+@@ -1090,67 +1000,34 @@ dependencies = [
+  "windows-link",
+ ]
+
+-[[package]]
+-name = "windows-targets"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+-dependencies = [
+- "windows_aarch64_gnullvm 0.48.5",
+- "windows_aarch64_msvc 0.48.5",
+- "windows_i686_gnu 0.48.5",
+- "windows_i686_msvc 0.48.5",
+- "windows_x86_64_gnu 0.48.5",
+- "windows_x86_64_gnullvm 0.48.5",
+- "windows_x86_64_msvc 0.48.5",
+-]
+-
+ [[package]]
+ name = "windows-targets"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+ dependencies = [
+- "windows_aarch64_gnullvm 0.52.6",
+- "windows_aarch64_msvc 0.52.6",
+- "windows_i686_gnu 0.52.6",
++ "windows_aarch64_gnullvm",
++ "windows_aarch64_msvc",
++ "windows_i686_gnu",
+  "windows_i686_gnullvm",
+- "windows_i686_msvc 0.52.6",
+- "windows_x86_64_gnu 0.52.6",
+- "windows_x86_64_gnullvm 0.52.6",
+- "windows_x86_64_msvc 0.52.6",
++ "windows_i686_msvc",
++ "windows_x86_64_gnu",
++ "windows_x86_64_gnullvm",
++ "windows_x86_64_msvc",
+ ]
+
+-[[package]]
+-name = "windows_aarch64_gnullvm"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+-
+ [[package]]
+ name = "windows_aarch64_gnullvm"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+-[[package]]
+-name = "windows_aarch64_msvc"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+-
+ [[package]]
+ name = "windows_aarch64_msvc"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+-[[package]]
+-name = "windows_i686_gnu"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+-
+ [[package]]
+ name = "windows_i686_gnu"
+ version = "0.52.6"
+@@ -1163,48 +1040,24 @@ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+-[[package]]
+-name = "windows_i686_msvc"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+-
+ [[package]]
+ name = "windows_i686_msvc"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+-[[package]]
+-name = "windows_x86_64_gnu"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+-
+ [[package]]
+ name = "windows_x86_64_gnu"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+-[[package]]
+-name = "windows_x86_64_gnullvm"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+-
+ [[package]]
+ name = "windows_x86_64_gnullvm"
+ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+-[[package]]
+-name = "windows_x86_64_msvc"
+-version = "0.48.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+-
+ [[package]]
+ name = "windows_x86_64_msvc"
+ version = "0.52.6"
+diff --git a/Cargo.toml b/Cargo.toml
+index f6c7c65..c84dc08 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -43,13 +43,5 @@ uuid = { version = "1.0", features = [
+ ureq = { version = "2.10", default-features = false, features = ["tls"] }
+ url = "2.5"
+
+-# Pin wasix-specific crate versions so patches work
+-socket2 = "=0.5.5"
+-libc = "=0.2.169"
+-
+ [dev-dependencies]
+ tiny_http = "0.12"
+-
+-[patch.crates-io]
+-socket2 = { git = "https://github.com/wasix-org/socket2.git", branch = "v0.5.5" }
+-libc = { git = "https://github.com/wasix-org/libc.git", branch = "wasix-0.2.169" }

--- a/pkgs/overlay/packages/wasix-sendmail/package.nix
+++ b/pkgs/overlay/packages/wasix-sendmail/package.nix
@@ -1,0 +1,35 @@
+{
+  final,
+  nix-update-script,
+  ...
+}:
+final.rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wasix-sendmail";
+  version = "0.1.10";
+
+  src = final.fetchFromGitHub {
+    owner = "wasix-org";
+    repo = "wasix-sendmail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2gdbeJgJ+CertmJp0r0K8InU7A8mEUmLm1IejMuUWps=";
+  };
+
+  cargoPatches = [./dependencies.patch];
+  cargoHash = "sha256-bLGQmYdPMMaVPzpvotqiCxr4QTZ/U7cX9kmm2b6ncwQ=";
+
+  passthru = {
+    wasix.shipped = true;
+    wasmer = {
+      owner = "sendmail";
+      name = "sendmail";
+    };
+    updateScript = nix-update-script {extraArgs = ["--flake"];};
+  };
+
+  meta = {
+    description = "Sendmail-compatible email sender with multiple backends";
+    homepage = "https://github.com/wasix-org/wasix-sendmail";
+    license = final.lib.licenses.agpl3Only;
+    mainProgram = "sendmail";
+  };
+})

--- a/pkgs/overlay/packages/wasix-sendmail/tests/basic.nix
+++ b/pkgs/overlay/packages/wasix-sendmail/tests/basic.nix
@@ -1,0 +1,21 @@
+{
+  pkgs,
+  testLib,
+  wasmerPkgs,
+  ...
+}: {
+  file-backend = testLib.mkWasixRun {
+    name = "wasix-sendmail-file-backend";
+    nativePkgs = [pkgs.gnugrep];
+    wasixPkgs = [wasmerPkgs.sendmail];
+    forwardEnv = testLib.defaultForwardEnv ++ ["SENDMAIL_FILE_PATH"];
+    script = ''
+      export SENDMAIL_FILE_PATH="$WASIX_TEST_ROOT/mail.txt"
+      printf 'To: recipient@example.com\nSubject: Test\n\nMessage body\n' | sendmail -t
+
+      grep -F 'Envelope-To: recipient@example.com' "$SENDMAIL_FILE_PATH"
+      grep -F 'Subject: Test' "$SENDMAIL_FILE_PATH"
+      grep -F 'Message body' "$SENDMAIL_FILE_PATH"
+    '';
+  };
+}


### PR DESCRIPTION
## Context

Package [wasix-org/wasix-sendmail](https://github.com/wasix-org/wasix-sendmail) 0.1.10 as the shipped `sendmail/sendmail` webc. The source patch drops upstream crate forks that overlap wasinix crate adaptations and resolves their dependencies onto versions covered by the shared WASIX patch set.

## Behavior checked

The optimized WASIX build produced `sendmail.wasm`. Running the generated webc under Wasmer with `SENDMAIL_FILE_PATH` accepted a message through stdin, extracted its recipient with `-t`, and wrote the expected envelope recipient, subject, and body.