### PR TITLE
python-registry: resolve every wheel's requirements against the index

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -124,7 +124,10 @@ pip install --index-url file://$(readlink -f result)/simple <pkg>
 A new `wheels.nix` entry lands in the registry automatically. Its test suite
 (`checks.<system>.python-registry`) walks the index for hash and metadata
 integrity and pip-installs representative packages, resolving their deps from
-the index too, then imports them under wasmer.
+the index too, then imports them under wasmer. The integrity walk also resolves
+every served wheel's `Requires-Dist` against the rest of the index, per
+interpreter the wheel installs on, since a resolver has no other source to fall
+back to.
 
 Alongside `simple/`, the index root carries `packages.json`: one JSON object per
 line naming a published wheel, which is how `wasmerio/wasmer-compat` decides

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -149,6 +149,14 @@ consuming project asks for. The native view carries no wheels of its own; its
 pages link to the copies under `simple/`, which keeps serving the full closure
 for use as a standalone index.
 
+Cross-installing for wasix from a host needs pip. `pip --platform wasix_wasm32`
+selects the tagged wheels, while uv's `--python-platform` is a closed enum with
+no wasix entry. uv does resolve the index in universal mode
+(`uv pip compile --universal`), which commits to no platform, and installs the
+pure-python wheels directly. anybuild's template suite
+(`pkgs/overlay/packages/anybuild/tests/python-templates.nix`) covers that path
+end to end, serving this index over loopback.
+
 ## Rels
 
 Every wheel is published as `<version>+wasix.<rel>`, a PEP 440 local version.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -126,6 +126,10 @@ A new `wheels.nix` entry lands in the registry automatically. Its test suite
 integrity and pip-installs representative packages, resolving their deps from
 the index too, then imports them under wasmer.
 
+Alongside `simple/`, the index root carries `packages.json`: one JSON object per
+line naming a published wheel, which is how `wasmerio/wasmer-compat` decides
+which projects the index covers.
+
 `native/simple/` is the same index over the projects that ship a platform-tagged
 wheel, which are the ones nothing else can supply. Point a resolver at that as
 its priority index and PyPI as the primary one:

--- a/pkgs/overlay/python-packages/history.json
+++ b/pkgs/overlay/python-packages/history.json
@@ -91,6 +91,16 @@
       "tag": "0.9.25"
     }
   },
