### PR TITLE
pkgs: add rsync

### DIFF
--- a/pkgs/overlay/packages/openssh/package.nix
+++ b/pkgs/overlay/packages/openssh/package.nix
@@ -4,26 +4,79 @@
 # session isolation reports that rather than pretending. ssh forks for
 # multiplexing and ProxyCommand, so this builds at the off profile.
 {
+  final,
   prev,
   helpers,
   ...
 }:
-helpers.libTweaks {
-  patches = [./patches/wasi-unsupported-calls.patch];
-  # no SCM_RIGHTS: openssh passes descriptors between its privsep processes and
-  # for ControlMaster multiplexing, and already carries a switch for platforms
-  # that cannot. wasi's msghdr does carry msg_control, so the probe says yes
-  # while struct cmsghdr stays undefined.
-  # wasi keeps no login records and has no chroot, so the accounting openssh
-  # writes on a session has nothing behind it; it carries switches for each.
-  env.NIX_CFLAGS_COMPILE = "-DDISABLE_FD_PASSING -DDISABLE_UTMP -DDISABLE_UTMPX -DDISABLE_WTMP -DDISABLE_WTMPX -DDISABLE_LASTLOG -DDISABLE_LOGIN";
-  configureFlags = [
-    "ac_cv_have_control_in_msghdr=no"
-    "ac_cv_have_accrights_in_msghdr=no"
-    # ifaddrs.h exists and getifaddrs does not, and openssh keys BindInterface
-    # off the header
-    "ac_cv_header_ifaddrs_h=no"
-  ];
-  passthru.wasix.supportedProfiles = ["off"];
-}
-prev.openssh
+helpers.wasmRename {wasmName = "ssh";} (
+  helpers.libTweaks {
+    patches = [
+      ./patches/wasi-unsupported-calls.patch
+      ./wasix-client.patch
+    ];
+    # no SCM_RIGHTS: openssh passes descriptors between its privsep processes and
+    # for ControlMaster multiplexing, and already carries a switch for platforms
+    # that cannot. wasi's msghdr does carry msg_control, so the probe says yes
+    # while struct cmsghdr stays undefined.
+    # wasi keeps no login records and has no chroot, so the accounting openssh
+    # writes on a session has nothing behind it; it carries switches for each.
+    env = {
+      NIX_CFLAGS_COMPILE = "-DDISABLE_FD_PASSING -DDISABLE_UTMP -DDISABLE_UTMPX -DDISABLE_WTMP -DDISABLE_WTMPX -DDISABLE_LASTLOG -DDISABLE_LOGIN";
+      ac_cv_func_daemon = "yes";
+      ac_cv_func_freeifaddrs = "no";
+      ac_cv_func_getifaddrs = "no";
+      ac_cv_search_getrrsetbyname = "none required";
+    };
+    configureFlags = old:
+      (helpers.dropFlagsByPrefix ["--with-libedit"] old)
+      ++ [
+        "--without-pam"
+        "--without-kerberos5"
+        "--without-security-key-builtin"
+        "--disable-security-key"
+        "--without-ldns"
+        "ac_cv_have_control_in_msghdr=no"
+        "ac_cv_have_accrights_in_msghdr=no"
+        # ifaddrs.h exists and getifaddrs does not, and openssh keys BindInterface
+        # off the header
+        "ac_cv_header_ifaddrs_h=no"
+      ];
+    passthru.wasix = {
+      shipped = true;
+      supportedProfiles = ["off"];
+    };
+    passthru.wasmer = {
+      name = "ssh";
+      entrypoint = "ssh";
+    };
+    outputs = _: ["out"];
+    postPatch = ''
+      mkdir -p wasix-compat
+      cp ${../git/wasix-compat/unistd.h} wasix-compat/unistd.h
+      cp ${../git/wasix-compat/proc.c} wasix-compat/proc.c
+    '';
+    preConfigure = ''
+      $CC -c wasix-compat/proc.c -o wasix-compat/proc.o
+      $AR rcs wasix-compat/libwasix-compat.a wasix-compat/proc.o
+      export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE-} -I$PWD/wasix-compat"
+      export NIX_LDFLAGS="''${NIX_LDFLAGS-} -L$PWD/wasix-compat -lwasix-compat"
+    '';
+    buildInputs = helpers.dropInputsByNameInfix ["libedit"];
+    propagatedBuildInputs = helpers.dropInputsByNameInfix ["libedit"];
+    buildFlags = old: old ++ ["ssh"];
+    installPhase = _: ''
+      runHook preInstall
+      install -D -m 0755 ssh "$out/bin/ssh"
+      runHook postInstall
+    '';
+    postInstall = _: "";
+  } (prev.openssh.override {
+    inherit (final) libedit openssl zlib;
+    withFIDO = false;
+    withKerberos = false;
+    withLdns = false;
+    withPAM = false;
+    withSecurityKey = false;
+  })
+)

