### PR TITLE
python-registry: sweep every served project with the real resolver

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -129,6 +129,11 @@ every served wheel's `Requires-Dist` against the rest of the index, per
 interpreter the wheel installs on, since a resolver has no other source to fall
 back to.
 
+`python-registry-resolve-sweep` runs pip itself over every served project, which
+catches what a model of pip cannot: a dependency reached only through an extra,
+say. A project has to resolve on one interpreter, not all of them, since a
+release states its own supported range.
+
 Alongside `simple/`, the index root carries `packages.json`: one JSON object per
 line naming a published wheel, which is how `wasmerio/wasmer-compat` decides
 which projects the index covers.

--- a/pkgs/python-publish.nix
+++ b/pkgs/python-publish.nix
@@ -49,6 +49,9 @@
         "python-publish: variants ${toString variants} skip an interpreter, which no single Requires-Python bound can express"
         ">=${lib.head allowed},<${nextMinor (lib.last allowed)}";
 in {
+  # The registry sweeps per interpreter, so it needs the same mapping.
+  inherit interpreters;
+
   # `suffix` marks PR-preview wheels, whose longer local version sorts above the
   # published one when the preview index is used as an extra index.
   publishOf = {

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -22,7 +22,7 @@
   # rels.json only to report keys no served version claims.
   rels = builtins.fromJSON (builtins.readFile ../../rels.json);
   relPrefix = "pythonRegistry.wheels.";
-  inherit (import ../python-publish.nix {inherit pkgs lib;}) publishOf;
+  inherit (import ../python-publish.nix {inherit pkgs lib;}) publishOf interpreters;
 
   # Repo-relative "path:line" of the package definition, for the index's
   # publish-time source link. Only for positions in this repo: closure wheels
@@ -73,6 +73,17 @@
       closure);
 
   perVersion = lib.mapAttrs servedOf pythonSets;
+
+  # pname -> the interpreter versions a resolver can reach it on. A wheel set is
+  # built per interpreter, so carrying the project is what makes it visible
+  # there; a noarch wheel sits in one set alone and is swept on that one.
+  projectInterpreters = lib.foldl' (
+    acc: pv:
+      lib.foldl' (a: e:
+        a // {${e.name} = lib.unique ((a.${e.name} or []) ++ [interpreters.${pv}]);})
+      acc
+      perVersion.${pv}
+  ) {} (lib.attrNames perVersion);
   wheelDists = lib.concatLists (lib.attrValues perVersion);
 
   # The published artifacts, addressable so the reproduce command on an index
@@ -121,9 +132,13 @@
     '';
 
   # e2e/import tests run on the default python webc, installing from the merged index.
-  tests = import ./tests.nix {
-    inherit pkgs lib registry testLib pythonWebc python3;
-  };
+  tests =
+    import ./tests.nix {
+      inherit pkgs lib registry testLib pythonWebc python3;
+    }
+    // import ./resolve-sweep.nix {
+      inherit pkgs lib registry testLib projectInterpreters;
+    };
 in
   registry.overrideAttrs (o: {
     passthru =

--- a/pkgs/python-registry/resolve-sweep.nix
+++ b/pkgs/python-registry/resolve-sweep.nix
@@ -1,0 +1,59 @@
+# One pip resolve per served project against the built index. The integrity walk
+# models pip's tag and metadata handling; this runs the real resolver, so it
+# catches what the model misses, such as a dependency reached only through an
+# extra.
+{
+  pkgs,
+  lib,
+  registry,
+  testLib,
+  # pname -> the interpreter versions whose wheel set carries it
+  projectInterpreters,
+}: let
+  hostPython = pkgs.python3.withPackages (ps: [ps.pip]);
+
+  worklist =
+    pkgs.writeText "registry-resolve-worklist"
+    (lib.concatStringsSep "\n"
+      (lib.mapAttrsToList (project: pyVersions: "${project} ${lib.concatStringsSep " " pyVersions}")
+        projectInterpreters)
+      + "\n");
+in {
+  # A project has to resolve on one interpreter, not on all of them: a release
+  # states its own supported range, and litellm's `<3.14` is not a defect in the
+  # index. Whether a wheel reaches the interpreters it claims is the integrity
+  # walk's question, which reads tags and Requires-Python directly.
+  resolve-sweep = testLib.mkScriptRun {
+    name = "registry-resolve-sweep";
+    packages = [hostPython];
+    script = ''
+      resolve_one() {
+        project=$1
+        shift
+        for py in "$@"; do
+          if python3 -m pip install \
+            --quiet --no-cache-dir --disable-pip-version-check \
+            --platform wasix_wasm32 --implementation cp \
+            --python-version "$py" --abi "cp''${py//./}" \
+            --only-binary :all: --index-url file://${registry}/simple \
+            --dry-run --report /dev/null "$project" >/dev/null 2>&1; then
+            return 0
+          fi
+        done
+        echo "  $project (tried python $*)"
+      }
+      export -f resolve_one
+
+      failures=$(xargs -a ${worklist} -L1 -P "''${NIX_BUILD_CORES:-4}" \
+        bash -c 'resolve_one "$@"' _)
+
+      if [ -n "$failures" ]; then
+        echo "served, but resolvable on no interpreter:" >&2
+        echo "$failures" >&2
+        echo "-> the index is the only source a resolver has, so serving a project it cannot install is a dead entry; serve the missing dependency or drop the project." >&2
+        exit 1
+      fi
+      echo "ok: $(wc -l < ${worklist}) projects resolve"
+    '';
+  };
+}


### PR DESCRIPTION
Stacked on #149, which is itself stacked on `registry-publish-drv`.

## Context

The integrity walk in #149 models pip: it reads tags and metadata and decides
what a resolver would pick. A model can be wrong in the same direction twice.
This runs pip itself over every served project against the built index, so a
dependency the model cannot see still fails the check. The case that motivated
it: `httpx[http2]` reaches `h2` only through an extra, and a bare wheel's extras
are inactive, so no amount of metadata reading finds it.

## Impact

One check derivation, not one per project. It resolves the 432 projects in
parallel and, on failure, names every project that resolved on nothing. At
~2 minutes it is an ordinary check, so no mechanism for keeping work off the PR
path is needed: no new workflow, no second test group, no new flake attr.

A project has to resolve on one interpreter rather than all of them, since a
release states its own supported range and `litellm`'s `<3.14` is not a defect
in the index. Whether a wheel reaches the interpreters it claims stays with the
integrity walk, which reads tags and Requires-Python directly.

## Behavior checked

`ok: 432 projects resolve`, in 135s.

The per-interpreter split is exercised both ways: `cramjam` is swept on 3.13
alone, being py313-only, and `pydantic` on both.