+  "cffi": {
+    "1.17.1": {
+      "hash": "sha256-JGskZDFFfG7XlES5wB4HNwQRzSPSOOvKpl4EdhLCIxs=",
+      "note": "snowflake-connector-python 3.18.1 pins cffi<2.0.0",
+      "tag": "v1.17.1",
+      "variants": [
+        "py313"
+      ]
+    }
+  },
   "charset-normalizer": {
     "3.4.7": {
       "hash": "sha256-dOdJ4f98smCYdskp3BwtQG6aOyK+2a73+x580FKRWDk=",

--- a/pkgs/python-registry/check-integrity.py
+++ b/pkgs/python-registry/check-integrity.py
@@ -1,21 +1,31 @@
 """Validate a generated registry (tests.nix `integrity`): the root index lists
 exactly the project dirs; every project-page anchor resolves to a file whose
 sha256 matches the fragment; every wheel has a PEP 658 .metadata sidecar whose
-hash matches data-core-metadata; no wheel on disk is missing from its page.
+hash matches data-core-metadata; no wheel on disk is missing from its page;
+packages.json lists exactly the served wheels; and every wheel's Requires-Dist
+is satisfiable from the index alone, on each interpreter the wheel installs on.
 
-Usage: check-integrity.py <registry store path>
+Usage: check-integrity.py <registry store path> <python-wheel-deps.py path>
 """
 
 import hashlib
+import importlib.util
+import json
 import re
 import sys
 from pathlib import Path
 from urllib.parse import unquote
 
+from packaging.markers import UndefinedEnvironmentName
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
 # the wheel anchor's opening tag; its visible text is the interpreter label
 # (plus a size span), so the filename comes from the href, not the link text.
 ANCHOR = re.compile(r'<a href="([^"#]+)#sha256=([0-9a-f]{64})"([^>]*)>')
 CORE_METADATA = re.compile(r'data-core-metadata="sha256=([0-9a-f]{64})"')
+CP_TAG = re.compile(r"cp(\d)(\d+)")
 PROJECT_LINK = re.compile(r'<a href="([^"]+)/">')
 
 
@@ -27,11 +37,37 @@ def fail(msg: str) -> None:
     sys.exit(f"registry integrity: {msg}")
 
 
+def load_module(path: str):
+    spec = importlib.util.spec_from_file_location("wheel_deps", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# {name}-{version}[-{build}]-{python}-{abi}-{platform}.whl: the build tag is
+# optional and follows the version, so the compatibility tags read from the right.
+def wheel_tags(fname: str) -> tuple[str, list[str], str]:
+    parts = fname[: -len(".whl")].split("-")
+    return parts[1], parts[-3].split("."), parts[-2]
+
+
+def installs_on(pytags: list[str], abi: str, interp: tuple[int, int]) -> bool:
+    major, minor = interp
+    for tag in pytags:
+        if tag in (f"py{major}", f"py{major}{minor}", f"cp{major}{minor}"):
+            return True
+        m = CP_TAG.fullmatch(tag)
+        # an abi3 wheel's python tag is a floor: it loads on every later CPython
+        if m and abi == "abi3" and (int(m[1]), int(m[2])) <= interp:
+            return True
+    return False
+
+
 def anchors(page: str) -> dict[str, str]:
     return {unquote(href): digest for href, digest, _ in ANCHOR.findall(page)}
 
 
-def check_native_view(root: Path, wheels: set[tuple[str, str]]) -> None:
+def check_native_view(root: Path, wheels: list[tuple[str, Path]]) -> None:
     """The native view must list exactly the projects with a platform-tagged
     wheel, and reach the copies simple/ holds rather than carrying its own.
 
@@ -42,8 +78,8 @@ def check_native_view(root: Path, wheels: set[tuple[str, str]]) -> None:
     native_dir = root / "native" / "simple"
     expected = {
         project
-        for project, fname in wheels
-        if fname[: -len(".whl")].rsplit("-", 1)[-1] != "any"
+        for project, path in wheels
+        if path.name[: -len(".whl")].rsplit("-", 1)[-1] != "any"
     }
     listed = set(PROJECT_LINK.findall((native_dir / "index.html").read_text()))
     on_disk = {d.name for d in native_dir.iterdir() if d.is_dir()}
@@ -69,8 +105,120 @@ def check_native_view(root: Path, wheels: set[tuple[str, str]]) -> None:
                 fail(f"native/{project}: {href} does not resolve into simple/")
 
 
+def parse_metadata(path: Path) -> tuple[SpecifierSet | None, list[Requirement]]:
+    """(Requires-Python, Requires-Dist) from a PEP 658 sidecar."""
+    bound = None
+    reqs = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("Requires-Python:"):
+            bound = SpecifierSet(line.split(":", 1)[1].strip())
+        elif line.startswith("Requires-Dist:"):
+            try:
+                reqs.append(Requirement(line.split(":", 1)[1].strip()))
+            except InvalidRequirement:
+                continue
+    return bound, reqs
+
+
+def check_packages_json(root: Path, wheels: list[tuple[str, Path]]) -> None:
+    """wasmer-compat reads this JSONL to decide which projects the index covers,
+    and skips any line it cannot parse, so a wrong shape degrades to an empty
+    index rather than an error."""
+    listed = set()
+    for n, line in enumerate(
+        root.joinpath("packages.json").read_text().splitlines(), 1
+    ):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as e:
+            fail(f"packages.json line {n} is not JSON: {e}")
+        if "filename" not in entry:
+            fail(f"packages.json line {n} has no 'filename' key")
+        listed.add(entry["filename"])
+    on_disk = {path.name for _, path in wheels}
+    if listed != on_disk:
+        fail(f"packages.json vs wheels on disk differ: {sorted(listed ^ on_disk)}")
+
+
+def check_requirements(wheels: list[tuple[str, Path]], wheel_deps) -> None:
+    interps = set()
+    for _, path in wheels:
+        _, pytags, abi = wheel_tags(path.name)
+        # an abi3 tag names the floor it was built against, not an interpreter
+        # the index serves, so cp37-abi3 must not invent a python 3.7
+        if abi == "abi3":
+            continue
+        for tag in pytags:
+            if m := CP_TAG.fullmatch(tag):
+                interps.add((int(m[1]), int(m[2])))
+    if not interps:
+        fail("no cp-tagged wheel, so the served interpreters cannot be derived")
+
+    meta = {
+        path: parse_metadata(path.with_name(f"{path.name}.metadata"))
+        for _, path in wheels
+    }
+
+    # interpreter -> project -> versions installable on it. A resolver takes a
+    # wheel only where both gates admit it, so a py3-none-any wheel is limited by
+    # its Requires-Python alone.
+    served: dict[tuple[int, int], dict[str, list[Version]]] = {i: {} for i in interps}
+    targets: dict[Path, list[tuple[int, int]]] = {}
+    for project, path in wheels:
+        version, pytags, abi = wheel_tags(path.name)
+        bound = meta[path][0]
+        applies = sorted(
+            i
+            for i in interps
+            if installs_on(pytags, abi, i)
+            and (bound is None or bound.contains(f"{i[0]}.{i[1]}"))
+        )
+        if not applies:
+            fail(f"{project}: {path.name} installs on none of {sorted(interps)}")
+        targets[path] = applies
+        for i in applies:
+            served[i].setdefault(project, []).append(Version(version))
+
+    unmet = []
+    for project, path in wheels:
+        reqs = meta[path][1]
+        for interp in targets[path]:
+            py = f"{interp[0]}.{interp[1]}"
+            env = dict(wheel_deps.ENV, python_version=py, python_full_version=py)
+            for req in reqs:
+                if req.marker is not None:
+                    try:
+                        if not req.marker.evaluate(env):
+                            continue
+                    except UndefinedEnvironmentName:
+                        continue  # an extra's requirement: not installed by default
+                have = served[interp].get(wheel_deps.normalize(req.name), [])
+                # filter() applies pip's rule: prefer stable, fall back to a
+                # pre-release only when nothing else matches.
+                if not any(req.specifier.filter(have)):
+                    unmet.append((path.name, py, str(req), have))
+
+    if unmet:
+        for fname, py, req, have in unmet:
+            state = (
+                f"served: {', '.join(sorted(map(str, have)))}" if have else "not served"
+            )
+            print(f"{fname} (python {py}): requires '{req}' ({state})", file=sys.stderr)
+        print(
+            "-> a resolver installing from this index sees no other source, so every "
+            "requirement must be satisfiable from it; serve the missing version or fix "
+            "the requiring package's metadata.",
+            file=sys.stderr,
+        )
+        fail(f"{len(unmet)} unsatisfiable requirement(s)")
+
+
 def main() -> None:
-    simple = Path(sys.argv[1]) / "simple"
+    root = Path(sys.argv[1])
+    wheel_deps = load_module(sys.argv[2])
+    simple = root / "simple"
     listed = set(
         re.findall(r'<a href="([^"]+)/">', (simple / "index.html").read_text())
     )
@@ -78,8 +226,7 @@ def main() -> None:
     if listed != on_disk:
         fail(f"root index vs project dirs differ: {sorted(listed ^ on_disk)}")
 
-    total = 0
-    served: set[tuple[str, str]] = set()
+    wheels = []
     for pdir in sorted(simple.iterdir()):
         if not pdir.is_dir():
             continue
@@ -101,18 +248,19 @@ def main() -> None:
             if not metadata.is_file() or sha256_of(metadata) != core.group(1):
                 fail(f"{pdir.name}: metadata sidecar missing or mismatched for {fname}")
             anchored.add(fname)
-            served.add((pdir.name, fname))
-            total += 1
+            wheels.append((pdir.name, wheel))
         wheels_on_disk = {f.name for f in pdir.glob("*.whl")}
         if anchored != wheels_on_disk:
             fail(
                 f"{pdir.name}: anchors vs wheels on disk differ: {sorted(anchored ^ wheels_on_disk)}"
             )
 
-    if total == 0:
+    if not wheels:
         fail("no wheels indexed at all")
-    check_native_view(Path(sys.argv[1]), served)
-    print(f"registry OK: {len(on_disk)} projects, {total} wheels")
+    check_packages_json(root, wheels)
+    check_native_view(root, wheels)
+    check_requirements(wheels, wheel_deps)
+    print(f"registry OK: {len(on_disk)} projects, {len(wheels)} wheels")
 
 
 if __name__ == "__main__":

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -12,6 +12,7 @@ Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
   <out>/simple/<project>/index.html     file list with #sha256= anchors
   <out>/simple/<project>/<wheel>        the wheel itself (relative hrefs)
   <out>/simple/<project>/<wheel>.metadata   its core metadata, for resolvers
+  <out>/packages.json                   flat wheel list, for wasmer-compat
   <out>/native/simple/...               the same index over native projects only
 """
 
@@ -391,6 +392,18 @@ def project_page(project: str, files: list[tuple], href_prefix: str = "") -> str
 """
 
 
+def write_packages_json(dest: Path, served) -> None:
+    """Flat wheel list, one JSON object per line, read by wasmer-compat to decide
+    which projects the index covers. It drops any line it cannot parse, so an
+    entry that loses its `filename` key goes silently uncounted."""
+    dest.write_text(
+        "".join(
+            json.dumps({"filename": fname, "hash": f"sha256={digest}"}) + "\n"
+            for fname, digest in sorted(served)
+        )
+    )
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("dists", type=Path)
@@ -442,6 +455,7 @@ def main() -> None:
             f" `publishOnce` in wheels.nix:\n{listed}"
         )
 
+    served: list[tuple[str, str]] = []
     # project -> the rows its page was built from, reused by the native view
     pages: dict[str, list[tuple]] = {}
     for project, wheels in sorted(projects.items()):
@@ -454,6 +468,7 @@ def main() -> None:
             (pdir / f"{fname}.metadata").write_bytes(metadata)
             md_digest = hashlib.sha256(metadata).hexdigest()
             digest = hashlib.sha256(src.read_bytes()).hexdigest()
+            served.append((fname, digest))
             # rev/attr/published/source are publish-time facts (publish.py
             # fills them from the manifest); size is intrinsic, so shown here
             # already.
@@ -500,6 +515,7 @@ def main() -> None:
     (out / "provenance.json").write_text(
         json.dumps(provenance, indent=2, sort_keys=True) + "\n"
     )
+    write_packages_json(out / "packages.json", served)
     print(
         f"indexed {sum(map(len, projects.values()))} wheels across {len(projects)} projects"
         f" ({len(native)} of them native)"

--- a/pkgs/python-registry/publish.py
+++ b/pkgs/python-registry/publish.py
@@ -10,6 +10,7 @@ lockfiles keep resolving.
 
 Volume layout (= the web root served by the app):
   index.html, simple/...     as in the nix output
+  packages.json              flat list of everything published so far
   manifests/<wheel>.json     {project, sha256, metadata_sha256, requires_python,
                               size, published (UTC date, frozen at first publish),
                               + provenance: attr, drv_path, wasinix_rev}
@@ -174,6 +175,10 @@ def main():
         make_index.page("Simple index", root)
     )
     (staging / "index.html").write_text(make_index.landing(projects))
+    make_index.write_packages_json(
+        staging / "packages.json",
+        ((fname, m["sha256"]) for fname, m in manifests.items()),
+    )
 
     print(
         f"publishing {len(new)} new wheels "

--- a/pkgs/python-registry/tests.nix
+++ b/pkgs/python-registry/tests.nix
@@ -66,8 +66,11 @@
 in {
   integrity = testLib.mkScriptRun {
     name = "registry-integrity";
-    packages = [pkgs.python3];
-    script = "python3 ${./check-integrity.py} ${registry}";
+    packages = [(pkgs.python3.withPackages (ps: [ps.packaging]))];
+    # python-wheel-deps.py carries the wasix marker environment the requirement
+    # walk evaluates against; it is a path argument because nix copies each
+    # script into the store on its own, losing the sibling relationship.
+    script = "python3 ${./check-integrity.py} ${registry} ${../python-wheel-deps.py}";
   };
 
   # pure wheel with a pure dep chain.

--- a/pkgs/python-wheel-deps.py
+++ b/pkgs/python-wheel-deps.py
@@ -77,4 +77,5 @@ def main() -> None:
     print(f"OK {Path(dist).name}: {len(wheels)} wheel(s)")
 
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The first three commits are the publish derivation, #174, which has to land
first; this diff collapses to the four after them when it does. (#173 carried
that work but was merged into this branch rather than into main.)

## Context

Every requirement in a served wheel's metadata has to be satisfiable from this
index, because a resolver installing from it has no other source: PyPI's
manylinux wheels cannot load under wasix. `python-wheel-deps.py` already checks
this, but by name only, for worklist entries, on one interpreter.

This walks the whole published set: for every wheel, on each interpreter it
installs on, every `Requires-Dist` that survives marker evaluation must name a
project the index serves at a version satisfying the specifier. It reads the
PEP 658 sidecars already on disk, so it costs seconds and joins the per-PR set.

The `+wasix.N` local version is the thing this has to get right, so the walk
uses `packaging`'s own `SpecifierSet` rather than comparing strings.

## Impact

`cffi 1.17.1` ships alongside 2.1.0: the walk found it as a genuine gap, with
served wheels requiring `cffi<2` that nothing could satisfy.

`packages.json` lands at the index root, one JSON object per line, which is the
shape `wasmerio/wasmer-compat` reads to decide what the index covers. Its
contents are asserted against the wheels on disk by the same check.

## Behavior checked

`registry OK: 432 projects, 750 wheels`.

Not trusted as a green run: a copy of the index with `totally-not-served>=99`
spliced into six's metadata, and the sidecar hash repointed so the tamper reads
as a requirements defect rather than a hash one, fails on both interpreters and
names the requirement.