--- a/pkgs/overlay/packages/openssh/wasix-client.patch
+++ b/pkgs/overlay/packages/openssh/wasix-client.patch
@@ -1,0 +1,211 @@
+diff --git a/dns.c b/dns.c
+index a44dc27..cc6e8d4 100644
+--- a/dns.c
++++ b/dns.c
+@@ -40 +40,9 @@
+-#include "digest.h"
++#include "digest.h"
++#ifndef ERRSET_SUCCESS
++#define ERRSET_SUCCESS 0
++#define ERRSET_NOMEMORY 1
++#define ERRSET_FAIL 2
++#define ERRSET_INVAL 3
++#define ERRSET_NONAME 4
++#define ERRSET_NODATA 5
++#endif
+@@ -178 +178,8 @@ verify_host_key_dns(const char *hostname, struct sockaddr *address,
+-	u_int counter;
++#ifdef __wasix__
++	(void)hostname;
++	(void)address;
++	(void)hostkey;
++	*flags = 0;
++	return -1;
++#else
++	u_int counter;
+@@ -277 +284,2 @@ verify_host_key_dns(const char *hostname, struct sockaddr *address,
+-	return 0;
++	return 0;
++#endif
+diff --git a/misc.c b/misc.c
+index 2973085..2219e1b 100644
+--- a/misc.c
++++ b/misc.c
+@@ -67 +67,21 @@
+ #include "platform.h"
++
++#ifdef __wasix__
++struct passwd *
++wasix_fallback_passwd(uid_t uid)
++{
++	static struct passwd pw;
++	char *home;
++
++	home = getenv("HOME");
++	pw.pw_name = "wasix";
++	pw.pw_passwd = "";
++	pw.pw_uid = uid;
++	pw.pw_gid = getgid();
++	pw.pw_gecos = "WASIX";
++	pw.pw_dir = home != NULL && *home != '\0' ? home : "/";
++	pw.pw_shell = "/bin/sh";
++	return &pw;
++}
++#endif
++
+@@ -1303,4 +1323,9 @@ tilde_expand(const char *filename, uid_t uid, char **retp)
+-	} else if ((pw = getpwuid(uid)) == NULL) {
+-		error_f("No such uid %ld", (long)uid);
+-		goto out;
+-	}
++#ifdef __wasix__
++	} else if ((pw = getpwuid(uid)) == NULL) {
++		pw = wasix_fallback_passwd(uid);
++#else
++	} else if ((pw = getpwuid(uid)) == NULL) {
++		error_f("No such uid %ld", (long)uid);
++		goto out;
++#endif
++	}
+@@ -2842 +2842,14 @@ subprocess(const char *tag, const char *command,
+-	FILE *f = NULL;
++#ifdef __wasix__
++	(void)tag;
++	(void)command;
++	(void)ac;
++	(void)av;
++	(void)child;
++	(void)flags;
++	(void)pw;
++	(void)drop_privs;
++	(void)restore_privs;
++	error_f("subprocess execution is not supported");
++	return 0;
++#else
++	FILE *f = NULL;
+@@ -2979 +2992,2 @@ subprocess(const char *tag, const char *command,
+-	return pid;
++	return pid;
++#endif
+diff --git a/misc.h b/misc.h
+index 8ed5a80..c2a19d4 100644
+--- a/misc.h
++++ b/misc.h
+@@ -89 +89,7 @@ int	 tilde_expand(const char *, uid_t, char **);
+ char	*tilde_expand_filename(const char *, uid_t);
++
++#ifdef __wasix__
++struct passwd;
++struct passwd *wasix_fallback_passwd(uid_t);
++#endif
++
+diff --git a/mux.c b/mux.c
+index e4c368e..5f71c70 100644
+--- a/mux.c
++++ b/mux.c
+@@ -31,6 +31,15 @@
+ #include <string.h>
+ #include <unistd.h>
+-
++#ifdef __wasix__
++static int
++wasix_daemon(int nochdir, int noclose)
++{
++	errno = ENOSYS;
++	return -1;
++}
++#define daemon wasix_daemon
++#endif
++
+ #include "xmalloc.h"
+ #include "log.h"
+ #include "ssh.h"
+diff --git a/readpass.c b/readpass.c
+index 525c0db..bd7210a 100644
+--- a/readpass.c
++++ b/readpass.c
+@@ -50 +50,2 @@ ssh_askpass(char *askpass, const char *msg, const char *env_hint)
+-	pid_t pid, ret;
++#ifndef __wasix__
++	pid_t pid, ret;
+@@ -107,0 +109,6 @@ ssh_askpass(char *askpass, const char *msg, const char *env_hint)
++#else
++	(void)askpass;
++	(void)msg;
++	(void)env_hint;
++	return NULL;
++#endif
+@@ -267,0 +276 @@ notify_start(int force_askpass, const char *fmt, ...)
++#ifndef __wasix__
+@@ -286 +296,2 @@ notify_start(int force_askpass, const char *fmt, ...)
+- out_ctx:
++#endif
++ out_ctx:
+diff --git a/readconf.c b/readconf.c
+index 8ab9072..711d222 100644
+--- a/readconf.c
++++ b/readconf.c
+@@ -50,6 +50,10 @@
+ #if defined(HAVE_STRNVIS) && defined(HAVE_VIS_H) && !defined(BROKEN_STRNVIS)
+ # include <vis.h>
+ #endif
++
++#ifdef __wasix__
++#undef HAVE_IFADDRS_H
++#endif
+-
++
+ #include "xmalloc.h"
+ #include "ssh.h"
+diff --git a/ssh.c b/ssh.c
+index 1530cdf..03ae64d 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -63,9 +63,17 @@
+ #include <limits.h>
+ #include <locale.h>
+-
++#ifdef __wasix__
++static int
++wasix_daemon(int nochdir, int noclose)
++{
++	errno = ENOSYS;
++	return -1;
++}
++#define daemon wasix_daemon
++#endif
++
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+-
+ #ifdef WITH_OPENSSL
+ #include <openssl/evp.h>
+ #include <openssl/err.h>
+@@ -664,4 +672,8 @@ main(int ac, char **av)
+-	if (!pw) {
+-		logit("No user exists for uid %lu", (u_long)getuid());
+-		exit(255);
+-	}
++	if (!pw) {
++#ifdef __wasix__
++		pw = wasix_fallback_passwd(getuid());
++#else
++		logit("No user exists for uid %lu", (u_long)getuid());
++		exit(255);
++#endif
++	}
+diff --git a/sshconnect.c b/sshconnect.c
+index 764a1cc..c77db18 100644
+--- a/sshconnect.c
++++ b/sshconnect.c
+@@ -37,6 +37,9 @@
+ #include <unistd.h>
+ #include <ifaddrs.h>
+-
++#ifdef __wasix__
++#undef HAVE_IFADDRS_H
++#endif
++
+ #include "xmalloc.h"
+ #include "hostfile.h"
+ #include "ssh.h"

--- a/pkgs/overlay/packages/rsync/package.nix
+++ b/pkgs/overlay/packages/rsync/package.nix
@@ -1,90 +1,49 @@
-# rsync for wasix. It fork()s (server/generator/receiver split), so it is
-# asyncified at link and gets git's fork shim (fork() is hidden under the EH
-# profiles and absent from libc.a). ACL/xattr support is dropped: WASI has no
-# ACLs or extended attributes. popt/xxhash/zstd/lz4/openssl/zlib come from the
-# overlay (xxhash is the NEON-fixed overlay lib, see packages/xxhash.nix);
-# iconv/perl/python stay build-platform tools.
 {
   final,
   prev,
   helpers,
+  preferredProfilePackages,
+  wasmerDependencies,
   ...
 }:
-helpers.libTweaks {
-  passthru.wasix.shipped = true;
-  # fork() needs asyncified binaries; wasixcc only asyncifies in the off profile
-  # on its own, so apply the pass here too (see git/findutils).
-  env.WASIXCC_WASM_OPT_FLAGS = "--asyncify:-O2";
-
-  # No ACLs or xattrs under WASI; configure would otherwise probe and misdetect.
-  configureFlags = [
-    "--disable-acl-support"
-    "--disable-xattr-support"
-  ];
-
-  postPatch = ''
-    # git's wasix-compat shim: unistd.h declaring fork() + proc.c implementing it
-    # via __wasi_proc_fork. TODO: lift wasix-compat into shared overlay infra.
-    mkdir -p wasix-compat
-    cp ${../git/wasix-compat/unistd.h} wasix-compat/unistd.h
-    cp ${../git/wasix-compat/proc.c} wasix-compat/proc.c
-
-    # wasix-libc gaps rsync trips over, force-included below:
-    #  - <sys/sysmacros.h> makedev/major/minor: no device nodes; stub them
-    #    (mknod fails at runtime anyway).
-    #  - fchdir / chroot: absent from libc.a; ENOSYS stubs in wasix-stubs.c.
-    #    rsync's pop_dir falls back to a saved path; chroot is daemon-only.
-    cat > wasix-compat/wasix-devmacros.h <<'EOF'
-    #ifndef _WASIX_DEVMACROS_H
-    #define _WASIX_DEVMACROS_H
-    #ifndef makedev
-    #define makedev(maj, min) ((unsigned)0)
-    #endif
-    #ifndef major
-    #define major(dev) ((unsigned)0)
-    #endif
-    #ifndef minor
-    #define minor(dev) ((unsigned)0)
-    #endif
-    int fchdir(int);
-    int chroot(const char *);
-    /* WASI has no POSIX file locking; give the F_*LK/F_*LCK values (locks fail
-       at runtime with EINVAL) so fcntl() lock calls in util1.c compile. */
-    #ifndef F_GETLK
-    #define F_GETLK 5
-    #define F_SETLK 6
-    #define F_SETLKW 7
-    #endif
-    #ifndef F_RDLCK
-    #define F_RDLCK 0
-    #define F_WRLCK 1
-    #define F_UNLCK 2
-    #endif
-    #endif
-    EOF
-    cat > wasix-compat/wasix-stubs.c <<'EOF'
-    #include <errno.h>
-    int chroot(const char *p) { (void)p; errno = ENOSYS; return -1; }
-    int fchdir(int fd) { (void)fd; errno = ENOSYS; return -1; }
-    EOF
-  '';
-  preConfigure = ''
-    export ac_cv_func_fork=yes
-    export ac_cv_func_vfork=yes
-    $CC -c wasix-compat/proc.c -o wasix-compat/proc.o
-    $CC -c wasix-compat/wasix-stubs.c -o wasix-compat/wasix-stubs.o
-    $AR rcs wasix-compat/libwasix-compat.a wasix-compat/proc.o wasix-compat/wasix-stubs.o
-    export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE-} -I$PWD/wasix-compat -include $PWD/wasix-compat/wasix-devmacros.h"
-    export NIX_LDFLAGS="''${NIX_LDFLAGS-} -L$PWD/wasix-compat -lwasix-compat"
-  '';
-
-  passthru.wasmer.entrypoint = "rsync";
-  postInstall = ''
-    if [ -f "$out/bin/rsync" ]; then
-      mv "$out/bin/rsync" "$out/bin/rsync.wasm"
-    fi
-  '';
-} (prev.rsync.overrideAttrs (old: {
-  buildInputs =
-    builtins.filter (d: !builtins.elem (d.pname or d.name or "") ["acl"]) (old.buildInputs or []);
-}))
+helpers.wasmRename {wasmName = "rsync";} (
+  helpers.libTweaks {
+    passthru.wasix.shipped = true;
+    passthru.wasix.updateNotes = [
+      "Recheck wasix-port.patch; drop rsync.h/util1.c fallbacks once rsync or wasix-libc provides the missing WASIX declarations."
+    ];
+    passthru.wasmer.dependencies = [
+      (wasmerDependencies.any preferredProfilePackages.openssh)
+    ];
+    configureFlags = [
+      "--disable-acl-support"
+      "--disable-xattr-support"
+      "ac_cv_func_getgroups=no"
+      "ac_cv_func_fork=yes"
+      "ac_cv_func_vfork=yes"
+    ];
+    env.WASIXCC_WASM_OPT_FLAGS = "--asyncify:-O2";
+    postPatch = ''
+      mkdir -p wasix-compat
+      cp ${../git/wasix-compat/unistd.h} wasix-compat/unistd.h
+      cp ${../git/wasix-compat/proc.c} wasix-compat/proc.c
+    '';
+    preConfigure = ''
+      $CC -c wasix-compat/proc.c -o wasix-compat/proc.o
+      $AR rcs wasix-compat/libwasix-compat.a wasix-compat/proc.o
+      export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE-} -I$PWD/wasix-compat"
+      export NIX_LDFLAGS="''${NIX_LDFLAGS-} -L$PWD/wasix-compat -lwasix-compat"
+    '';
+    patches = [./wasix-port.patch];
+    postInstall = ''
+      rm -f "$out/bin/rsync-ssl"
+    '';
+  } (prev.rsync.override {
+    inherit (final) libiconv zlib popt;
+    enableACLs = false;
+    enableLZ4 = false;
+    enableOpenSSL = false;
+    enableXXHash = false;
+    enableZstd = false;
+  })
+)

