### PR TITLE
ci: comparisons at eval time, and the second shakedown wave

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -36,6 +36,18 @@ jobs:
       pullRequest: ${{ steps.authorize.outputs.pullRequest }}
       headSha: ${{ steps.authorize.outputs.headSha }}
     steps:
+      # Heard, seconds after posting: authorization needs the binary and can
+      # take minutes when its closure is cold. Advisory, so failures pass.
+      - name: Acknowledge
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api --silent \
+            "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes || true
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,14 +40,21 @@ leaves a typed fragment. The report is folded from the fragments by
 `ci/report.rs` and nowhere else, so the terminal verdict, `run failures`, the
 markdown comment, and the check summary describe the same facts.
 
+Tasks do work and emit facts; anything computable from persisted facts is a
+projection the fold derives. The diff comparison is the example: no task
+computes it, `ci/compare.rs` projects it from the case directories each time the
+fold runs, so its eval half (added, removed, version moves, rebuilds) reaches
+the comment as soon as both evaluations exist and its build half (regressions,
+fixes) joins when results land.
+
 Progress is an append-only `events.jsonl`; the snapshot is derived from it, not
 maintained beside it. Every progress view (the terminal ladder, `run watch`,
 `run logs --follow`, a remote observer) replays that one stream.
 
 The verdict has three values. A green run passes; a red run has a failed
-required gate; a diff whose baseline could not evaluate concludes **neutral**,
-never red, because a failure the base shares is the status quo, not a regression
-the change introduced.
+required gate or a comparison with regressions; a diff whose baseline could not
+evaluate concludes **neutral**, never red, because a failure the base shares is
+the status quo, not a regression the change introduced.
 
 ## Durable and remote runs
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -192,6 +192,16 @@ import.
 To run tests against a locally built runtime instead of the pinned one:
 `WASMER_BIN=/path/to/wasmer nix build --impure .#checks.x86_64-linux.<name>`.
 
+## Update scripts
+
+A package that pins its own source (rather than overriding nixpkgs) declares its
+bump in `passthru.updateScript` (`docs/updating.md`). Verify the script end to
+end locally before shipping it: downgrade to an explicit older release
+(`wasinix update <target>@<version>`, or `@rev:<sha>` for revision targets),
+then update back to latest (`wasinix update <target>`), and check both edits
+land in the pin file. A script that has only ever answered "already up to date"
+has exercised none of its rewriting.
+
 ## Pitfalls
 
 - Nix only sees git-tracked files, so `git add -N` a new one before building

--- a/pkgs/overlay/python-packages/tree-sitter-grammars/package.nix
+++ b/pkgs/overlay/python-packages/tree-sitter-grammars/package.nix
@@ -125,7 +125,7 @@ in {
   }: let
     updater = final.buildPackages.writeShellApplication {
       name = "update-tree-sitter-grammars";
-      runtimeInputs = [final.buildPackages.curl final.buildPackages.jq final.buildPackages.nix];
+      runtimeInputs = with final.buildPackages; [curl git gnused jq nix];
       text = builtins.readFile ./update.sh;
     };
   in

--- a/pkgs/overlay/python-packages/tree-sitter-grammars/update.sh
+++ b/pkgs/overlay/python-packages/tree-sitter-grammars/update.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 lang="${1:?usage: update.sh <language>}"
-nix_file="$(dirname "$0")/package.nix"
+# The script runs inlined from the store, so the checkout's copy of the
+# grammar table is addressed through the repo, never through $0.
+nix_file="$(git rev-parse --show-toplevel)/pkgs/overlay/python-packages/tree-sitter-grammars/package.nix"
 
 block_field() {
   sed -n "/^    ${lang} = {\$/,/^    };\$/p" "$nix_file" |

--- a/pkgs/products/cargo-wasix-unwrapped/package.nix
+++ b/pkgs/products/cargo-wasix-unwrapped/package.nix
@@ -4,7 +4,6 @@
 {
   rustPlatform,
   fetchFromGitHub,
-  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-wasix";
@@ -24,6 +23,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # contacts GitHub. Keep the remaining offline library unit tests.
   cargoTestFlags = ["--lib"];
   checkFlags = ["--skip" "toolchain::tests::test_download_toolchain"];
-
-  passthru.updateScript = nix-update-script {};
 })