--- a/pkgs/overlay/packages/rsync/tests/basic.nix
+++ b/pkgs/overlay/packages/rsync/tests/basic.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  wasmerPkgs,
+  testLib,
+  ...
+}: let
+  native = [pkgs.rsync];
+  wasix = [wasmerPkgs.rsync];
+in {
+  version = testLib.mkWasixRun {
+    name = "rsync-version";
+    wasixPkgs = wasix;
+    script = "rsync --version";
+  };
+
+  sshRemoteShell = testLib.mkWasixRun {
+    name = "rsync-ssh-remote-shell";
+    wasixPkgs = wasix;
+    script = ''
+      mkdir home
+      HOME="$PWD/home" ssh -G -F /dev/null example.test >config
+      grep 'identityfile ~/.ssh/id_rsa' config
+
+      rsync -e 'ssh -V' localhost:/tmp/does-not-exist out 2>err && exit 1
+      cat err
+      grep 'OpenSSH_' err
+    '';
+  };
+
+  # Re-enable this as a Wasmer test once rsync local-copy runtime validation is in scope.
+  nativeLocalCopy = testLib.mkScriptRun {
+    name = "rsync-native-local-copy";
+    packages = native;
+    script = ''
+      mkdir -p src/sub dst
+      printf 'hello\n' > src/a.txt
+      printf 'nested\n' > src/sub/b.txt
+      rsync -r src/ dst/
+      find dst -type f -print | sort
+      cat dst/a.txt dst/sub/b.txt
+    '';
+  };
+}

--- a/pkgs/overlay/packages/rsync/wasix-port.patch
+++ b/pkgs/overlay/packages/rsync/wasix-port.patch
@@ -1,0 +1,51 @@
+diff --git a/rsync.h b/rsync.h
+index 3e1d945..be0860d 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -504,4 +504,16 @@ extern int syslog_facility;
+ # endif
+ #elif defined MAJOR_IN_SYSMACROS
+ #include <sys/sysmacros.h>
++#elif defined __wasix__
++#include <errno.h>
++#include <stdint.h>
++#define major(dev) ((unsigned int)(((uint64_t)(dev) >> 8) & 0xfff))
++#define minor(dev) ((unsigned int)(((uint64_t)(dev) & 0xff) | (((uint64_t)(dev) >> 12) & 0xfff00)))
++#define makedev(maj, min) ((dev_t)(((((uint64_t)(maj)) & 0xfff) << 8) | (((uint64_t)(min)) & 0xff) \
++                            | ((((uint64_t)(min)) & 0xfff00) << 12)))
++#endif
++
++#ifdef __wasix__
++#define chroot(path) (errno = ENOSYS, -1)
++#define fchdir(fd) (errno = ENOSYS, -1)
+ #endif
+diff --git a/util1.c b/util1.c
+index d74e87f..75b0025 100644
+--- a/util1.c
++++ b/util1.c
+@@ -631,14 +631,17 @@ pid_t do_fork(void)
+ /** Lock a byte range in a open file */
+ int lock_range(int fd, int offset, int len)
+ {
++#if defined F_WRLCK && defined F_SETLK
+-	struct flock lock;
+-
+-	lock.l_type = F_WRLCK;
+-	lock.l_whence = SEEK_SET;
+-	lock.l_start = offset;
+-	lock.l_len = len;
+-	lock.l_pid = 0;
+-
+-	return fcntl(fd,F_SETLK,&lock) == 0;
++    struct flock lock;
++    lock.l_type = F_WRLCK;
++    lock.l_whence = SEEK_SET;
++    lock.l_start = offset;
++    lock.l_len = len;
++    lock.l_pid = 0;
++    return fcntl(fd,F_SETLK,&lock) == 0;
++#else
++    errno = ENOSYS;
++    return 0;
++#endif
+ }


### PR DESCRIPTION
## Summary

Ports `rsync` to WASIX and adds Wasmer package wiring for it.

This includes a client-only `ssh` webc package and wires it as an rsync webc dependency, so `rsync -e ssh` can resolve an SSH command at runtime. The OpenSSH patch keeps unsupported helper paths disabled on WASIX and adds a minimal passwd fallback for bare Wasmer environments that do not mount `/etc/passwd`.

The rsync port keeps asyncify enabled because rsync uses forked sender/generator/receiver processes during transfers. The WASIX build gaps are handled with targeted source patches rather than a generated compatibility header.

## Draft Status

This PR is draft. SSH is now packaged and covered by a remote-shell smoke test, but full rsync-over-SSH integration against an SSH server still needs validation.

## Tests

- `nix fmt`
- `git diff --check && git diff --cached --check`
- `nix build .#wasmerPackages.ssh.webc -L --show-trace`
- `nix build .#wasmerPackages.rsync.tests -L --show-trace`
- `nix build .#wasmerPackages.rsync.webc -L --show-trace`

The Wasmer local-copy rsync test is intentionally skipped for now per follow-up guidance; local copy coverage remains native-only.