--- a/pkgs/products/cargo-wasix/package.nix
+++ b/pkgs/products/cargo-wasix/package.nix
@@ -65,8 +65,8 @@ in
     '';
 
     passthru = {
-      # The recipe is products/cargo-wasix, which carries the version,
-      # the src and the updateScript; this wrapper only adds the toolchain env.
+      # The recipe is products/cargo-wasix, which carries the version and
+      # the src; the wrapper adds the toolchain env and declares the bump.
       unwrapped = cargoWasixUnwrapped;
       # nix-update needs version + src on the drv it evals: the wrapper has
       # neither, so point it at the unwrapped package

--- a/pkgs/products/default.nix
+++ b/pkgs/products/default.nix
@@ -24,8 +24,12 @@ in {
       then nativeNixUpdateScript
       else final.nix-update-script;
   in
-    prev.lib.genAttrs names (name:
-      final.callPackage (dir + "/${name}/package.nix") {
-        inherit nix-update-script;
-      });
+    prev.lib.genAttrs names (name: let
+      path = dir + "/${name}/package.nix";
+    in
+      final.callPackage path (
+        prev.lib.optionalAttrs
+        (builtins.functionArgs (import path) ? nix-update-script)
+        {inherit nix-update-script;}
+      ));
 }

--- a/pkgs/products/wasix-rust/package.nix
+++ b/pkgs/products/wasix-rust/package.nix
@@ -390,7 +390,11 @@ in
 
       # Bumps, then re-derives the stage0 bootstrap pin from the new source's
       # src/stage0 (the nix-update command is passed through as its argv).
+      # Named: the one pin surfaces under several attrs (nativePackages,
+      # per-profile, wasmerPackages), which must stay one target.
       updateScript = {
+        name = "wasix-rust";
+        attrPath = "nativePackages.wasix-rust";
         command = ["${updateWrapper}/bin/wasix-rust-update"] ++ nix-update-script {extraArgs = ["--flake"];};
         accepts = ["release" "revision"];
         source = {

--- a/pkgs/products/wasixcc-unwrapped/package.nix
+++ b/pkgs/products/wasixcc-unwrapped/package.nix
@@ -5,7 +5,6 @@
 {
   rustPlatform,
   fetchFromGitHub,
-  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasixcc-unwrapped";
@@ -43,6 +42,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cp "$(find target -type f -path '*/release/wasixccenv' | head -n 1)" "$out/libexec/wasixccenv"
     runHook postInstall
   '';
-
-  passthru.updateScript = nix-update-script {};
 })

--- a/pkgs/products/wasixcc/package.nix
+++ b/pkgs/products/wasixcc/package.nix
@@ -40,8 +40,8 @@ in
     '';
 
     passthru = {
-      # The recipe is products/wasixcc, which carries the version, the
-      # src and the updateScript; this wrapper only adds the toolchain locations.
+      # The recipe is products/wasixcc, which carries the version and the
+      # src; the wrapper adds the toolchain locations and declares the bump.
       unwrapped = wasixccUnwrapped;
       updateScript = {
         command = nix-update-script {extraArgs = ["--flake"];};

--- a/tools/wasinix/fixtures/golden/comment-diff-green.md
+++ b/tools/wasinix/fixtures/golden/comment-diff-green.md
@@ -37,7 +37,7 @@
 
 <details><summary>Details</summary>
 
-**Request**
+<details><summary>Request</summary>
 
 ```json
 {
@@ -76,6 +76,8 @@
   ]
 }
 ```
+
+</details>
 
 **Pipeline**
 

--- a/tools/wasinix/fixtures/golden/comment-diff-green.md
+++ b/tools/wasinix/fixtures/golden/comment-diff-green.md
@@ -33,7 +33,7 @@
 
 </details>
 
-<sub>candidate-1: Formatting ✅ · Evaluation inputs ✅ · Evaluation ✅ · Core ✅ · Compare candidate-1 ✅<br>baseline: Evaluation inputs ✅ · Evaluation ✅ · Core ✅<br><a href="https://github.com/wasix-org/wasinix/actions/runs/1">full pipeline</a></sub>
+<sub>candidate-1: Formatting ✅ · Evaluation inputs ✅ · Evaluation ✅ · Core ✅<br>baseline: Evaluation inputs ✅ · Evaluation ✅ · Core ✅<br><a href="https://github.com/wasix-org/wasinix/actions/runs/1">full pipeline</a></sub>
 
 <details><summary>Details</summary>
 
@@ -88,7 +88,6 @@
 | candidate-1: Evaluation | ✅ | ok |
 | baseline: Core | ✅ | ok |
 | candidate-1: Core | ✅ | ok |
-| Compare candidate-1 | ✅ | no regressions |
 
 **Downstream version changes (1)**
 

--- a/tools/wasinix/fixtures/golden/comment-diff-in-progress.md
+++ b/tools/wasinix/fixtures/golden/comment-diff-in-progress.md
@@ -1,0 +1,17 @@
+### ⏳ Wasinix CI · building · [run](https://github.com/wasix-org/wasinix/actions/runs/1) · `aaaaaaaaaaaa`
+
+**Comparison** · 1 rebuilt · 0 version/rel changes · 1 added · 0 removed · builds pending
+
+<details><summary>Rebuilt (1)</summary>
+
+- `checks.zlib` at 1.3.2
+
+</details>
+
+<details><summary>Added (1)</summary>
+
+- `checks.brotli` at 1.1.0
+
+</details>
+
+<sub>candidate-1: Formatting ✅ · Evaluation inputs ✅ · Evaluation ✅ · Core ⏳<br>baseline: Evaluation inputs ✅ · Evaluation ✅ · Core ⏳</sub>

--- a/tools/wasinix/fixtures/golden/comment-failing.md
+++ b/tools/wasinix/fixtures/golden/comment-failing.md
@@ -10,7 +10,7 @@
 
 <details><summary>Details</summary>
 
-**Request**
+<details><summary>Request</summary>
 
 ```json
 {
@@ -28,6 +28,8 @@
   ]
 }
 ```
+
+</details>
 
 **Pipeline**
 

--- a/tools/wasinix/fixtures/golden/comment-green.md
+++ b/tools/wasinix/fixtures/golden/comment-green.md
@@ -4,7 +4,7 @@
 
 <details><summary>Details</summary>
 
-**Request**
+<details><summary>Request</summary>
 
 ```json
 {
@@ -22,6 +22,8 @@
   ]
 }
 ```
+
+</details>
 
 **Pipeline**
 

--- a/tools/wasinix/fixtures/golden/comment-hostile.md
+++ b/tools/wasinix/fixtures/golden/comment-hostile.md
@@ -8,7 +8,7 @@
 
 <details><summary>Details</summary>
 
-**Request**
+<details><summary>Request</summary>
 
 ```json
 {
@@ -26,6 +26,8 @@
   ]
 }
 ```
+
+</details>
 
 **Pipeline**
 

--- a/tools/wasinix/fixtures/golden/report-infra-neutral.json
+++ b/tools/wasinix/fixtures/golden/report-infra-neutral.json
@@ -1,4 +1,11 @@
 {
+  "comparisons": [
+    {
+      "baseEvaluated": false,
+      "candidate": "candidate-1",
+      "headEvaluated": true
+    }
+  ],
   "complete": true,
   "conclusion": "neutral",
   "kind": "report",
@@ -72,7 +79,7 @@
     {
       "case": "candidate-1",
       "enabled": true,
-      "gate": false,
+      "gate": true,
       "headline": "x",
       "kind": "eval",
       "label": "candidate-1: Evaluation inputs",
@@ -82,7 +89,7 @@
     {
       "case": "candidate-1",
       "enabled": true,
-      "gate": false,
+      "gate": true,
       "headline": "x",
       "kind": "eval",
       "label": "candidate-1: Evaluation",
@@ -108,16 +115,6 @@
       "label": "candidate-1: Core",
       "status": "success",
       "taskId": "candidate-1.core"
-    },
-    {
-      "case": "candidate-1",
-      "enabled": true,
-      "gate": true,
-      "headline": "",
-      "kind": "comparison",
-      "label": "Compare candidate-1",
-      "status": "cancelled",
-      "taskId": "compare.candidate-1"
     }
   ],
   "title": "CI could not compare: the base did not evaluate"

--- a/tools/wasinix/fixtures/golden/step-summary-untrusted.md
+++ b/tools/wasinix/fixtures/golden/step-summary-untrusted.md
@@ -11,7 +11,7 @@
 
 <details><summary>Details</summary>
 
-**Request**
+<details><summary>Request</summary>
 
 ```json
 {
@@ -29,6 +29,8 @@
   ]
 }
 ```
+
+</details>
 
 **Pipeline**
 

--- a/tools/wasinix/src/ci/compare.rs
+++ b/tools/wasinix/src/ci/compare.rs
@@ -1,7 +1,10 @@
-//! Compare two evaluated and built cases by stable job name.
+//! Compare two cases by stable job name, as a projection of persisted state.
 //!
 //! This is the product: everything else exists to put two comparable cases in
-//! front of it. It computes facts; rendering lives with the other renderers.
+//! front of it. No task computes it; the fold derives it from the case
+//! directories whenever it runs, so each half of the story surfaces the
+//! moment its inputs exist. Tasks do work and emit facts; anything
+//! computable from persisted facts belongs here.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -135,9 +138,36 @@ pub fn junit_status(paths: &[std::path::PathBuf]) -> StatusMap {
     status
 }
 
+
+/// The eval-time half of a comparison: what two evaluations say changed.
+/// Computable the moment both maps exist, long before anything builds.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Comparison {
+pub struct EvalDiff {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added: Vec<JobAddr>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<JobAddr>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rebuilt: Vec<JobAddr>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub identity_transitions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub version_updates: Vec<VersionUpdate>,
+    /// Jobs erroring in the head evaluation that the base evaluated clean.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub new_eval_errors: Vec<JobAddr>,
+    /// Job -> the version it serves, for rendering. Every list here names
+    /// jobs; a reader wants to know which version each one is.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub identities: BTreeMap<JobAddr, String>,
+    pub selected_count: usize,
+}
+
+/// The build-time half: status transitions over the shared coverage.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildDiff {
     /// Jobs both cases cover that stopped passing.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub regressions: Vec<JobAddr>,
@@ -152,98 +182,115 @@ pub struct Comparison {
     pub fixes: Vec<JobAddr>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub existing_failures: Vec<JobAddr>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub new_eval_errors: Vec<JobAddr>,
-    pub selected_count: usize,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub rebuilt: Vec<JobAddr>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub identity_changed: Vec<JobAddr>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub identity_transitions: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub version_updates: Vec<VersionUpdate>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub added: Vec<JobAddr>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub removed: Vec<JobAddr>,
-    /// Job -> the version it serves, for rendering. Every list in this report
-    /// names jobs; a reader wants to know which version each one is.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub identities: BTreeMap<JobAddr, String>,
     #[serde(default)]
     pub case_failure: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub missing_results: Vec<String>,
 }
 
-impl Comparison {
-    /// Everything that fails the comparison, however the job entered it.
+impl BuildDiff {
     pub fn regression_count(&self) -> usize {
         self.regressions.len()
             + self.new_failures.len()
             + self.dropped_successes.len()
-            + self.new_eval_errors.len()
             + usize::from(self.case_failure)
     }
 }
 
-pub fn compare_case_results(
+/// One candidate's comparison against the baseline, derived from persisted
+/// case state whenever the fold runs; each half is present once its inputs
+/// exist. No task computes this.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Comparison {
+    pub candidate: String,
+    pub base_evaluated: bool,
+    pub head_evaluated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval: Option<EvalDiff>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builds: Option<BuildDiff>,
+}
+
+impl Comparison {
+    /// Everything that fails the comparison, however the job entered it.
+    pub fn regression_count(&self) -> usize {
+        self.eval
+            .as_ref()
+            .map(|eval| eval.new_eval_errors.len())
+            .unwrap_or(0)
+            + self
+                .builds
+                .as_ref()
+                .map(BuildDiff::regression_count)
+                .unwrap_or(0)
+    }
+}
+
+/// What the two cases cover, shared by both halves.
+struct Coverage {
+    base: BTreeSet<String>,
+    head: BTreeSet<String>,
+    both: Vec<String>,
+    /// A spot case covers only its own targets, so added/removed carry no
+    /// signal and the diff is judged on the shared jobs alone.
+    common_only: bool,
+}
+
+fn coverage(
     base_case: CaseRef<'_, RevSource>,
     base_map: &EvalMap,
-    base_status: &StatusMap,
     head_case: CaseRef<'_, RevSource>,
     head_map: &EvalMap,
-    head_status: &StatusMap,
-) -> Result<Comparison> {
-    let base_selected = selected_case(base_case, base_map)?;
-    let head_selected = selected_case(head_case, head_map)?;
-    let both: Vec<&String> = base_selected.intersection(&head_selected).collect();
-    let common_coverage =
+) -> Result<Coverage> {
+    let base = selected_case(base_case, base_map)?;
+    let head = selected_case(head_case, head_map)?;
+    let both: Vec<String> = base.intersection(&head).cloned().collect();
+    let common_only =
         matches!(base_case, CaseRef::Spot(_)) || matches!(head_case, CaseRef::Spot(_));
-    if common_coverage && both.is_empty() {
+    if common_only && both.is_empty() {
         return request_error("diff cases have no shared target coverage");
     }
+    Ok(Coverage {
+        base,
+        head,
+        both,
+        common_only,
+    })
+}
 
-    let transitioned = |from: JobStatus, to: JobStatus| -> Vec<JobAddr> {
-        both.iter()
-            .filter(|job| {
-                base_status.get(job.as_str()) == Some(&from)
-                    && head_status.get(job.as_str()) == Some(&to)
-            })
-            .map(|job| JobAddr((*job).clone()))
-            .collect()
-    };
-
-    let added: Vec<JobAddr> = if common_coverage {
+fn eval_diff(coverage: &Coverage, base_map: &EvalMap, head_map: &EvalMap) -> EvalDiff {
+    let added: Vec<JobAddr> = if coverage.common_only {
         Vec::new()
     } else {
-        head_selected
-            .difference(&base_selected)
+        coverage
+            .head
+            .difference(&coverage.base)
             .cloned()
             .map(JobAddr)
             .collect()
     };
-    let removed: Vec<JobAddr> = if common_coverage {
+    let removed: Vec<JobAddr> = if coverage.common_only {
         Vec::new()
     } else {
-        base_selected
-            .difference(&head_selected)
+        coverage
+            .base
+            .difference(&coverage.head)
             .cloned()
             .map(JobAddr)
             .collect()
     };
-    let identity_changed: Vec<JobAddr> = both
+    let identity_changed: Vec<&String> = coverage
+        .both
         .iter()
         .filter(|job| base_map.identity(job) != head_map.identity(job))
-        .map(|job| JobAddr((*job).clone()))
         .collect();
     // Keyed by the package's own changelog as well as its subject: two
     // different packages can share a display subject and a version move, and
     // must not merge into one row with unioned changelogs.
     type UpdateKey = (String, String, String, Option<String>);
     let mut version_updates: BTreeMap<UpdateKey, VersionUpdate> = BTreeMap::new();
-    for job in &both {
+    for job in &coverage.both {
         let (Some(before), Some(after)) = (base_map.version(job), head_map.version(job)) else {
             continue;
         };
@@ -253,7 +300,7 @@ pub fn compare_case_results(
         let info = head_map.info.get(job.as_str());
         let subject = info
             .and_then(|info| info.subject.clone().or_else(|| info.display_name.clone()))
-            .unwrap_or_else(|| (*job).clone());
+            .unwrap_or_else(|| job.clone());
         let changelog = info.and_then(|info| info.changelog.clone());
         let update = version_updates
             .entry((
@@ -269,62 +316,49 @@ pub fn compare_case_results(
                 changelogs: changelog.into_iter().collect(),
                 jobs: Vec::new(),
             });
-        update.jobs.push(JobAddr((*job).clone()));
+        update.jobs.push(JobAddr(job.clone()));
     }
-
-    Ok(Comparison {
-        regressions: transitioned(JobStatus::Success, JobStatus::Failure),
-        new_failures: added
-            .iter()
-            .filter(|job| head_status.get(job.as_str()) == Some(&JobStatus::Failure))
-            .cloned()
-            .collect(),
-        dropped_successes: removed
-            .iter()
-            .filter(|job| base_status.get(job.as_str()) == Some(&JobStatus::Success))
-            .cloned()
-            .collect(),
-        fixes: transitioned(JobStatus::Failure, JobStatus::Success),
-        existing_failures: transitioned(JobStatus::Failure, JobStatus::Failure),
-        new_eval_errors: both
-            .iter()
-            .filter(|job| {
-                head_map.errors.contains_key(job.as_str())
-                    && !base_map.errors.contains_key(job.as_str())
-            })
-            .map(|job| JobAddr((**job).clone()))
-            .collect(),
-        selected_count: if common_coverage {
-            both.len()
-        } else {
-            base_selected.union(&head_selected).count()
-        },
-        rebuilt: both
+    EvalDiff {
+        rebuilt: coverage
+            .both
             .iter()
             .filter(|job| {
                 base_map.jobs.get(job.as_str()) != head_map.jobs.get(job.as_str())
                     && head_map.rebuild_signal(job)
             })
-            .map(|job| JobAddr((*job).clone()))
+            .map(|job| JobAddr(job.clone()))
             .collect(),
         identity_transitions: identity_changed
             .iter()
             .map(|job| {
                 format!(
                     "{job}: {} -> {}",
-                    base_map.identity(job.as_str()).unwrap_or_else(|| "?".into()),
-                    head_map.identity(job.as_str()).unwrap_or_else(|| "?".into())
+                    base_map.identity(job).unwrap_or_else(|| "?".into()),
+                    head_map.identity(job).unwrap_or_else(|| "?".into())
                 )
             })
             .collect(),
         version_updates: version_updates.into_values().collect(),
-        identity_changed,
+        new_eval_errors: coverage
+            .both
+            .iter()
+            .filter(|job| {
+                head_map.errors.contains_key(job.as_str())
+                    && !base_map.errors.contains_key(job.as_str())
+            })
+            .map(|job| JobAddr(job.clone()))
+            .collect(),
+        selected_count: if coverage.common_only {
+            coverage.both.len()
+        } else {
+            coverage.base.union(&coverage.head).count()
+        },
         // A removed job has no head identity, so the base is the only side
         // that can say which version went away.
-        identities: if common_coverage {
-            both.into_iter().cloned().collect::<BTreeSet<_>>()
+        identities: if coverage.common_only {
+            coverage.both.iter().cloned().collect::<BTreeSet<_>>()
         } else {
-            base_selected.union(&head_selected).cloned().collect()
+            coverage.base.union(&coverage.head).cloned().collect()
         }
         .iter()
         .filter_map(|job| {
@@ -336,7 +370,175 @@ pub fn compare_case_results(
         .collect(),
         added,
         removed,
+    }
+}
+
+fn build_diff(
+    coverage: &Coverage,
+    eval: &EvalDiff,
+    base_status: &StatusMap,
+    head_status: &StatusMap,
+) -> BuildDiff {
+    let transitioned = |from: JobStatus, to: JobStatus| -> Vec<JobAddr> {
+        coverage
+            .both
+            .iter()
+            .filter(|job| {
+                base_status.get(job.as_str()) == Some(&from)
+                    && head_status.get(job.as_str()) == Some(&to)
+            })
+            .map(|job| JobAddr(job.clone()))
+            .collect()
+    };
+    BuildDiff {
+        regressions: transitioned(JobStatus::Success, JobStatus::Failure),
+        new_failures: eval
+            .added
+            .iter()
+            .filter(|job| head_status.get(job.as_str()) == Some(&JobStatus::Failure))
+            .cloned()
+            .collect(),
+        dropped_successes: eval
+            .removed
+            .iter()
+            .filter(|job| base_status.get(job.as_str()) == Some(&JobStatus::Success))
+            .cloned()
+            .collect(),
+        fixes: transitioned(JobStatus::Failure, JobStatus::Success),
+        existing_failures: transitioned(JobStatus::Failure, JobStatus::Failure),
         case_failure: false,
         missing_results: Vec::new(),
-    })
+    }
+}
+
+/// Jobs a case promised results for but did not deliver, which makes any
+/// comparison against it incomplete rather than clean.
+fn missing_case_results(
+    case: CaseRef<'_, RevSource>,
+    mapping: &EvalMap,
+    status: &StatusMap,
+) -> Result<Vec<String>> {
+    let case_id = case.case_id();
+    let missing = match case {
+        CaseRef::Build(build) => crate::ci::baseline::missing_status(build, mapping, status)?,
+        CaseRef::Spot(_) => {
+            let delivered: BTreeSet<String> =
+                status.keys().map(|job| job.as_str().to_string()).collect();
+            selected_case(case, mapping)?
+                .difference(&delivered)
+                .cloned()
+                .collect()
+        }
+    };
+    Ok(missing
+        .into_iter()
+        .map(|name| format!("{case_id}:{name}"))
+        .collect())
+}
+
+/// One candidate's halves from loaded state: the eval half always, the build
+/// half when both sides' statuses are given. The pure core of [`project`].
+pub fn compare_loaded(
+    base_case: CaseRef<'_, RevSource>,
+    base_map: &EvalMap,
+    head_case: CaseRef<'_, RevSource>,
+    head_map: &EvalMap,
+    statuses: Option<(&StatusMap, &StatusMap)>,
+) -> Result<(EvalDiff, Option<BuildDiff>)> {
+    let coverage = coverage(base_case, base_map, head_case, head_map)?;
+    let eval = eval_diff(&coverage, base_map, head_map);
+    let builds = statuses
+        .map(|(base_status, head_status)| build_diff(&coverage, &eval, base_status, head_status));
+    Ok((eval, builds))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn candidate_halves(
+    base_case: CaseRef<'_, RevSource>,
+    base_map: &EvalMap,
+    base_paths: &Path,
+    head_case: CaseRef<'_, RevSource>,
+    head_map: &EvalMap,
+    head_paths: &Path,
+    finished: bool,
+) -> Result<(EvalDiff, Option<BuildDiff>)> {
+    let base_status = case_status(base_paths);
+    let head_status = case_status(head_paths);
+    let with_builds = finished || (!base_status.is_empty() && !head_status.is_empty());
+    let (eval, builds) = compare_loaded(
+        base_case,
+        base_map,
+        head_case,
+        head_map,
+        with_builds.then_some((&base_status, &head_status)),
+    )?;
+    let builds = match builds {
+        None => None,
+        Some(mut builds) => {
+            let mut missing = missing_case_results(base_case, base_map, &base_status)?;
+            missing.extend(missing_case_results(head_case, head_map, &head_status)?);
+            builds.case_failure = !missing.is_empty();
+            builds.missing_results = missing;
+            Some(builds)
+        }
+    };
+    Ok((eval, builds))
+}
+
+fn try_load_map(case: &Path) -> Option<EvalMap> {
+    crate::support::schema::read(&crate::ci::prepare::eval_map_path(case)).ok()
+}
+
+/// Derive every candidate's comparison from the run's persisted case state:
+/// the eval half once both maps exist, the build half once both sides carry
+/// results (or unconditionally at finish, where absence is incompleteness).
+pub fn project(
+    run_dir: &Path,
+    request: &crate::ci::types::ResolvedRequest,
+    finished: bool,
+) -> Result<Vec<Comparison>> {
+    let crate::ci::types::Request::Diff(diff) = request else {
+        return Ok(Vec::new());
+    };
+    let Some(baseline) = diff
+        .cases
+        .iter()
+        .find(|case| case.case_id() == diff.baseline)
+    else {
+        return request_error("diff has no baseline case");
+    };
+    let base_paths = crate::ci::prepare::case_dir(run_dir, baseline.case_id());
+    let base_map = try_load_map(&base_paths);
+    let mut comparisons = Vec::new();
+    for candidate in &diff.cases {
+        if candidate.case_id() == diff.baseline {
+            continue;
+        }
+        let head_paths = crate::ci::prepare::case_dir(run_dir, candidate.case_id());
+        let head_map = try_load_map(&head_paths);
+        let mut comparison = Comparison {
+            candidate: candidate.case_id().to_string(),
+            base_evaluated: base_map.is_some(),
+            head_evaluated: head_map.is_some(),
+            eval: None,
+            builds: None,
+        };
+        if let (Some(base_map), Some(head_map)) = (&base_map, &head_map) {
+            // A candidate whose selection cannot resolve against its own map
+            // is that case's failure, already reported by its tasks; it must
+            // not take down the fold deriving everyone else's comparison.
+            match candidate_halves(baseline.as_ref(), base_map, &base_paths, candidate.as_ref(), head_map, &head_paths, finished) {
+                Ok((eval, builds)) => {
+                    comparison.eval = Some(eval);
+                    comparison.builds = builds;
+                }
+                Err(error) => crate::support::ui::warning(format!(
+                    "no comparison for {}: {error}",
+                    comparison.candidate
+                )),
+            }
+        }
+        comparisons.push(comparison);
+    }
+    Ok(comparisons)
 }

--- a/tools/wasinix/src/ci/contentdiff.rs
+++ b/tools/wasinix/src/ci/contentdiff.rs
@@ -68,11 +68,15 @@ fn basename(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
-/// Narinfo per store path, chunked and tolerant: one failing invocation must
-/// not lose the whole comparison.
+/// Narinfo per store path, chunked and tolerant: nix path-info fails the
+/// whole invocation when any queried path is absent, so a failed chunk
+/// bisects until each missing path costs only itself, never its chunkmates.
 fn path_infos(paths: &[String], store: Option<&str>) -> BTreeMap<String, Option<Value>> {
-    let mut infos = BTreeMap::new();
-    for chunk in paths.chunks(NARINFO_CHUNK) {
+    fn query(
+        chunk: &[String],
+        store: Option<&str>,
+        infos: &mut BTreeMap<String, Option<Value>>,
+    ) {
         let mut invocation = Invocation::plain("path-info")
             .json()
             .args(["--json-format", "2"])
@@ -80,7 +84,7 @@ fn path_infos(paths: &[String], store: Option<&str>) -> BTreeMap<String, Option<
         if let Some(store) = store {
             invocation = invocation.args(["--store", store]);
         }
-        match invocation.probe("one failing chunk must not lose the comparison") {
+        match invocation.probe("a missing path must not lose the comparison") {
             Ok(output) if output.status.is_success() => {
                 if let Ok(value) = serde_json::from_slice::<Value>(&output.stdout) {
                     for (key, info) in value["info"].as_object().into_iter().flatten() {
@@ -95,18 +99,27 @@ fn path_infos(paths: &[String], store: Option<&str>) -> BTreeMap<String, Option<
                     }
                 }
             }
+            _ if chunk.len() > 1 => {
+                let (left, right) = chunk.split_at(chunk.len() / 2);
+                query(left, store, infos);
+                query(right, store, infos);
+            }
             result => {
                 if let Ok(output) = result {
                     crate::support::ui::warning(format!(
-                        "path-info failed for a chunk: {}",
-                        output.stderr.trim().chars().take(200).collect::<String>()
+                        "path-info: {}: {}",
+                        basename(&chunk[0]),
+                        output.stderr.trim().lines().last().unwrap_or_default()
+                            .chars().take(160).collect::<String>()
                     ));
                 }
-                for path in chunk {
-                    infos.insert(basename(path).to_string(), None);
-                }
+                infos.insert(basename(&chunk[0]).to_string(), None);
             }
         }
+    }
+    let mut infos = BTreeMap::new();
+    for chunk in paths.chunks(NARINFO_CHUNK) {
+        query(chunk, store, &mut infos);
     }
     infos
 }

--- a/tools/wasinix/src/ci/exec.rs
+++ b/tools/wasinix/src/ci/exec.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
-use crate::ci::compare::{case_status, compare_case_results, selected_case, JobStatuses};
+use crate::ci::compare::JobStatuses;
 use crate::ci::evalmap::EvalMap;
 use crate::ci::events::{Event, Tracker};
 use crate::ci::facts;
@@ -1038,93 +1038,6 @@ fn run_build_tasks(
     Ok(worst)
 }
 
-/// Jobs a case promised results for but did not deliver, which makes any
-/// comparison against it incomplete rather than clean.
-fn missing_case_results(
-    case: CaseRef<'_, RevSource>,
-    mapping: &EvalMap,
-    status: &crate::ci::evalmap::StatusMap,
-) -> Result<Vec<String>> {
-    let case_id = case.case_id();
-    let missing = match case {
-        CaseRef::Build(build) => crate::ci::baseline::missing_status(build, mapping, status)?,
-        CaseRef::Spot(_) => {
-            let delivered: BTreeSet<String> =
-                status.keys().map(|job| job.as_str().to_string()).collect();
-            selected_case(case, mapping)?
-                .difference(&delivered)
-                .cloned()
-                .collect()
-        }
-    };
-    Ok(missing
-        .into_iter()
-        .map(|name| format!("{case_id}:{name}"))
-        .collect())
-}
-
-fn compare(
-    ctx: &Context,
-    request: &ResolvedRequest,
-    candidate_id: &str,
-) -> Result<Fragment> {
-    let Request::Diff(diff) = request else {
-        return request_error("compare requires a diff request");
-    };
-    let baseline = diff
-        .cases
-        .iter()
-        .find(|case| case.case_id() == diff.baseline)
-        .ok_or_else(|| Error::Request("diff has no baseline case".into()))?;
-    let candidate = diff
-        .cases
-        .iter()
-        .find(|case| case.case_id() == candidate_id)
-        .ok_or_else(|| Error::Request(format!("unknown candidate {candidate_id:?}")))?;
-
-    let base_paths = case_dir(ctx.run_dir, baseline.case_id());
-    let head_paths = case_dir(ctx.run_dir, candidate_id);
-    let base_map = load_map(&base_paths)?;
-    let base_status = case_status(&base_paths);
-    let head_map = load_map(&head_paths)?;
-    let head_status = case_status(&head_paths);
-    let mut result = compare_case_results(
-        baseline.as_ref(),
-        &base_map,
-        &base_status,
-        candidate.as_ref(),
-        &head_map,
-        &head_status,
-    )?;
-    let mut missing = missing_case_results(baseline.as_ref(), &base_map, &base_status)?;
-    missing.extend(missing_case_results(
-        candidate.as_ref(),
-        &head_map,
-        &head_status,
-    )?);
-    result.case_failure = !missing.is_empty();
-    result.missing_results = missing;
-
-    let regressions = result.regression_count();
-    let headline = if regressions > 0 {
-        format!("{regressions} regressions")
-    } else {
-        format!("no regressions, {} fixes", result.fixes.len())
-    };
-    Ok(Fragment::new(
-        format!("compare.{candidate_id}"),
-        format!("Compare {candidate_id}"),
-        TaskKind::Comparison,
-        if regressions > 0 {
-            TaskStatus::Failure
-        } else {
-            TaskStatus::Success
-        },
-        headline,
-    )
-    .with_data(FragmentData::Comparison(Box::new(result))))
-}
-
 fn content(
     ctx: &Context,
     request: &ResolvedRequest,
@@ -1192,10 +1105,8 @@ fn run_phase(
     case_id: &str,
     phase: Phase,
 ) -> Result<Fragment> {
-    match phase {
-        Phase::Compare => return compare(ctx, request, case_id),
-        Phase::Content => return content(ctx, request, case_id),
-        _ => {}
+    if phase == Phase::Content {
+        return content(ctx, request, case_id);
     }
 
     let case = request
@@ -1230,12 +1141,12 @@ fn run_phase(
         (Phase::Eval | Phase::Build { .. }, CaseRef::Spot(_)) => {
             request_error("build phase on a spot case")
         }
-        (Phase::Compare | Phase::Content, _) => unreachable!("handled above"),
+        (Phase::Content, _) => unreachable!("handled above"),
     }
 }
 
 pub(crate) fn blocked_by_case_failure(phase: Phase) -> bool {
-    !matches!(phase, Phase::Treefmt | Phase::Compare | Phase::Content)
+    !matches!(phase, Phase::Treefmt | Phase::Content)
 }
 
 /// A phase whose failure blocks the rest of its case. Builds run as one
@@ -1366,10 +1277,10 @@ pub fn run_tasks(ctx: &Context, loaded: &Loaded, only: &[String]) -> Result<Comm
             )?;
             continue;
         }
-        // A comparison whose baseline never evaluated goes hungry rather
-        // than reporting: the fold reads its absent fragment as "could not
-        // compare" and concludes neutral, never red.
-        if matches!(task.phase, Phase::Compare | Phase::Content)
+        // A content diff against a baseline that never evaluated has no base
+        // side to read; it stays unreported rather than failing as advisory
+        // noise for the base's condition.
+        if task.phase == Phase::Content
             && loaded
                 .baseline_case()
                 .is_some_and(|baseline| broken.contains(&baseline))
@@ -1452,6 +1363,7 @@ pub fn run_tasks(ctx: &Context, loaded: &Loaded, only: &[String]) -> Result<Comm
             started_at: tracker.snapshot().started_at,
             finished_at: Some(unix_secs()),
             request: Some(request.clone()),
+            comparisons: crate::ci::compare::project(ctx.run_dir, request, true)?,
         },
     );
     schema::write(&crate::ci::prepare::report_path(ctx.run_dir), &report)?;

--- a/tools/wasinix/src/ci/exec.rs
+++ b/tools/wasinix/src/ci/exec.rs
@@ -1078,13 +1078,20 @@ fn content(
         allowed_jobs: Some(&allowed),
         store: route.store().as_deref(),
     });
+    // Skipped pairs were not compared; counting them in the denominator
+    // would present "could not fetch a side" as "every output changed".
+    let compared = summary.identical.len() + summary.changed.len();
     let headline = if summary.pair_count() == 0 {
         "nothing to compare".to_string()
+    } else if compared == 0 {
+        format!("{} pairs skipped, none compared", summary.skipped.len())
+    } else if summary.skipped.is_empty() {
+        format!("{}/{compared} outputs identical", summary.identical.len())
     } else {
         format!(
-            "{}/{} outputs identical",
+            "{}/{compared} outputs identical · {} skipped",
             summary.identical.len(),
-            summary.pair_count()
+            summary.skipped.len()
         )
     };
     Ok(Fragment::new(

--- a/tools/wasinix/src/ci/origin.rs
+++ b/tools/wasinix/src/ci/origin.rs
@@ -176,6 +176,9 @@ pub fn verify(
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Command {
     pub command: String,
+    /// build or mutation; renamed on the wire because the document envelope
+    /// reserves the top-level "kind" key for the document type.
+    #[serde(rename = "commandKind")]
     pub kind: String,
     pub origin: Origin,
 }

--- a/tools/wasinix/src/ci/plan.rs
+++ b/tools/wasinix/src/ci/plan.rs
@@ -57,7 +57,6 @@ pub enum Phase {
     Eval,
     Build { set: BuildTarget },
     Spot,
-    Compare,
     Content,
 }
 
@@ -68,7 +67,6 @@ pub enum TaskKind {
     Eval,
     Build,
     Spot,
-    Comparison,
     Analysis,
 }
 
@@ -186,7 +184,10 @@ pub fn plan_of<S>(request: &Request<S>, request_id: Option<&str>, reused: &[Stri
         order: 0,
     };
     // A diff is decided by its comparison, not by either side building clean:
-    // a failure both cases share is the status quo, not a regression.
+    // a failure both cases share is the status quo, not a regression. A
+    // candidate must still evaluate for a comparison to exist, so its
+    // evaluation gates; a broken baseline is the base's condition and
+    // concludes neutral, so nothing on the baseline gates.
     let gate_builds = !request.is_diff();
     let baseline = match request {
         Request::Diff(diff) => Some(diff.baseline.as_str()),
@@ -214,6 +215,8 @@ pub fn plan_of<S>(request: &Request<S>, request_id: Option<&str>, reused: &[Stri
             continue;
         }
         match case {
+            // A failed spot build still lays out its map and statuses, so a
+            // failure both sides share stays the comparison's call.
             CaseRef::Spot(_) => builder.push(
                 format!("{id}.spot"),
                 format!("{id}: Spot"),
@@ -222,7 +225,9 @@ pub fn plan_of<S>(request: &Request<S>, request_id: Option<&str>, reused: &[Stri
                 Phase::Spot,
                 gate_builds,
             ),
-            CaseRef::Build(build) => plan_evaluation(&mut builder, build, gate_builds),
+            CaseRef::Build(build) => {
+                plan_evaluation(&mut builder, build, gate_builds || baseline != Some(id))
+            }
         }
     }
 
@@ -238,14 +243,6 @@ pub fn plan_of<S>(request: &Request<S>, request_id: Option<&str>, reused: &[Stri
     if let Request::Diff(diff) = request {
         for case in diff.cases.iter().skip(1) {
             let id = case.case_id().to_string();
-            builder.push(
-                format!("compare.{id}"),
-                format!("Compare {id}"),
-                TaskKind::Comparison,
-                &id,
-                Phase::Compare,
-                true,
-            );
             if diff.content_diff {
                 builder.push(
                     format!("content-diff.{id}"),

--- a/tools/wasinix/src/ci/report.rs
+++ b/tools/wasinix/src/ci/report.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::ci::compare::{Comparison, VersionUpdate};
+
 use crate::ci::contentdiff::ContentSummary;
 use crate::ci::facts::{BuildFacts, Failure};
 use crate::ci::plan::{Plan, Task, TaskKind};
@@ -53,7 +54,6 @@ pub struct LogExcerpt {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum FragmentData {
     Build(BuildFacts),
-    Comparison(Box<Comparison>),
     Eval(EvalSummary),
     Content(ContentSummary),
     Log(LogExcerpt),
@@ -207,6 +207,10 @@ pub struct Report {
     pub failures: BTreeMap<String, Vec<Failure>>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub version_updates: BTreeMap<String, Vec<VersionUpdate>>,
+    /// Per candidate, the projection of its case against the baseline; each
+    /// half fills in as its inputs land. Derived by the fold, never a task.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comparisons: Vec<Comparison>,
     /// The request this run executed, echoed so a reader can tell what was
     /// selected without reconstructing it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -231,6 +235,9 @@ pub struct FoldContext {
     pub started_at: Option<u64>,
     pub finished_at: Option<u64>,
     pub request: Option<ResolvedRequest>,
+    /// The candidates' projections against the baseline, from
+    /// [`crate::ci::compare::project`]; empty for a plain build.
+    pub comparisons: Vec<Comparison>,
 }
 
 /// A check-run annotation anchored at the failing package's definition.
@@ -333,34 +340,52 @@ pub fn fold(
         .filter(|view| view.task.enabled && failed(view.status))
         .count();
 
-    // Failed gates whose case is the diff baseline (or that went hungry
-    // because the baseline never evaluated) are the base's condition, not the
-    // submitted change's: the run concludes neutral, never red.
-    let baseline_only = failed_gates > 0
-        && context.baseline_case.as_deref().is_some_and(|baseline| {
-            views
-                .iter()
-                .filter(|view| view.task.enabled && view.task.gate && failed(view.status))
-                .all(|view| {
-                    view.task.case == baseline
-                        || (view.task.kind == TaskKind::Comparison && view.fragment.is_none())
-                })
-        });
+    // The diff verdict comes from the projections: regressions fail the run
+    // the moment the build halves exist; a candidate with no comparison
+    // basis at finish is the base's condition (neutral) when the base never
+    // evaluated, and the candidate's failure otherwise.
+    let is_diff = context.baseline_case.is_some();
+    let regressions: usize = context
+        .comparisons
+        .iter()
+        .map(Comparison::regression_count)
+        .sum();
+    let no_base = context
+        .comparisons
+        .iter()
+        .any(|comparison| comparison.eval.is_none() && !comparison.base_evaluated);
+    let uncompared = context
+        .comparisons
+        .iter()
+        .any(|comparison| comparison.eval.is_none());
+    // A diff stays open until its process finishes: its builds do not gate,
+    // so gate accounting alone would conclude it while builds still run.
+    let diff_open = is_diff && !context.finished;
 
-    let (conclusion, title) = if failed_gates > 0 && baseline_only {
-        (
-            Some(Conclusion::Neutral),
-            "CI could not compare: the base did not evaluate".to_string(),
-        )
-    } else if failed_gates > 0 {
+    let (conclusion, title) = if failed_gates > 0 {
         (Some(Conclusion::Failure), "CI failed".to_string())
-    } else if pending_gates > 0 {
+    } else if regressions > 0 {
+        (
+            Some(Conclusion::Failure),
+            format!("CI found {regressions} regressions"),
+        )
+    } else if pending_gates > 0 || diff_open {
         let title = if active_failures > 0 {
             format!("CI running with {active_failures} failed")
         } else {
             "CI in progress".to_string()
         };
         (None, title)
+    } else if is_diff && no_base {
+        (
+            Some(Conclusion::Neutral),
+            "CI could not compare: the base did not evaluate".to_string(),
+        )
+    } else if is_diff && uncompared {
+        (
+            Some(Conclusion::Failure),
+            "CI could not compare a candidate".to_string(),
+        )
     } else if !plan.tasks.is_empty() || !fragments.is_empty() {
         let title = if advisory_failures > 0 {
             format!("CI passed with {advisory_failures} advisory failures")
@@ -375,7 +400,7 @@ pub fn fold(
         )
     };
 
-    let complete = failed_gates > 0 || pending_gates == 0;
+    let complete = conclusion.is_some();
 
     let annotations = views
         .iter()
@@ -415,14 +440,12 @@ pub fn fold(
             _ => None,
         })
         .collect();
-    let version_updates = views
+    let version_updates = context
+        .comparisons
         .iter()
-        .filter(|view| view.task.enabled)
-        .filter_map(|view| match view.fragment?.data.as_ref()? {
-            FragmentData::Comparison(comparison) if !comparison.version_updates.is_empty() => {
-                Some((view.task.task_id.clone(), comparison.version_updates.clone()))
-            }
-            _ => None,
+        .filter_map(|comparison| {
+            let updates = &comparison.eval.as_ref()?.version_updates;
+            (!updates.is_empty()).then(|| (comparison.candidate.clone(), updates.clone()))
         })
         .collect();
 
@@ -436,6 +459,7 @@ pub fn fold(
         tasks,
         failures,
         version_updates,
+        comparisons: context.comparisons,
         request: context.request,
     }
 }
@@ -462,6 +486,7 @@ pub fn from_run_state(run: &crate::runs::Run) -> Report {
         tasks: Vec::new(),
         failures: std::collections::BTreeMap::new(),
         version_updates: std::collections::BTreeMap::new(),
+        comparisons: Vec::new(),
         request: None,
     }
 }

--- a/tools/wasinix/src/github/markdown.rs
+++ b/tools/wasinix/src/github/markdown.rs
@@ -241,9 +241,9 @@ fn details(report: &Report) -> Markdown {
         if let Ok(echo) = serde_json::to_string_pretty(request) {
             body = Markdown::concat([
                 body,
-                Markdown::constant("**Request**\n\n"),
+                Markdown::constant("<details><summary>Request</summary>\n\n"),
                 Markdown::fenced(&echo, "json"),
-                Markdown::constant("\n"),
+                Markdown::constant("\n</details>\n\n"),
             ]);
         }
     }

--- a/tools/wasinix/src/github/markdown.rs
+++ b/tools/wasinix/src/github/markdown.rs
@@ -91,15 +91,6 @@ fn blocked_count(report: &Report) -> usize {
         .count()
 }
 
-fn comparison(fragments: &BTreeMap<String, Fragment>) -> Option<(&str, &Comparison)> {
-    fragments.values().find_map(|fragment| match &fragment.data {
-        Some(FragmentData::Comparison(comparison)) => {
-            Some((fragment.task_id.as_str(), comparison.as_ref()))
-        }
-        _ => None,
-    })
-}
-
 fn job_count(fragments: &BTreeMap<String, Fragment>) -> Option<usize> {
     fragments.values().find_map(|fragment| match &fragment.data {
         Some(FragmentData::Eval(summary)) => Some(summary.job_count),
@@ -244,7 +235,7 @@ fn footer(report: &Report, fragments: &BTreeMap<String, Fragment>, links: &Links
     )
 }
 
-fn details(report: &Report, fragments: &BTreeMap<String, Fragment>) -> Markdown {
+fn details(report: &Report) -> Markdown {
     let mut body = Markdown::new();
     if let Some(request) = &report.request {
         if let Ok(echo) = serde_json::to_string_pretty(request) {
@@ -271,34 +262,35 @@ fn details(report: &Report, fragments: &BTreeMap<String, Fragment>) -> Markdown 
             Markdown::constant(" |\n"),
         ]);
     }
-    if let Some((_, comparison)) = comparison(fragments) {
-        if !comparison.version_updates.is_empty() {
+    for updates in report.version_updates.values() {
+        if updates.is_empty() {
+            continue;
+        }
+        body = Markdown::concat([
+            body,
+            Markdown::constant("\n**Downstream version changes ("),
+            Markdown::text(&updates.len().to_string()),
+            Markdown::constant(")**\n\n"),
+        ]);
+        for update in updates.iter().take(20) {
             body = Markdown::concat([
                 body,
-                Markdown::constant("\n**Downstream version changes ("),
-                Markdown::text(&comparison.version_updates.len().to_string()),
-                Markdown::constant(")**\n\n"),
+                Markdown::constant("- **"),
+                Markdown::cell(&update.subject),
+                Markdown::constant("** "),
+                Markdown::cell(&update.before),
+                Markdown::constant(" → "),
+                Markdown::cell(&update.after),
+                Markdown::constant("\n"),
             ]);
-            for update in comparison.version_updates.iter().take(20) {
-                body = Markdown::concat([
-                    body,
-                    Markdown::constant("- **"),
-                    Markdown::cell(&update.subject),
-                    Markdown::constant("** "),
-                    Markdown::cell(&update.before),
-                    Markdown::constant(" → "),
-                    Markdown::cell(&update.after),
-                    Markdown::constant("\n"),
-                ]);
-            }
-            if comparison.version_updates.len() > 20 {
-                body = Markdown::concat([
-                    body,
-                    Markdown::constant("- ... and "),
-                    Markdown::text(&(comparison.version_updates.len() - 20).to_string()),
-                    Markdown::constant(" more\n"),
-                ]);
-            }
+        }
+        if updates.len() > 20 {
+            body = Markdown::concat([
+                body,
+                Markdown::constant("- ... and "),
+                Markdown::text(&(updates.len() - 20).to_string()),
+                Markdown::constant(" more\n"),
+            ]);
         }
     }
     Markdown::concat([
@@ -308,13 +300,17 @@ fn details(report: &Report, fragments: &BTreeMap<String, Fragment>) -> Markdown 
     ])
 }
 
-/// The comparison's summary and lists, in the comment body proper: what a
-/// diff changed is the comment's story, not a collapsed detail.
-fn comparison_block(fragments: &BTreeMap<String, Fragment>) -> Markdown {
-    match comparison(fragments) {
-        Some((_, comparison)) => comparison_lists(comparison).push(Markdown::constant("\n")),
-        None => Markdown::new(),
-    }
+/// The comparisons' summaries and lists, in the comment body proper: what a
+/// diff changed is the comment's story, not a collapsed detail. Each half
+/// renders as soon as the fold could derive it.
+fn comparison_block(report: &Report) -> Markdown {
+    Markdown::concat(
+        report
+            .comparisons
+            .iter()
+            .filter(|comparison| comparison.eval.is_some())
+            .map(|comparison| comparison_lists(comparison).push(Markdown::constant("\n"))),
+    )
 }
 
 const COMPARE_LIST_ROWS: usize = 250;
@@ -365,44 +361,58 @@ fn job_list(
 
 /// The comparison's non-failure stories: what got fixed, rebuilt,
 /// re-versioned, added, or removed. Failures render in the report body, not
-/// here.
+/// here. The eval half is always present (the caller filters); the build
+/// half renders once builds finished.
 fn comparison_lists(comparison: &Comparison) -> Markdown {
-    let mut body = Markdown::concat([
-        Markdown::constant("**Comparison** · "),
-        Markdown::text(&comparison.fixes.len().to_string()),
-        Markdown::constant(" fixed · "),
-        Markdown::text(&comparison.rebuilt.len().to_string()),
+    let Some(eval) = &comparison.eval else {
+        return Markdown::new();
+    };
+    let mut body = Markdown::constant("**Comparison** · ");
+    if let Some(builds) = &comparison.builds {
+        body = Markdown::concat([
+            body,
+            Markdown::text(&builds.fixes.len().to_string()),
+            Markdown::constant(" fixed · "),
+        ]);
+    }
+    body = Markdown::concat([
+        body,
+        Markdown::text(&eval.rebuilt.len().to_string()),
         Markdown::constant(" rebuilt · "),
-        Markdown::text(&comparison.identity_transitions.len().to_string()),
+        Markdown::text(&eval.identity_transitions.len().to_string()),
         Markdown::constant(" version/rel changes · "),
-        Markdown::text(&comparison.added.len().to_string()),
+        Markdown::text(&eval.added.len().to_string()),
         Markdown::constant(" added · "),
-        Markdown::text(&comparison.removed.len().to_string()),
-        Markdown::constant(" removed\n"),
+        Markdown::text(&eval.removed.len().to_string()),
+        Markdown::constant(" removed"),
+        Markdown::constant(if comparison.builds.is_none() {
+            " · builds pending\n"
+        } else {
+            "\n"
+        }),
     ]);
     body = body.push(job_list(
-        "Removed jobs that passed",
-        &comparison.dropped_successes,
-        &comparison.identities,
+        "New evaluation failures",
+        &eval.new_eval_errors,
+        &eval.identities,
         true,
     ));
-    body = body.push(job_list(
-        "Fixed",
-        &comparison.fixes,
-        &comparison.identities,
-        false,
-    ));
-    if !comparison.identity_transitions.is_empty() {
+    if let Some(builds) = &comparison.builds {
+        body = body.push(job_list(
+            "Removed jobs that passed",
+            &builds.dropped_successes,
+            &eval.identities,
+            true,
+        ));
+        body = body.push(job_list("Fixed", &builds.fixes, &eval.identities, false));
+    }
+    if !eval.identity_transitions.is_empty() {
         let mut section = Markdown::concat([
             Markdown::constant("\n<details><summary>Version or rel changed ("),
-            Markdown::text(&comparison.identity_transitions.len().to_string()),
+            Markdown::text(&eval.identity_transitions.len().to_string()),
             Markdown::constant(")</summary>\n\n"),
         ]);
-        for transition in comparison
-            .identity_transitions
-            .iter()
-            .take(COMPARE_LIST_ROWS)
-        {
+        for transition in eval.identity_transitions.iter().take(COMPARE_LIST_ROWS) {
             section = Markdown::concat([
                 section,
                 Markdown::constant("- "),
@@ -414,35 +424,20 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     }
     // A toolchain change rebuilds nearly everything, so the list carries no
     // signal at that size; the count does.
-    if comparison.selected_count > 0 && comparison.rebuilt.len() > comparison.selected_count / 2 {
+    if eval.selected_count > 0 && eval.rebuilt.len() > eval.selected_count / 2 {
         body = Markdown::concat([
             body,
             Markdown::constant("\nRebuilt "),
-            Markdown::text(&comparison.rebuilt.len().to_string()),
+            Markdown::text(&eval.rebuilt.len().to_string()),
             Markdown::constant(" of "),
-            Markdown::text(&comparison.selected_count.to_string()),
+            Markdown::text(&eval.selected_count.to_string()),
             Markdown::constant(" jobs (toolchain-wide).\n"),
         ]);
     } else {
-        body = body.push(job_list(
-            "Rebuilt",
-            &comparison.rebuilt,
-            &comparison.identities,
-            false,
-        ));
+        body = body.push(job_list("Rebuilt", &eval.rebuilt, &eval.identities, false));
     }
-    body = body.push(job_list(
-        "Added",
-        &comparison.added,
-        &comparison.identities,
-        false,
-    ));
-    body = body.push(job_list(
-        "Removed",
-        &comparison.removed,
-        &comparison.identities,
-        false,
-    ));
+    body = body.push(job_list("Added", &eval.added, &eval.identities, false));
+    body = body.push(job_list("Removed", &eval.removed, &eval.identities, false));
     body
 }
 
@@ -472,10 +467,10 @@ fn green(report: &Report, fragments: &BTreeMap<String, Fragment>, links: &Links)
         jobs,
         links.heading_suffix(),
         Markdown::constant("\n\n"),
-        comparison_block(fragments),
+        comparison_block(report),
         footer(report, fragments, links),
         Markdown::constant("\n"),
-        details(report, fragments),
+        details(report),
     ])
 }
 
@@ -483,29 +478,41 @@ fn failing(report: &Report, fragments: &BTreeMap<String, Fragment>, links: &Link
     let all = failures(report);
     // In a diff, regressions are the story and shared failures are the
     // baseline's condition; in a build, every failure is new.
-    let (primary, preexisting, what) = match comparison(fragments) {
-        Some((_, comparison)) => {
-            let regressed: Vec<(&str, &Failure)> = all
-                .iter()
-                .filter(|(_, failure)| {
-                    comparison.regressions.contains(&failure.job)
-                        || comparison.new_failures.contains(&failure.job)
+    let builds: Vec<&crate::ci::compare::BuildDiff> = report
+        .comparisons
+        .iter()
+        .filter_map(|comparison| comparison.builds.as_ref())
+        .collect();
+    let (primary, preexisting, what) = if builds.is_empty() {
+        let count = all.len();
+        (all.clone(), Vec::new(), plural(count, "failure"))
+    } else {
+        let regressed: Vec<(&str, &Failure)> = all
+            .iter()
+            .filter(|(_, failure)| {
+                builds.iter().any(|diff| {
+                    diff.regressions.contains(&failure.job)
+                        || diff.new_failures.contains(&failure.job)
                 })
-                .cloned()
-                .collect();
-            let existing: Vec<(&str, &Failure)> = all
-                .iter()
-                .filter(|(_, failure)| comparison.existing_failures.contains(&failure.job))
-                .cloned()
-                .collect();
-            let count = comparison.regression_count();
-            let what = plural(count, "failure").push(Markdown::constant(" new"));
-            (regressed, existing, what)
-        }
-        None => {
-            let count = all.len();
-            (all.clone(), Vec::new(), plural(count, "failure"))
-        }
+            })
+            .cloned()
+            .collect();
+        let existing: Vec<(&str, &Failure)> = all
+            .iter()
+            .filter(|(_, failure)| {
+                builds
+                    .iter()
+                    .any(|diff| diff.existing_failures.contains(&failure.job))
+            })
+            .cloned()
+            .collect();
+        let count: usize = report
+            .comparisons
+            .iter()
+            .map(Comparison::regression_count)
+            .sum();
+        let what = plural(count, "failure").push(Markdown::constant(" new"));
+        (regressed, existing, what)
     };
     // Failed gates without failure atoms (treefmt, a timed-out eval) still
     // deserve an honest count; a report with no failed tasks at all (a
@@ -566,10 +573,10 @@ fn failing(report: &Report, fragments: &BTreeMap<String, Fragment>, links: &Link
     }
     Markdown::concat([
         text,
-        comparison_block(fragments),
+        comparison_block(report),
         footer(report, fragments, links),
         Markdown::constant("\n"),
-        details(report, fragments),
+        details(report),
     ])
 }
 
@@ -649,6 +656,7 @@ fn in_progress(report: &Report, snapshot: Option<&Snapshot>, links: &Links) -> M
     }
     Markdown::concat([
         text,
+        comparison_block(report),
         ladder(
             report.tasks.iter().filter(|task| task.enabled),
             trailing,

--- a/tools/wasinix/src/github/publish.rs
+++ b/tools/wasinix/src/github/publish.rs
@@ -99,6 +99,7 @@ pub(crate) fn load_running(
             started_at: snapshot.started_at,
             finished_at: None,
             request: Some(loaded.request.clone()),
+            comparisons: crate::ci::compare::project(run_dir, &loaded.request, false)?,
         },
     );
     Ok(Some(Rendered {

--- a/tools/wasinix/src/nix/buildset.rs
+++ b/tools/wasinix/src/nix/buildset.rs
@@ -192,12 +192,23 @@ struct JobSpec {
     outputs: Vec<String>,
 }
 
-/// The derivations a dry-run plan says must actually build. Everything else
-/// is already valid locally or substitutable, which the driver reports as
-/// cached without realising, so a warm run downloads nothing.
-pub(crate) fn dry_run_to_build(plan: &str) -> Result<BTreeSet<String>> {
+/// A dry-run plan, partitioned: the derivations that must actually build,
+/// and the paths that would be fetched from a substituter. A path in neither
+/// set is already valid locally.
+pub(crate) struct DryRunPlan {
+    pub(crate) to_build: BTreeSet<String>,
+    pub(crate) fetched: BTreeSet<String>,
+}
+
+/// Parse `nix-store --realise --dry-run` output. Everything outside the
+/// build section is either substitutable or already valid locally, which the
+/// driver reports as cached without realising, so a warm run downloads
+/// nothing.
+pub(crate) fn dry_run_plan(plan: &str) -> Result<DryRunPlan> {
     let mut to_build = BTreeSet::new();
+    let mut fetched = BTreeSet::new();
     let mut in_build_section = false;
+    let mut in_fetch_section = false;
     let mut recognized = false;
     for line in plan.lines() {
         let trimmed = line.trim();
@@ -205,6 +216,7 @@ pub(crate) fn dry_run_to_build(plan: &str) -> Result<BTreeSet<String>> {
             || (trimmed.starts_with("these ") && trimmed.contains("will be built"))
         {
             in_build_section = true;
+            in_fetch_section = false;
             recognized = true;
             continue;
         }
@@ -212,6 +224,7 @@ pub(crate) fn dry_run_to_build(plan: &str) -> Result<BTreeSet<String>> {
             || (trimmed.starts_with("these ") && trimmed.contains("will be fetched"))
         {
             in_build_section = false;
+            in_fetch_section = true;
             recognized = true;
             continue;
         }
@@ -219,9 +232,13 @@ pub(crate) fn dry_run_to_build(plan: &str) -> Result<BTreeSet<String>> {
             if in_build_section && trimmed.ends_with(".drv") {
                 to_build.insert(trimmed.to_string());
             }
+            if in_fetch_section {
+                fetched.insert(trimmed.to_string());
+            }
             continue;
         }
         in_build_section = false;
+        in_fetch_section = false;
     }
     // A phrasing this parser does not know must not read as "fully cached".
     if !recognized && plan.contains(".drv") {
@@ -230,7 +247,7 @@ pub(crate) fn dry_run_to_build(plan: &str) -> Result<BTreeSet<String>> {
             crate::support::error::tail(plan, 500)
         )));
     }
-    Ok(to_build)
+    Ok(DryRunPlan { to_build, fetched })
 }
 
 /// The derivation a realise progress line announces, e.g.
@@ -443,14 +460,26 @@ pub fn build_union(
         .operands(jobs.keys().cloned())
         .route(request.route)?
         .probe("the dry-run plan partitions cached from to-build")?;
-    let to_build = dry_run_to_build(&plan.stderr)?;
+    let plan = dry_run_plan(&plan.stderr)?;
+    let to_build = plan.to_build;
 
     let mut pending: BTreeSet<String> = BTreeSet::new();
+    // Outputs cached by local validity (a bootstrap build, a previous run's
+    // leftovers) are in neither the build nor the fetch set, and nothing has
+    // pushed them. They go to the uploader, which skips whatever the remote
+    // already has.
+    let mut local_only: Vec<String> = Vec::new();
     for (drv, spec) in &jobs {
         if to_build.contains(drv) {
             pending.insert(drv.clone());
             continue;
         }
+        local_only.extend(
+            spec.outputs
+                .iter()
+                .filter(|output| !plan.fetched.contains(*output))
+                .cloned(),
+        );
         for attr in &spec.attrs {
             emit(
                 serde_json::json!({
@@ -474,6 +503,10 @@ pub fn build_union(
     );
 
     let uploader = Uploader::start(key.as_ref().map(SigningKey::store));
+    if key.is_some() && !local_only.is_empty() {
+        crate::support::ui::fact("pushing locally built outputs", local_only.len());
+        uploader.push(local_only);
+    }
     let started = std::time::Instant::now();
     let mut build_started: BTreeMap<String, std::time::Instant> = BTreeMap::new();
     // Announced build-time dependencies, pushed as their outputs turn valid.

--- a/tools/wasinix/src/support/naming.rs
+++ b/tools/wasinix/src/support/naming.rs
@@ -132,9 +132,11 @@ struct Entry {
 }
 
 impl Entry {
-    /// The addresses that name this entry: the path, the path without its
-    /// variant segment, and every suffix of both that still reaches the leaf.
-    fn forms(&self) -> Vec<Vec<&str>> {
+    /// The structural addresses that name this entry: the path, the path
+    /// without its variant segment, and every suffix of both that still
+    /// reaches the leaf. Aliases are matched separately, since an alias hit
+    /// outranks a suffix hit when a name is claimed by both.
+    fn path_forms(&self) -> Vec<Vec<&str>> {
         fn suffixes<'a>(path: &[&'a str], forms: &mut Vec<Vec<&'a str>>) {
             for start in 0..path.len() {
                 forms.push(path[start..].to_vec());
@@ -148,7 +150,6 @@ impl Entry {
             without.remove(axis);
             suffixes(&without, &mut forms);
         }
-        forms.extend(self.aliases.iter().map(|alias| vec![alias.as_str()]));
         forms
     }
 
@@ -213,27 +214,37 @@ impl Domain {
         self
     }
 
-    fn matches(&self, spec: &Spec) -> Vec<&Entry> {
+    /// Every entry a spec names, with whether it was named by its declared
+    /// alias rather than a structural address.
+    fn matches(&self, spec: &Spec) -> Vec<(&Entry, bool)> {
         let glob = spec.is_glob();
         // A flattened CI job name joins its segments with dots and loses which
         // dots were separators, so the joined form is always accepted too.
         let flat = spec.segments.join(".");
+        let segment_matches = |segment: &str, wanted: &str| {
+            if glob {
+                matches_glob(wanted, segment)
+            } else {
+                segment == wanted
+            }
+        };
         self.entries
             .iter()
-            .filter(|entry| {
-                if !glob && entry.path.join(".") == flat {
-                    return true;
-                }
-                entry.forms().into_iter().any(|form| {
-                    form.len() == spec.segments.len()
-                        && form.iter().zip(&spec.segments).all(|(segment, wanted)| {
-                            if glob {
-                                matches_glob(wanted, segment)
-                            } else {
-                                segment == wanted
-                            }
-                        })
-                })
+            .filter_map(|entry| {
+                let by_alias = spec.segments.len() == 1
+                    && entry
+                        .aliases
+                        .iter()
+                        .any(|alias| segment_matches(alias, &spec.segments[0]));
+                let by_path = (!glob && entry.path.join(".") == flat)
+                    || entry.path_forms().into_iter().any(|form| {
+                        form.len() == spec.segments.len()
+                            && form
+                                .iter()
+                                .zip(&spec.segments)
+                                .all(|(segment, wanted)| segment_matches(segment, wanted))
+                    });
+                (by_alias || by_path).then_some((entry, by_alias))
             })
             .collect()
     }
@@ -280,7 +291,7 @@ impl Domain {
     /// two different things is an error that prints both, so the fix is always
     /// to copy one back.
     pub fn resolve(&self, spec: &Spec) -> Result<Vec<Resolved>> {
-        let hits = self.matches(spec);
+        let mut hits = self.matches(spec);
         if hits.is_empty() {
             let nearest = self.nearest(spec);
             let suggestion = if nearest.is_empty() {
@@ -295,10 +306,27 @@ impl Domain {
             ));
         }
         if !spec.is_glob() {
-            let mut identities: BTreeMap<String, &Entry> = BTreeMap::new();
-            for entry in &hits {
-                identities.entry(entry.identity()).or_insert(entry);
+            let identities = |hits: &[(&Entry, bool)]| {
+                let mut seen: BTreeMap<String, ()> = BTreeMap::new();
+                for (entry, _) in hits {
+                    seen.entry(entry.identity()).or_insert(());
+                }
+                seen
+            };
+            // A declared name outranks another entry's structural suffix:
+            // naming a thing by what it is called must not go ambiguous
+            // because someone else's address happens to end the same way.
+            if identities(&hits).len() > 1 {
+                let by_alias: Vec<(&Entry, bool)> = hits
+                    .iter()
+                    .copied()
+                    .filter(|(_, by_alias)| *by_alias)
+                    .collect();
+                if identities(&by_alias).len() == 1 {
+                    hits = by_alias;
+                }
             }
+            let identities = identities(&hits);
             if identities.len() > 1 {
                 let options: Vec<String> = identities.keys().cloned().collect();
                 return request_error(format!(
@@ -309,7 +337,7 @@ impl Domain {
             }
         }
         let mut resolved: Vec<Resolved> = Vec::new();
-        for entry in hits {
+        for (entry, _) in hits {
             if resolved.iter().any(|done| done.key == entry.key) {
                 continue;
             }

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4795,7 +4795,7 @@ mod table {
 
 
 mod buildset {
-    use crate::nix::buildset::{dry_run_to_build, realise_building_drv};
+    use crate::nix::buildset::{dry_run_plan, realise_building_drv};
     use crate::nix::evaljobs;
 
     #[test]
@@ -4813,16 +4813,21 @@ mod buildset {
     #[test]
     fn the_dry_run_plan_partitions_in_every_phrasing() {
         let plural = "these 2 derivations will be built:\n  /nix/store/a.drv\n  /nix/store/b.drv\nthese 3 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n  /nix/store/c\n  /nix/store/d\n  /nix/store/e\n";
-        let built = dry_run_to_build(plural).unwrap();
+        let plan = dry_run_plan(plural).unwrap();
         assert_eq!(
-            built.iter().collect::<Vec<_>>(),
+            plan.to_build.iter().collect::<Vec<_>>(),
             ["/nix/store/a.drv", "/nix/store/b.drv"]
         );
+        assert_eq!(
+            plan.fetched.iter().collect::<Vec<_>>(),
+            ["/nix/store/c", "/nix/store/d", "/nix/store/e"],
+            "the fetch set separates substitutable from locally valid"
+        );
         let singular = "this derivation will be built:\n  /nix/store/only.drv\n";
-        assert_eq!(dry_run_to_build(singular).unwrap().len(), 1);
-        assert!(dry_run_to_build("").unwrap().is_empty());
+        assert_eq!(dry_run_plan(singular).unwrap().to_build.len(), 1);
+        assert!(dry_run_plan("").unwrap().to_build.is_empty());
         // A phrasing the parser does not know must not read as fully cached.
-        assert!(dry_run_to_build("cannot price /nix/store/x.drv").is_err());
+        assert!(dry_run_plan("cannot price /nix/store/x.drv").is_err());
     }
 
     /// Real-nix integration: run with `cargo test -- --ignored` on a

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -2595,6 +2595,32 @@ mod update {
     }
 
     #[test]
+    fn one_pin_is_one_target_however_many_attrs_declare_it() {
+        let target = |name: &str, file: &str, command: &[&str]| Target {
+            name: name.into(),
+            backend: Backend::UpdateScript,
+            input: String::new(),
+            attr: format!("legacyPackages.x.{name}"),
+            version: String::new(),
+            command: command.iter().map(|part| part.to_string()).collect(),
+            command_drv_paths: Vec::new(),
+            file: file.into(),
+            accepts: Vec::new(),
+            source: None,
+        };
+        let deduped = crate::update::targets::dedupe(vec![
+            // A wrapper and its unwrapped package: same file, same command.
+            target("cargo-wasix", "pkgs/cargo-wasix.nix", &["nix-update", "--flake"]),
+            target("cargo-wasix-unwrapped", "pkgs/cargo-wasix.nix", &["nix-update", "--flake"]),
+            // Grammars share a file but each command names its language.
+            target("tree-sitter-c", "pkgs/grammars.nix", &["update-grammars", "c"]),
+            target("tree-sitter-go", "pkgs/grammars.nix", &["update-grammars", "go"]),
+        ]);
+        let names: Vec<&str> = deduped.iter().map(|target| target.name.as_str()).collect();
+        assert_eq!(names, ["cargo-wasix", "tree-sitter-c", "tree-sitter-go"]);
+    }
+
+    #[test]
     fn declarations_parse_the_flakes_camel_case_keys() {
         let value = serde_json::json!({
             "name": "wasix-libc",

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -494,6 +494,26 @@ mod authorization {
         schema::to_value(&origin()).unwrap()
     }
 
+    /// The document envelope reserves the top-level "kind" and "schema"
+    /// keys; a document field serializing to either panics at write. The
+    /// authorize document is the one that collided in production.
+    #[test]
+    fn the_command_document_round_trips_through_its_envelope() {
+        let command = crate::ci::origin::Command {
+            command: "build checks.zlib".into(),
+            kind: "build".into(),
+            origin: origin(),
+        };
+        let value = schema::to_value(&command).unwrap();
+        assert_eq!(value["kind"], "ciCommand");
+        assert_eq!(value["commandKind"], "build");
+        let scratch = crate::support::fs::Scratch::create("wasinix-test").unwrap();
+        let path = scratch.path().join("command.json");
+        schema::write(&path, &command).unwrap();
+        let read: crate::ci::origin::Command = schema::read(&path).unwrap();
+        assert_eq!(read, command);
+    }
+
     #[test]
     fn shape_is_checked_before_anything_else() {
         assert!(validate(&origin_value(), Some("wasix-org")).is_ok());

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -227,15 +227,20 @@ mod plan {
     }
 
     #[test]
-    fn diff_builds_are_advisory_and_the_comparison_gates() {
+    fn diff_builds_are_advisory_and_candidate_evals_gate() {
         let plan = plan_of(&core_diff(), None, &[]);
         let gate = |id: &str| plan.tasks.iter().find(|t| t.task_id == id).unwrap().gate;
         assert!(!gate("baseline.core"));
         assert!(!gate("candidate-1.core"));
-        assert!(gate("compare.candidate-1"));
+        // Without a candidate evaluation there is nothing to compare; a
+        // broken baseline concludes neutral instead, so it never gates.
+        assert!(gate("candidate-1.eval"));
+        assert!(!gate("baseline.eval"));
         assert!(gate("candidate-1.treefmt"));
         // The baseline is not the submitted tree, so it is never format-checked.
         assert!(!plan.tasks.iter().any(|task| task.task_id == "baseline.treefmt"));
+        // The comparison is a fold-time projection, never a task.
+        assert!(!plan.tasks.iter().any(|task| task.task_id.starts_with("compare.")));
     }
 
     #[test]
@@ -249,18 +254,13 @@ mod plan {
             ],
         });
         let plan = plan_of(&request, None, &[]);
+        // A failed spot build still lays out its map and statuses, so a
+        // failure both sides share stays the comparison's call.
         assert!(
             !plan
                 .tasks
                 .iter()
                 .find(|task| task.task_id == "candidate-1.spot")
-                .unwrap()
-                .gate
-        );
-        assert!(
-            plan.tasks
-                .iter()
-                .find(|task| task.task_id == "compare.candidate-1")
                 .unwrap()
                 .gate
         );
@@ -290,7 +290,6 @@ mod plan {
         assert!(!ids.contains(&"baseline.eval"));
         assert!(!ids.contains(&"baseline.core"));
         assert!(ids.contains(&"candidate-1.core"));
-        assert!(ids.contains(&"compare.candidate-1"));
     }
 
     #[test]
@@ -631,13 +630,13 @@ mod authorization {
 }
 
 mod compare {
-    use crate::ci::compare::{compare_case_results, Comparison};
+    use crate::ci::compare::{compare_loaded, BuildDiff, Comparison, EvalDiff};
     use crate::ci::evalmap::{EvalMap, JobInfo, StatusMap};
     use crate::ci::types::{Build, CaseRef, RevSource, Selector, SelectorKind, Spot};
     use crate::support::atoms::{JobAddr, JobStatus, Rev};
 
-    /// The tests exercise one-case comparisons; production drives
-    /// compare_case_results with CaseRefs directly.
+    /// The tests exercise one-candidate comparisons over loaded state, the
+    /// same core [`crate::ci::compare::project`] drives.
     fn compare_cases(
         base_case: &Build<RevSource>,
         base_map: &EvalMap,
@@ -645,15 +644,15 @@ mod compare {
         head_case: &Build<RevSource>,
         head_map: &EvalMap,
         head_status: &StatusMap,
-    ) -> crate::support::error::Result<Comparison> {
-        compare_case_results(
+    ) -> crate::support::error::Result<(EvalDiff, BuildDiff)> {
+        let (eval, builds) = compare_loaded(
             crate::ci::types::CaseRef::Build(base_case),
             base_map,
-            base_status,
             crate::ci::types::CaseRef::Build(head_case),
             head_map,
-            head_status,
-        )
+            Some((base_status, head_status)),
+        )?;
+        Ok((eval, builds.expect("statuses were given")))
     }
 
     fn source(fill: char) -> RevSource {
@@ -728,18 +727,18 @@ mod compare {
             ("packagesByProfile.exnrefEh.curl", JobStatus::Success),
         ]);
         let head_status = status(&[("packagesByProfile.exnrefEh.zlib", JobStatus::Failure)]);
-        let result = compare_case_results(
+        let (eval, builds) = compare_loaded(
             CaseRef::Build(&build),
             &mapping,
-            &base_status,
             CaseRef::Spot(&spot),
             &mapping,
-            &head_status,
+            Some((&base_status, &head_status)),
         )
         .unwrap();
-        assert_eq!(result.regressions, addrs(&["packagesByProfile.exnrefEh.zlib"]));
-        assert!(result.removed.is_empty());
-        assert_eq!(result.selected_count, 1);
+        let builds = builds.expect("statuses were given");
+        assert_eq!(builds.regressions, addrs(&["packagesByProfile.exnrefEh.zlib"]));
+        assert!(eval.removed.is_empty());
+        assert_eq!(eval.selected_count, 1);
     }
 
     #[test]
@@ -749,7 +748,7 @@ mod compare {
             ("fixed", "/nix/store/b.drv"),
             ("existing", "/nix/store/c.drv"),
         ];
-        let result = compare_cases(
+        let (_, builds) = compare_cases(
             &case(&["regressed", "fixed", "existing"]),
             &map(&names),
             &status(&[
@@ -766,14 +765,14 @@ mod compare {
             ]),
         )
         .unwrap();
-        assert_eq!(result.regressions, addrs(&["regressed"]));
-        assert_eq!(result.fixes, addrs(&["fixed"]));
-        assert_eq!(result.existing_failures, addrs(&["existing"]));
+        assert_eq!(builds.regressions, addrs(&["regressed"]));
+        assert_eq!(builds.fixes, addrs(&["fixed"]));
+        assert_eq!(builds.existing_failures, addrs(&["existing"]));
     }
 
     #[test]
     fn new_and_dropped_jobs_count_as_regressions() {
-        let result = compare_cases(
+        let (_, builds) = compare_cases(
             &case(&["kept", "dropped"]),
             &map(&[
                 ("kept", "/nix/store/a.drv"),
@@ -788,10 +787,10 @@ mod compare {
             &status(&[("kept", JobStatus::Success), ("fresh", JobStatus::Failure)]),
         )
         .unwrap();
-        assert!(result.regressions.is_empty());
-        assert_eq!(result.new_failures, addrs(&["fresh"]));
-        assert_eq!(result.dropped_successes, addrs(&["dropped"]));
-        assert_eq!(result.regression_count(), 2);
+        assert!(builds.regressions.is_empty());
+        assert_eq!(builds.new_failures, addrs(&["fresh"]));
+        assert_eq!(builds.dropped_successes, addrs(&["dropped"]));
+        assert_eq!(builds.regression_count(), 2);
     }
 
     #[test]
@@ -804,7 +803,7 @@ mod compare {
                 ..Default::default()
             },
         );
-        let result = compare_cases(
+        let (eval, _) = compare_cases(
             &case(&["job"]),
             &map(&[("job", "/nix/store/a.drv")]),
             &StatusMap::new(),
@@ -813,14 +812,14 @@ mod compare {
             &StatusMap::new(),
         )
         .unwrap();
-        assert!(result.rebuilt.is_empty());
+        assert!(eval.rebuilt.is_empty());
     }
 
     #[test]
     fn new_eval_errors_are_regressions() {
         let mut head = EvalMap::default();
         head.errors.insert(JobAddr("job".into()), "broken".into());
-        let result = compare_cases(
+        let (eval, builds) = compare_cases(
             &case(&["job"]),
             &map(&[("job", "/nix/store/a.drv")]),
             &StatusMap::new(),
@@ -829,8 +828,15 @@ mod compare {
             &StatusMap::new(),
         )
         .unwrap();
-        assert_eq!(result.new_eval_errors, addrs(&["job"]));
-        assert_eq!(result.regression_count(), 1);
+        assert_eq!(eval.new_eval_errors, addrs(&["job"]));
+        let comparison = Comparison {
+            candidate: "candidate-1".into(),
+            base_evaluated: true,
+            head_evaluated: true,
+            eval: Some(eval),
+            builds: Some(builds),
+        };
+        assert_eq!(comparison.regression_count(), 1);
     }
 
     #[test]
@@ -844,7 +850,7 @@ mod compare {
         base.info.insert(JobAddr("changed".into()), info("1.2.3", 1));
         let mut head = map(&[("changed", "/nix/store/a.drv")]);
         head.info.insert(JobAddr("changed".into()), info("1.2.3", 2));
-        let result = compare_cases(
+        let (eval, _) = compare_cases(
             &case(&["changed"]),
             &base,
             &StatusMap::new(),
@@ -853,9 +859,9 @@ mod compare {
             &StatusMap::new(),
         )
         .unwrap();
-        assert_eq!(result.identity_transitions, ["changed: 1.2.3 -> 1.2.3 r2"]);
-        assert!(result.version_updates.is_empty());
-        assert!(result.rebuilt.is_empty());
+        assert_eq!(eval.identity_transitions, ["changed: 1.2.3 -> 1.2.3 r2"]);
+        assert!(eval.version_updates.is_empty());
+        assert!(eval.rebuilt.is_empty());
     }
 
     #[test]
@@ -889,7 +895,7 @@ mod compare {
             info("1.3.1", Some("https://example.com/zlib-1.3.1")),
         );
 
-        let result = compare_cases(
+        let (eval, _) = compare_cases(
             &case(&jobs),
             &base,
             &StatusMap::new(),
@@ -899,8 +905,8 @@ mod compare {
         )
         .unwrap();
 
-        assert_eq!(result.version_updates.len(), 1);
-        let update = &result.version_updates[0];
+        assert_eq!(eval.version_updates.len(), 1);
+        let update = &eval.version_updates[0];
         assert_eq!(update.subject, "zlib");
         assert_eq!(update.before, "1.2.13");
         assert_eq!(update.after, "1.3.1");
@@ -931,7 +937,7 @@ mod compare {
         head.info
             .insert(JobAddr(jobs[1].into()), info("https://example.com/py"));
 
-        let result = compare_cases(
+        let (eval, _) = compare_cases(
             &case(&jobs),
             &base,
             &StatusMap::new(),
@@ -940,15 +946,15 @@ mod compare {
             &StatusMap::new(),
         )
         .unwrap();
-        assert_eq!(result.version_updates.len(), 2);
-        let all_changelogs: Vec<&str> = result
+        assert_eq!(eval.version_updates.len(), 2);
+        let all_changelogs: Vec<&str> = eval
             .version_updates
             .iter()
             .flat_map(|u| u.changelogs.iter().map(String::as_str))
             .collect();
         assert!(all_changelogs.contains(&"https://example.com/cpp"));
         assert!(all_changelogs.contains(&"https://example.com/py"));
-        for update in &result.version_updates {
+        for update in &eval.version_updates {
             assert_eq!(update.changelogs.len(), 1, "no unioned changelog rows");
         }
     }
@@ -956,6 +962,70 @@ mod compare {
     #[test]
     fn an_empty_comparison_reports_no_regressions() {
         assert_eq!(Comparison::default().regression_count(), 0);
+    }
+
+    /// The projection over a run directory grows with what is on disk: no
+    /// head map means no eval half, statuses on both sides bring the build
+    /// half, and a finished run computes it regardless so absence reads as
+    /// incompleteness instead of a clean pass.
+    #[test]
+    fn the_projection_tracks_what_the_run_dir_holds() {
+        use crate::ci::types::{Case, Diff, Request};
+        let scratch = crate::support::fs::Scratch::create("wasinix-test").unwrap();
+        let run_dir = scratch.path();
+        let request = Request::Diff(Diff {
+            baseline: "baseline".into(),
+            content_diff: false,
+            cases: vec![
+                Case::Build(Build {
+                    case_id: Some("baseline".into()),
+                    ..case(&["job"])
+                }),
+                Case::Build(Build {
+                    case_id: Some("candidate-1".into()),
+                    ..case(&["job"])
+                }),
+            ],
+        });
+        let write_map = |id: &str, drv: &str| {
+            let dir = crate::ci::prepare::case_dir(run_dir, id);
+            crate::support::fs::create_dir_all(&crate::ci::prepare::maps_dir(&dir)).unwrap();
+            crate::support::schema::write(
+                &crate::ci::prepare::eval_map_path(&dir),
+                &map(&[("job", drv)]),
+            )
+            .unwrap();
+        };
+        let write_status = |id: &str, value: JobStatus| {
+            let dir = crate::ci::prepare::case_dir(run_dir, id);
+            crate::support::schema::write(
+                &crate::ci::prepare::status_path(&dir),
+                &crate::ci::compare::JobStatuses {
+                    statuses: status(&[("job", value)]),
+                },
+            )
+            .unwrap();
+        };
+
+        write_map("baseline", "/nix/store/a.drv");
+        let early = crate::ci::compare::project(run_dir, &request, false).unwrap();
+        assert_eq!(early.len(), 1);
+        assert!(early[0].base_evaluated && !early[0].head_evaluated);
+        assert!(early[0].eval.is_none());
+
+        write_map("candidate-1", "/nix/store/b.drv");
+        let evaluated = crate::ci::compare::project(run_dir, &request, false).unwrap();
+        assert!(evaluated[0].eval.is_some(), "eval half appears with both maps");
+        assert!(evaluated[0].builds.is_none(), "no statuses yet");
+
+        write_status("baseline", JobStatus::Success);
+        write_status("candidate-1", JobStatus::Failure);
+        let built = crate::ci::compare::project(run_dir, &request, false).unwrap();
+        let builds = built[0].builds.as_ref().expect("statuses on both sides");
+        assert_eq!(builds.regressions, addrs(&["job"]));
+
+        let finished = crate::ci::compare::project(run_dir, &request, true).unwrap();
+        assert!(finished[0].builds.is_some());
     }
 }
 
@@ -1458,7 +1528,6 @@ mod exec {
             set: BuildTarget::Packages,
         }));
         assert!(!blocked_by_case_failure(Phase::Treefmt));
-        assert!(!blocked_by_case_failure(Phase::Compare));
         assert!(!blocked_by_case_failure(Phase::Content));
     }
 
@@ -1930,6 +1999,12 @@ mod markdown {
             let (report, fragments) = scenario;
             check_text(name, &comment(&report, &fragments, None, &links()).into_string());
         }
+        let (report, fragments) = scenarios::diff_in_progress();
+        assert_eq!(report.conclusion, None, "a mid-run diff stays open");
+        check_text(
+            "comment-diff-in-progress.md",
+            &comment(&report, &fragments, None, &links()).into_string(),
+        );
         let (report, fragments) = scenarios::in_progress();
         let snapshot = crate::ci::events::Snapshot {
             state: crate::support::atoms::RunState::Running,
@@ -3669,7 +3744,7 @@ mod fold {
         for task in &plan.tasks {
             let status = if task.case == "baseline" && task.kind == TaskKind::Eval {
                 TaskStatus::Failure
-            } else if task.case == "baseline" || task.kind == TaskKind::Comparison {
+            } else if task.case == "baseline" {
                 continue;
             } else {
                 TaskStatus::Success
@@ -3685,10 +3760,129 @@ mod fold {
             FoldContext {
                 baseline_case: Some("baseline".into()),
                 finished: true,
+                comparisons: vec![crate::ci::compare::Comparison {
+                    candidate: "candidate-1".into(),
+                    base_evaluated: false,
+                    head_evaluated: true,
+                    eval: None,
+                    builds: None,
+                }],
                 ..FoldContext::default()
             },
         );
         assert_eq!(report.conclusion, Some(Conclusion::Neutral), "{}", report.title);
+        assert!(report.title.contains("could not compare"), "{}", report.title);
+    }
+
+    fn all_green(plan: &crate::ci::plan::Plan) -> BTreeMap<String, Fragment> {
+        plan.tasks
+            .iter()
+            .map(|task| {
+                (
+                    task.task_id.clone(),
+                    fragment(&task.task_id, task.kind, TaskStatus::Success, "ok"),
+                )
+            })
+            .collect()
+    }
+
+    fn projected(
+        eval: Option<crate::ci::compare::EvalDiff>,
+        builds: Option<crate::ci::compare::BuildDiff>,
+    ) -> crate::ci::compare::Comparison {
+        crate::ci::compare::Comparison {
+            candidate: "candidate-1".into(),
+            base_evaluated: true,
+            head_evaluated: true,
+            eval,
+            builds,
+        }
+    }
+
+    #[test]
+    fn a_diff_stays_open_until_its_process_finishes() {
+        let plan = plan_of(&diff_request(), None, &[]);
+        // Every task reported green, builds included; only the eval half of
+        // the comparison exists. Gate accounting alone would conclude here.
+        let report = fold(
+            &plan,
+            &all_green(&plan),
+            FoldContext {
+                baseline_case: Some("baseline".into()),
+                finished: false,
+                comparisons: vec![projected(
+                    Some(crate::ci::compare::EvalDiff::default()),
+                    None,
+                )],
+                ..FoldContext::default()
+            },
+        );
+        assert_eq!(report.conclusion, None, "{}", report.title);
+        assert!(!report.complete);
+    }
+
+    #[test]
+    fn regressions_in_the_projection_conclude_failure() {
+        let plan = plan_of(&diff_request(), None, &[]);
+        let report = fold(
+            &plan,
+            &all_green(&plan),
+            FoldContext {
+                baseline_case: Some("baseline".into()),
+                finished: true,
+                comparisons: vec![projected(
+                    Some(crate::ci::compare::EvalDiff::default()),
+                    Some(crate::ci::compare::BuildDiff {
+                        regressions: vec![crate::support::atoms::JobAddr("checks.zlib".into())],
+                        ..crate::ci::compare::BuildDiff::default()
+                    }),
+                )],
+                ..FoldContext::default()
+            },
+        );
+        assert_eq!(report.conclusion, Some(Conclusion::Failure));
+        assert!(report.title.contains("1 regressions"), "{}", report.title);
+    }
+
+    #[test]
+    fn a_clean_finished_diff_concludes_success() {
+        let plan = plan_of(&diff_request(), None, &[]);
+        let report = fold(
+            &plan,
+            &all_green(&plan),
+            FoldContext {
+                baseline_case: Some("baseline".into()),
+                finished: true,
+                comparisons: vec![projected(
+                    Some(crate::ci::compare::EvalDiff::default()),
+                    Some(crate::ci::compare::BuildDiff::default()),
+                )],
+                ..FoldContext::default()
+            },
+        );
+        assert_eq!(report.conclusion, Some(Conclusion::Success), "{}", report.title);
+    }
+
+    #[test]
+    fn an_uncompared_candidate_with_an_evaluated_base_concludes_failure() {
+        let plan = plan_of(&diff_request(), None, &[]);
+        let report = fold(
+            &plan,
+            &all_green(&plan),
+            FoldContext {
+                baseline_case: Some("baseline".into()),
+                finished: true,
+                comparisons: vec![crate::ci::compare::Comparison {
+                    candidate: "candidate-1".into(),
+                    base_evaluated: true,
+                    head_evaluated: false,
+                    eval: None,
+                    builds: None,
+                }],
+                ..FoldContext::default()
+            },
+        );
+        assert_eq!(report.conclusion, Some(Conclusion::Failure), "{}", report.title);
         assert!(report.title.contains("could not compare"), "{}", report.title);
     }
 
@@ -3937,7 +4131,7 @@ mod scenarios {
         for task in &plan.tasks {
             let status = if task.case == "baseline" && task.kind == TaskKind::Eval {
                 TaskStatus::Failure
-            } else if task.case == "baseline" || task.kind == TaskKind::Comparison {
+            } else if task.case == "baseline" {
                 continue;
             } else {
                 TaskStatus::Success
@@ -3953,6 +4147,13 @@ mod scenarios {
             FoldContext {
                 baseline_case: Some("baseline".into()),
                 finished: true,
+                comparisons: vec![crate::ci::compare::Comparison {
+                    candidate: "candidate-1".into(),
+                    base_evaluated: false,
+                    head_evaluated: true,
+                    eval: None,
+                    builds: None,
+                }],
                 request: Some(request),
                 ..FoldContext::default()
             },
@@ -3963,7 +4164,7 @@ mod scenarios {
     /// A green diff whose comparison carries every non-failure story: fixes,
     /// rebuilds, version moves, added and removed jobs.
     pub fn diff_green() -> (Report, Fragments) {
-        use crate::ci::compare::{Comparison, VersionUpdate};
+        use crate::ci::compare::{BuildDiff, Comparison, EvalDiff, VersionUpdate};
         let request = Request::Diff(Diff {
             baseline: "baseline".into(),
             content_diff: false,
@@ -3973,53 +4174,100 @@ mod scenarios {
             ],
         });
         let plan = plan_of(&request, Some("golden"), &[]);
-        let mut fragments = green_fragments(&plan);
+        let fragments = green_fragments(&plan);
         let comparison = Comparison {
-            fixes: vec![JobAddr("checks.curl".into())],
-            rebuilt: vec![
-                JobAddr("checks.zlib".into()),
-                JobAddr("packagesByProfile.eh.zlib".into()),
-            ],
-            identity_transitions: vec!["packagesByProfile.eh.zlib: 1.3.1 -> 1.3.2".into()],
-            version_updates: vec![VersionUpdate {
-                subject: "zlib".into(),
-                before: "1.3.1".into(),
-                after: "1.3.2".into(),
-                changelogs: Vec::new(),
-                jobs: vec![JobAddr("packagesByProfile.eh.zlib".into())],
-            }],
-            added: vec![JobAddr("checks.brotli".into())],
-            removed: vec![JobAddr("checks.legacy-tool".into())],
-            identities: BTreeMap::from([
-                (JobAddr("checks.brotli".into()), "1.1.0".to_string()),
-                (JobAddr("checks.legacy-tool".into()), "0.9.1".to_string()),
-                (JobAddr("checks.zlib".into()), "1.3.2".to_string()),
-            ]),
-            selected_count: 40,
-            ..Comparison::default()
+            candidate: "candidate-1".into(),
+            base_evaluated: true,
+            head_evaluated: true,
+            eval: Some(EvalDiff {
+                rebuilt: vec![
+                    JobAddr("checks.zlib".into()),
+                    JobAddr("packagesByProfile.eh.zlib".into()),
+                ],
+                identity_transitions: vec!["packagesByProfile.eh.zlib: 1.3.1 -> 1.3.2".into()],
+                version_updates: vec![VersionUpdate {
+                    subject: "zlib".into(),
+                    before: "1.3.1".into(),
+                    after: "1.3.2".into(),
+                    changelogs: Vec::new(),
+                    jobs: vec![JobAddr("packagesByProfile.eh.zlib".into())],
+                }],
+                added: vec![JobAddr("checks.brotli".into())],
+                removed: vec![JobAddr("checks.legacy-tool".into())],
+                identities: BTreeMap::from([
+                    (JobAddr("checks.brotli".into()), "1.1.0".to_string()),
+                    (JobAddr("checks.legacy-tool".into()), "0.9.1".to_string()),
+                    (JobAddr("checks.zlib".into()), "1.3.2".to_string()),
+                ]),
+                selected_count: 40,
+                ..EvalDiff::default()
+            }),
+            builds: Some(BuildDiff {
+                fixes: vec![JobAddr("checks.curl".into())],
+                ..BuildDiff::default()
+            }),
         };
+        let report = fold(
+            &plan,
+            &fragments,
+            FoldContext {
+                baseline_case: Some("baseline".into()),
+                finished: true,
+                started_at: Some(1_755_000_000),
+                finished_at: Some(1_755_003_600),
+                comparisons: vec![comparison],
+                request: Some(request),
+            },
+        );
+        (report, fragments)
+    }
+
+    /// A diff mid-run: both evals landed, builds still going, so only the
+    /// eval half of the comparison exists. The comment must already tell the
+    /// added/removed/version story.
+    pub fn diff_in_progress() -> (Report, Fragments) {
+        use crate::ci::compare::{Comparison, EvalDiff};
+        let request = Request::Diff(Diff {
+            baseline: "baseline".into(),
+            content_diff: false,
+            cases: vec![
+                Case::Build(build("baseline")),
+                Case::Build(build("candidate-1")),
+            ],
+        });
+        let plan = plan_of(&request, Some("golden"), &[]);
+        let mut fragments = BTreeMap::new();
         for task in &plan.tasks {
-            if task.kind == TaskKind::Comparison {
+            if matches!(task.kind, TaskKind::Eval | TaskKind::Validation) {
                 fragments.insert(
                     task.task_id.clone(),
-                    Fragment::new(
-                        &task.task_id,
-                        &task.label,
-                        task.kind,
-                        TaskStatus::Success,
-                        "no regressions",
-                    )
-                    .with_data(FragmentData::Comparison(Box::new(comparison.clone()))),
+                    Fragment::new(&task.task_id, &task.label, task.kind, TaskStatus::Success, "ok"),
                 );
             }
         }
+        let comparison = Comparison {
+            candidate: "candidate-1".into(),
+            base_evaluated: true,
+            head_evaluated: true,
+            eval: Some(EvalDiff {
+                rebuilt: vec![JobAddr("checks.zlib".into())],
+                added: vec![JobAddr("checks.brotli".into())],
+                identities: BTreeMap::from([
+                    (JobAddr("checks.brotli".into()), "1.1.0".to_string()),
+                    (JobAddr("checks.zlib".into()), "1.3.2".to_string()),
+                ]),
+                selected_count: 40,
+                ..EvalDiff::default()
+            }),
+            builds: None,
+        };
         let report = fold(
             &plan,
             &fragments,
             FoldContext {
                 baseline_case: Some("baseline".into()),
                 started_at: Some(1_755_000_000),
-                finished_at: Some(1_755_003_600),
+                comparisons: vec![comparison],
                 request: Some(request),
                 ..FoldContext::default()
             },

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -40,6 +40,20 @@ mod naming {
             Some(1),
             Vec::new(),
         );
+        // The crate-pins/server shape: one target's declared name is the
+        // trailing segment of another's address.
+        domain.add_path(
+            vec!["cargoRegistry".into(), "crates".into()],
+            "crate-pins",
+            None,
+            vec!["cargo-registry".into()],
+        );
+        domain.add_path(
+            vec!["nativePackages".into(), "cargo-registry".into()],
+            "registry-server",
+            None,
+            vec!["cargo-registry-server".into()],
+        );
         domain
     }
 
@@ -48,6 +62,16 @@ mod naming {
             .into_iter()
             .map(|hit| hit.key)
             .collect())
+    }
+
+    #[test]
+    fn a_declared_name_outranks_a_structural_suffix() {
+        assert_eq!(resolve("cargo-registry").unwrap(), ["crate-pins"]);
+        assert_eq!(resolve("cargo-registry-server").unwrap(), ["registry-server"]);
+        assert_eq!(
+            resolve("nativePackages.cargo-registry").unwrap(),
+            ["registry-server"]
+        );
     }
 
     #[test]

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -160,21 +160,35 @@ pub(crate) fn declared_target(repo: &Path, attr: &str, value: &Value) -> Result<
     })
 }
 
-/// One target per package, deduped across the per-profile attrs.
-pub fn discovered_targets(repo: &Path) -> Result<Vec<Target>> {
-    let declared = eval(&Flake::default(), "updateScripts", None)?;
-    // Ordered by attribute, deduped by name: the first attr declaring a name
-    // wins, and a package's position in the run follows where it was found.
+/// One target per pin. Declarations are ordered by attribute; the first attr
+/// declaring a name wins. A wrapper and its unwrapped package (or the same
+/// package under several profiles) declare the same script against the same
+/// file, which is one pin and one target, not one per spelling.
+pub(crate) fn dedupe(declared: Vec<Target>) -> Vec<Target> {
     let mut targets: Vec<Target> = Vec::new();
-    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for (attr, value) in declared.as_object().into_iter().flatten() {
-        let target = declared_target(repo, attr, value)?;
-        if !seen.insert(target.name.clone()) {
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut pins: std::collections::BTreeSet<(String, Vec<String>)> =
+        std::collections::BTreeSet::new();
+    for target in declared {
+        if !target.file.is_empty() && !pins.insert((target.file.clone(), target.command.clone()))
+        {
+            continue;
+        }
+        if !names.insert(target.name.clone()) {
             continue;
         }
         targets.push(target);
     }
-    Ok(targets)
+    targets
+}
+
+pub fn discovered_targets(repo: &Path) -> Result<Vec<Target>> {
+    let declared = eval(&Flake::default(), "updateScripts", None)?;
+    let mut targets: Vec<Target> = Vec::new();
+    for (attr, value) in declared.as_object().into_iter().flatten() {
+        targets.push(declared_target(repo, attr, value)?);
+    }
+    Ok(dedupe(targets))
 }
 
 pub struct Hook {


### PR DESCRIPTION
Two arcs: the comparison becomes a fold-time projection so diff results reach the comment as soon as their inputs exist, and fixes for everything the first live update dispatch and comment command surfaced.

## Comparison as a projection

The comparison was a task scheduled after builds, so the whole difference story rendered only at the end of a run; the pre-rewrite CI had reported it right after evaluation. No task computes it now: `compare::project` derives it from the persisted case directories each time the report folds, with provenance in the type (`Comparison { eval, builds }`). The in-progress comment shows added/removed/version moves/rebuilds (marked "builds pending") as soon as both evaluations land; regressions and fixes join when results exist. The Compare task, fragment, and ladder row are gone; candidate evaluations gate, a broken baseline still concludes neutral, and regressions fail the run straight from the projection. Verified with a live self-diff: both halves projected, `CI passed`, 10/10 jobs.

Note: run dirs from before this change carry a comparison fragment that no longer loads; they predate the branch and are re-runnable.

## Comment commands never worked

`/wasinix` comments have never worked in the rewritten CI: the authorize document has a field named `kind`, colliding with the document envelope's reserved key, and the assert panics on the first write. Renamed on the wire, with a round-trip test for the collision class. The authorize job also reacts 👀 before any nix setup, so a command is visibly heard seconds after posting.

## The cache misses that would not die

`checks.wasinix` concluded "cached" on every run and never reached the cache: the workflow's bootstrap build makes it locally valid, the dry-run classifies it cached, and cached jobs were never pushed. The driver now keeps the dry-run fetch set and uploads outputs that are valid only locally. Downstream, the same missing path made the wasmer bump PR report "0/53 outputs identical": `nix path-info` fails a whole chunk when any path is absent, so one unpushed base output marked all 53 pairs unavailable and total skippage rendered as total difference. Failed chunks now bisect, and the headline counts only pairs actually compared.

## The update dispatch, second round

Of 26 remaining failures: 22 grammar bumps lacked `sed` in the updater's inputs and resolved `package.nix` through `$0`, which points into the store for an inlined script (now via the repo toplevel; verified live end to end). The rest were duplicate targets: vestigial `updateScript` declarations on unwrapped packages, and wasix-rust's one pin surfacing under four attrs with two names. Declarations fixed at the source, `nativePackages.wasix-rust` pinned as the evaluable attr, discovery dedupes by (pin file, command), and a declared target name now outranks another entry's address suffix so `update cargo-registry` resolves again. Packaging docs ask for a local downgrade-and-back round trip before a self-sourced package's update script ships.

Also: the request echo in the comment folds into its own nested details block.

Each commit replays green individually (194 to 197 tests accruing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)