### PR TITLE
python: set wasmer name to python/python

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,10 @@ dependencies that may use another profile.
 
 `pkgs/wasmer/` turns shipped CLIs into webc packages. The default manifest uses
 `meta.mainProgram` and the package's `bin/*.wasm`; deviations belong in
-`passthru.wasmer`. Tests run under Wasmer through `pkgs/wasmer/test-lib.nix`.
+`passthru.wasmer`. Shipped entries in `preferredProfilePackages` also expose
+their `.pkg`, `.webc`, and `.shim`, plus `.tests` when present; `wasmerPackages`
+is the deduplicated publication inventory keyed by published name. Tests run
+under Wasmer through `pkgs/wasmer/test-lib.nix`.
 
 ## Flake outputs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,9 @@ dependencies that may use another profile.
 `meta.mainProgram` and the package's `bin/*.wasm`; deviations belong in
 `passthru.wasmer`. Shipped entries in `preferredProfilePackages` also expose
 their `.pkg`, `.webc`, and `.shim`, plus `.tests` when present; `wasmerPackages`
-is the deduplicated publication inventory keyed by published name. Tests run
-under Wasmer through `pkgs/wasmer/test-lib.nix`.
+is the public package namespace and includes explicitly declared aliases. Its
+canonical entries alone drive publication, CI, and aggregate generation. Tests
+run under Wasmer through `pkgs/wasmer/test-lib.nix`.
 
 ## Flake outputs
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -176,11 +176,11 @@ nixpkgs, crate edits, and the overlay registry: `docs/rust.md`.
 derivations built with `pkgs/wasmer/test-lib.nix` (a `helpers.nix` is shared
 setup). They attach as `passthru.tests` and appear under
 `checks.<system>.<name>`. Besides `pkgs`/`testLib`/`wasmerPkgs`, test files can
-take `crossPkgs` (the default-profile cross set) and `makeWasmerPackage` to
-cross-build and package a consumer program. See icu-data's smoke test for an
-example. `mkScriptComparison` diffs against the native tool; `expectFail` marks
-a must-fail test; `broken "reason"` tolerates a known failure and fails loudly
-once it starts passing.
+take `preferredProfilePackages`, `crossPkgs` (the default-profile cross set),
+and `makeWasmerPackage` to cross-build and package a consumer program. See
+icu-data's smoke test for an example. `mkScriptComparison` diffs against the
+native tool; `expectFail` marks a must-fail test; `broken "reason"` tolerates a
+known failure and fails loudly once it starts passing.
 
 Every wheel also gets the guards in `pkgs/python-wheels.nix`: `import` runs the
 module on the shipped python, `self-contained` rejects a baked `/nix/store`

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -126,11 +126,16 @@ nixpkgs, crate edits, and the overlay registry: `docs/rust.md`.
    time.
 
 2. The webc manifest is generated; most packages need zero config. Deviations go
-   in `passthru.wasmer`: `name`, `version`, `commands` (aliases), `entrypoint`,
+   in `passthru.wasmer`: `name`, `version`, `aliases` (`wasmerPackages` attr
+   aliases), `commands` (manifest command aliases), `entrypoint`,
    `fs."<path>" = <store path>`, `commandEnv.<cmd>`, `autoSelfMount` (mount
    store paths found in the wasm), `selfMounts` (paths referenced from scripts,
    which autoSelfMount can't see). See git's package.nix for an example with
    several deviations.
+
+   `aliases` are explicit public addresses for the same package. They must not
+   collide with a canonical published-name key or resolve to different packages.
+   Publication, CI, and aggregate generation use only canonical entries.
 
    `commands` also names several commands on one module, which is how bash
    serves `sh` and coreutils serves a command per program without repeating the

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -93,6 +93,9 @@ Keys differ per set, and webcs are normalised:
 - webcs: `wasmerPackages` and the run-by-name stubs use `<name>-<semver>`, so a
   test asks for `wasmerPkgs."jq-1.6.0"`.
 
+A package may declare stable `passthru.wasmer.aliases` for public Nix addresses.
+These resolve to the canonical entry but do not create another publication.
+
 Webc attrs use full MAJOR.MINOR.PATCH while `history.json` keeps the upstream
 version as written. For example, jq `"1.6"` becomes `jq-1.6.0`.
 

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,7 @@
       src = ./tools/wasinix;
       cargoLock.lockFile = ./tools/wasinix/Cargo.lock;
       doCheck = true;
-      nativeCheckInputs = [wasix.pkgs.gitMinimal];
+      nativeCheckInputs = with wasix.pkgs; [gitMinimal nixVersions.latest];
       meta.mainProgram = "wasinix";
     };
     # Every command is runnable from the same installed closure, so a remote
@@ -599,6 +599,15 @@
             })
           packages)
         wasix.ciPackagesByProfile;
+      wasmerJobAliases =
+        lib.concatMapAttrs (packageKey: package: let
+          aliases = package.passthru.wasmer.aliases or [];
+          addresses = map (alias: "wasmerPackages.${alias}") aliases;
+        in {
+          "wasmerPackages.${packageKey}" = addresses;
+          "wasmerPackages.${packageKey}.webc" = map (address: "${address}.webc") addresses;
+        })
+        wasix.wasmerPackageInventory;
       ciJobInfo = lib.mapAttrs (name: drv: let
         isCheck = lib.hasPrefix "checks." name;
         wasixMeta = drv.passthru.wasix or {};
@@ -626,6 +635,7 @@
           inherit subject;
           testName = wasixMeta.ciTestName or null;
           inherit variant artifactKind;
+          aliases = wasmerJobAliases.${name} or [];
           tags = wasixLib.ciTagsOf drv;
           role =
             if isCheck

--- a/flake.nix
+++ b/flake.nix
@@ -420,8 +420,8 @@
         (collectTests wasix.toolchainTestPkgs)
       ];
       packages = mergeDisjoint "checksBySet.packages" [
-        (collectTests (removeAttrs wasix.wasmerPackages ["rust"]))
-        (lib.optionalAttrs (wasix.wasmerPackages ? rust) {rust-webc = wasix.wasmerPackages.rust.tests;})
+        (collectTests (removeAttrs wasix.wasmerPackageInventory ["rust"]))
+        (lib.optionalAttrs (wasix.wasmerPackageInventory ? rust) {rust-webc = wasix.wasmerPackageInventory.rust.tests;})
         (collectTests {cargo-registry = wasix.cargoRegistry;})
         (lib.mapAttrs' (p: lib.nameValuePair "abi-${p}") wasix.abiChecks)
         # non-shipped library packages carrying a tests/ dir
@@ -529,7 +529,7 @@
         packages = [
           # The package-declared coverage, not every profile a package supports.
           (flattenDrvs "packagesByProfile" wasix.ciPackagesByProfile)
-          (flattenDrvs "wasmerPackages" buildable.wasmerPackages)
+          (flattenDrvs "wasmerPackages" wasix.wasmerPackageInventory)
           (flattenDrvs "nativePackages" buildable.nativePackages)
           (flattenDrvs "" {inherit (buildable) cargoRegistry;})
           (flattenDrvs "checks" checksBySet.packages)
@@ -697,7 +697,7 @@
               lib.concatMap
               (perPython: lib.attrValues (perPython.${name} or {}))
               (lib.attrValues wasix.pythonRegistry.wheels);
-            webcs = lib.groupBy (p: p.pkg.id.name) (lib.attrValues wasix.wasmerPackages);
+            webcs = lib.groupBy (p: p.pkg.id.name) (lib.attrValues wasix.wasmerPackageInventory);
             relInfo =
               lib.mapAttrs' (name: versions:
                 lib.nameValuePair "pythonRegistry.wheels.${name}" {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -344,8 +344,8 @@
     inherit pythonRegistry;
   };
   preferredProfilePackagesWithWebc = wasmerLayer.preferredProfilePackages;
-  # keyed by program name, each carrying passthru.pkg / .webc / .tests
-  inherit (wasmerLayer) wasmerPackages allWasmerPackages libraryTestPkgs;
+  # Public package names and aliases; canonical-only consumers use the inventory.
+  inherit (wasmerLayer) wasmerPackages wasmerPackageInventory allWasmerPackages libraryTestPkgs;
 
   # The shipped wheels plus their transitive deps as one static PEP 503 index over
   # both interpreters: a resolver picks the right file by its cp313/cp314 tag.
@@ -373,7 +373,7 @@ in {
   inherit nativePackages packagesByProfile ciPackagesByProfile;
   inherit toolchain toolchainByProfile nixpkgsByProfile allWasmerPackages;
   preferredProfilePackages = preferredProfilePackagesWithWebc;
-  inherit shippedCommands wasmerPackages toolchainTestPkgs abiChecks;
+  inherit shippedCommands wasmerPackages wasmerPackageInventory toolchainTestPkgs abiChecks;
   inherit libraryTestPkgs;
   inherit pythonWheels pythonRegistry cargoRegistry;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -288,7 +288,7 @@
       inherit pkgs lib mkTestGroup select pyKey;
       python3 = nixpkgsByProfile.exnrefEhpic.${pyAttr};
       wasmer = wasmerRuntime;
-      pythonWebc = wasmerLayer.wasmerPackages.${pyAttr}.webc;
+      pythonWebc = preferredProfilePackagesWithWebc.${pyAttr}.webc;
     };
     withPublication = _: drv:
       drv.overrideAttrs (o: {
@@ -343,6 +343,7 @@
     packagesDir = ./overlay/packages;
     inherit pythonRegistry;
   };
+  preferredProfilePackagesWithWebc = wasmerLayer.preferredProfilePackages;
   # keyed by program name, each carrying passthru.pkg / .webc / .tests
   inherit (wasmerLayer) wasmerPackages allWasmerPackages libraryTestPkgs;
 
@@ -365,12 +366,13 @@
     inherit (wasmerLayer) testLib;
     # default python interpreter + its webc, both from the top-level `python3`.
     python3 = nixpkgsByProfile.exnrefEhpic.python3;
-    pythonWebc = wasmerLayer.wasmerPackages.python.shim;
+    pythonWebc = preferredProfilePackagesWithWebc.python3.shim;
   };
 in {
   inherit pkgs pkgsCross nixUpdate defaultProfileName wasixPkgNames;
   inherit nativePackages packagesByProfile ciPackagesByProfile;
-  inherit toolchain toolchainByProfile nixpkgsByProfile preferredProfilePackages allWasmerPackages;
+  inherit toolchain toolchainByProfile nixpkgsByProfile allWasmerPackages;
+  preferredProfilePackages = preferredProfilePackagesWithWebc;
   inherit shippedCommands wasmerPackages toolchainTestPkgs abiChecks;
   inherit libraryTestPkgs;
   inherit pythonWheels pythonRegistry cargoRegistry;

--- a/pkgs/overlay/packages/anybuild/tests/python-templates.nix
+++ b/pkgs/overlay/packages/anybuild/tests/python-templates.nix
@@ -13,6 +13,7 @@
 # runs on both, so the newer interpreter's wheels are still exercised end to end.
 {
   pkgs,
+  preferredProfilePackages,
   testLib,
   helpers,
   pythonRegistry,
@@ -37,15 +38,14 @@
   # extensions, so a successful request exercises loading them.
   servedTemplate = "python-pillow";
 
-  # {"3.13" = {host = pkgs.python313; webc = wasmerPackages.python313;}; ...}
   interpreters = {
     "3.13" = {
       host = pkgs.python313;
-      webc = wasmerPackages.python313;
+      webc = preferredProfilePackages.python313;
     };
     "3.14" = {
       host = pkgs.python314;
-      webc = wasmerPackages.python314;
+      webc = preferredProfilePackages.python314;
     };
   };
 

--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -1,5 +1,5 @@
-# CPython for wasix, following the wasix-org/cpython recipe. Shipped for 3.13 and 3.14,
-# each under its own webc name so both publish; `python3` aliases the default 3.14.
+# CPython for wasix, following the wasix-org/cpython recipe. Shipped for 3.13 and 3.14
+# as versions of python/python; `python3` aliases the current 3.14 derivation.
 # ehpic only: dl/ctypes need the PIC sysroot.
 {
   names = ["python3" "python313" "python314"];
@@ -13,6 +13,7 @@
     ...
   }: let
     lib = prev.lib;
+    current = prev.python314;
 
     mkWasixPython = base: let
       pyVer = base.pythonVersion;
@@ -263,6 +264,7 @@
             wasmer = {
               owner = "python";
               name = "python";
+              history = pyVer != current.pythonVersion;
               entrypoint = "python${pyVer}";
               # The atom is the module name, and a consumer's manifest refers to
               # an interpreter as <package>:python (anybuild's serve command
@@ -343,7 +345,7 @@
       py;
   in rec {
     python313 = mkWasixPython prev.python313;
-    python314 = mkWasixPython prev.python314;
+    python314 = mkWasixPython current;
     python3 = python314;
   };
 }

--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -14,11 +14,10 @@
   }: let
     lib = prev.lib;
 
-    mkWasixPython = base: webcName: let
+    mkWasixPython = base: let
       pyVer = base.pythonVersion;
       py =
         helpers.libTweaks {
-          passthru.wasix.shipped = true;
           configureFlags = [
             "--enable-wasm-dynamic-linking"
             # nixpkgs presets ac_cv_x87_double_rounding=yes for every cross build, an
@@ -253,6 +252,7 @@
             );
 
           passthru = {
+            wasix.shipped = true;
             # dlfcn.h and dlopen/dlsym, needed by ctypes, ship only in the PIC sysroots.
             wasix.supportedProfiles = ["ehpic"];
             # PYO3_CROSS_LIB_DIR and setuptools-rust's pyLibDir, so a 3.13 wheel targets 3.13.
@@ -261,7 +261,8 @@
             # picks the build interpreter's 64-bit headers and pyport.h fatals on wasm32.
             crossIncludeDir = "${py}/include/${py.libPrefix}";
             wasmer = {
-              name = webcName;
+              owner = "python";
+              name = "python";
               entrypoint = "python${pyVer}";
               # The atom is the module name, and a consumer's manifest refers to
               # an interpreter as <package>:python (anybuild's serve command
@@ -340,11 +341,9 @@
         });
     in
       py;
-  in {
-    # No dot: a wasmer manifest rejects a dependency name carrying one, so
-    # `wasmer/python3.13` is a package nothing can depend on.
-    python313 = mkWasixPython prev.python313 "python313";
-    python314 = mkWasixPython prev.python314 "python314";
-    python3 = mkWasixPython prev.python314 "python";
+  in rec {
+    python313 = mkWasixPython prev.python313;
+    python314 = mkWasixPython prev.python314;
+    python3 = python314;
   };
 }

--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -265,6 +265,10 @@
               owner = "python";
               name = "python";
               history = pyVer != current.pythonVersion;
+              aliases =
+                if pyVer == current.pythonVersion
+                then ["python3" "python314"]
+                else ["python313"];
               entrypoint = "python${pyVer}";
               # The atom is the module name, and a consumer's manifest refers to
               # an interpreter as <package>:python (anybuild's serve command

--- a/pkgs/overlay/packages/python3/tests/ctypes-findlib.nix
+++ b/pkgs/overlay/packages/python3/tests/ctypes-findlib.nix
@@ -2,9 +2,9 @@
   pkgs,
   testLib,
   helpers,
-  wasmerPkgs,
+  preferredProfilePackages,
 }:
-helpers.forEachPython wasmerPkgs ({
+helpers.forEachPython preferredProfilePackages ({
   python,
   pyVer,
   tag,

--- a/pkgs/overlay/packages/python3/tests/helpers.nix
+++ b/pkgs/overlay/packages/python3/tests/helpers.nix
@@ -1,5 +1,5 @@
-# Discovery imports helpers.nix with only pkgs, so wasmerPkgs is passed per
-# call site.
+# Discovery imports helpers.nix with only pkgs, so preferredProfilePackages is
+# passed per call site.
 {pkgs}: let
   lib = pkgs.lib;
 in {
@@ -8,7 +8,7 @@ in {
   # The tags are static on purpose: deriving attr names from the shim's
   # .version forces the wasmer package set while its test groups are still
   # being assembled (infinite recursion); pyVer is safe in values only.
-  forEachPython = wasmerPkgs: f: let
+  forEachPython = preferredProfilePackages: f: let
     instantiate = {
       python,
       tag,
@@ -20,11 +20,11 @@ in {
       });
   in
     instantiate {
-      python = wasmerPkgs.python;
+      python = preferredProfilePackages.python3.shim;
       tag = "";
     }
     // instantiate {
-      python = wasmerPkgs.python313;
+      python = preferredProfilePackages.python313.shim;
       tag = "313";
     };
 }

--- a/pkgs/overlay/packages/python3/tests/mp-context.nix
+++ b/pkgs/overlay/packages/python3/tests/mp-context.nix
@@ -2,9 +2,9 @@
   pkgs,
   testLib,
   helpers,
-  wasmerPkgs,
+  preferredProfilePackages,
 }:
-helpers.forEachPython wasmerPkgs ({
+helpers.forEachPython preferredProfilePackages ({
   python,
   pyVer,
   tag,

--- a/pkgs/overlay/packages/python3/tests/spawn-passfds.nix
+++ b/pkgs/overlay/packages/python3/tests/spawn-passfds.nix
@@ -2,11 +2,11 @@
   pkgs,
   testLib,
   helpers,
-  wasmerPkgs,
+  preferredProfilePackages,
 }: let
   lib = pkgs.lib;
 in
-  helpers.forEachPython wasmerPkgs ({
+  helpers.forEachPython preferredProfilePackages ({
     python,
     pyVer,
     tag,

--- a/pkgs/overlay/packages/python3/tests/subprocess-opts.nix
+++ b/pkgs/overlay/packages/python3/tests/subprocess-opts.nix
@@ -2,9 +2,9 @@
   pkgs,
   testLib,
   helpers,
-  wasmerPkgs,
+  preferredProfilePackages,
 }:
-helpers.forEachPython wasmerPkgs ({
+helpers.forEachPython preferredProfilePackages ({
   python,
   pyVer,
   tag,

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -17,7 +17,8 @@
   # overlay/packages dir, used to locate each package's tests/.
   packagesDir,
   # the served wheel index, for tests that resolve against it. Forced only by a
-  # test, and it reads wasmerPackages.python.shim, which never forces .tests.
+  # test, and it reads preferredProfilePackages.python3.shim, which never forces
+  # .tests.
   pythonRegistry,
 }: let
   testLib = import ./test-lib.nix {inherit pkgs wasmer;};
@@ -37,7 +38,7 @@
         else {};
       scope = {
         inherit pkgs testLib helpers crossPkgs crossPkgsPic makeWasmerPackage pythonRegistry;
-        inherit preferredProfilePackages;
+        preferredProfilePackages = preferredProfilePackagesWithWebc;
         # Shims, for putting another package's commands on PATH. .shim drives the
         # packed .webc, .pkg.shim the source dir.
         wasmerPkgs = lib.mapAttrs (_: p: p.shim) wasmerPackages;
@@ -113,6 +114,13 @@
   servedByName =
     lib.mapAttrs (_: infos: lib.unique (map (i: i.id.baseVersion) infos))
     (lib.groupBy (i: i.id.name) shippedInfo);
+  shippedPackages =
+    lib.listToAttrs
+    (map (i:
+      lib.nameValuePair i.overlayName
+      (augment i.overlayName i.crossPkg servedByName.${i.id.name}))
+    shippedInfo);
+  preferredProfilePackagesWithWebc = preferredProfilePackages // shippedPackages;
   # Alias attrs (icu-data -> icu-data76) repeat a key with the same drv; only
   # distinct drvs sharing a key are an error.
   byKey = lib.groupBy (i: i.key) shippedInfo;
@@ -123,13 +131,7 @@
   wasmerPackages =
     lib.throwIf (conflicting != [])
     "wasmerPackages: duplicate webc keys (${lib.concatStringsSep ", " conflicting}); a second version of a name must set passthru.wasmer.history"
-    (lib.mapAttrs (
-        _: is: let
-          i = lib.head is;
-        in
-          augment i.overlayName i.crossPkg servedByName.${i.id.name}
-      )
-      byKey);
+    (lib.mapAttrs (_: is: shippedPackages.${(lib.head is).overlayName}) byKey);
 
   # One subtree per key: two versions of one webc share the inner pkg/<name> dir
   # name, so a flat merge would collide.
@@ -167,5 +169,6 @@
         })
     );
 in {
+  preferredProfilePackages = preferredProfilePackagesWithWebc;
   inherit wasmerPackages allWasmerPackages testLib libraryTestPkgs;
 }

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -70,7 +70,7 @@
 
   # Forcing the package or its .pkg.shim never forces .tests, so tests referencing
   # other packages' shims do not cycle.
-  augment = overlayName: crossPkg: servedVersions: let
+  augment = overlayName: packageKey: crossPkg: servedVersions: let
     group = testGroupFor overlayName;
     pkg = makeWasmerPackage {
       package = crossPkg;
@@ -85,6 +85,7 @@
           # git -> "git" webc, but history.json keys by overlay attr, so
           # `history` and `update` need this to map a webc back to its entry.
           inherit overlayName;
+          wasmer = ((o.passthru or {}).wasmer or {}) // {inherit packageKey;};
           inherit pkg;
           webc = pkg.webc;
           # run-by-name wrapper; forcing it never forces .tests
@@ -118,7 +119,7 @@
     lib.listToAttrs
     (map (i:
       lib.nameValuePair i.overlayName
-      (augment i.overlayName i.crossPkg servedByName.${i.id.name}))
+      (augment i.overlayName i.key i.crossPkg servedByName.${i.id.name}))
     shippedInfo);
   preferredProfilePackagesWithWebc = preferredProfilePackages // shippedPackages;
   # Alias attrs (icu-data -> icu-data76) repeat a key with the same drv; only
@@ -128,10 +129,28 @@
   conflicting =
     lib.attrNames
     (lib.filterAttrs (_: is: lib.length is > 1 && distinctDrvs is > 1) byKey);
-  wasmerPackages =
+  wasmerPackageInventory =
     lib.throwIf (conflicting != [])
     "wasmerPackages: duplicate webc keys (${lib.concatStringsSep ", " conflicting}); a second version of a name must set passthru.wasmer.history"
     (lib.mapAttrs (_: is: shippedPackages.${(lib.head is).overlayName}) byKey);
+  aliasInfo = lib.concatLists (lib.mapAttrsToList (packageKey: is:
+    map (name: {
+      inherit name packageKey;
+      package = wasmerPackageInventory.${packageKey};
+    }) ((lib.head is).crossPkg.passthru.wasmer.aliases or []))
+  byKey);
+  byAlias = lib.groupBy (i: i.name) aliasInfo;
+  conflictingAliases = lib.attrNames (lib.filterAttrs (_: is:
+    lib.length (lib.unique (map (i: i.packageKey) is)) > 1)
+  byAlias);
+  shadowingAliases = lib.intersectLists (lib.attrNames wasmerPackageInventory) (lib.attrNames byAlias);
+  aliasPackages = lib.mapAttrs (_: is: (lib.head is).package) byAlias;
+  wasmerPackages =
+    lib.throwIf (shadowingAliases != [])
+    "wasmerPackages: aliases shadow canonical keys (${lib.concatStringsSep ", " shadowingAliases})"
+    (lib.throwIf (conflictingAliases != [])
+      "wasmerPackages: aliases resolve to multiple packages (${lib.concatStringsSep ", " conflictingAliases})"
+      (wasmerPackageInventory // aliasPackages));
 
   # One subtree per key: two versions of one webc share the inner pkg/<name> dir
   # name, so a flat merge would collide.
@@ -139,12 +158,12 @@
     set -euo pipefail
     mkdir -p "$out/pkg"
     ${lib.concatMapStringsSep "\n" (n: ''
-        if [ -d "${wasmerPackages.${n}.pkg}/pkg" ]; then
+        if [ -d "${wasmerPackageInventory.${n}.pkg}/pkg" ]; then
           mkdir -p "$out/pkg/${n}"
-          ${pkgs.coreutils}/bin/cp -R --no-preserve=mode,ownership "${wasmerPackages.${n}.pkg}/pkg/." "$out/pkg/${n}/"
+          ${pkgs.coreutils}/bin/cp -R --no-preserve=mode,ownership "${wasmerPackageInventory.${n}.pkg}/pkg/." "$out/pkg/${n}/"
         fi
       '')
-      (builtins.attrNames wasmerPackages)}
+      (builtins.attrNames wasmerPackageInventory)}
   '';
   # Non-shipped library packages use the same tests/ convention as shipped CLIs but
   # have no webc to hang .tests off, so the group attaches to the package itself.
@@ -170,5 +189,5 @@
     );
 in {
   preferredProfilePackages = preferredProfilePackagesWithWebc;
-  inherit wasmerPackages allWasmerPackages testLib libraryTestPkgs;
+  inherit wasmerPackages wasmerPackageInventory allWasmerPackages testLib libraryTestPkgs;
 }

--- a/tools/wasinix/src/ci/compare.rs
+++ b/tools/wasinix/src/ci/compare.rs
@@ -376,9 +376,16 @@ fn eval_diff(coverage: &Coverage, base_map: &EvalMap, head_map: &EvalMap) -> Eva
 fn build_diff(
     coverage: &Coverage,
     eval: &EvalDiff,
+    head_map: &EvalMap,
     base_status: &StatusMap,
     head_status: &StatusMap,
 ) -> BuildDiff {
+    let head_aliases: BTreeSet<&str> = coverage
+        .head
+        .iter()
+        .filter_map(|job| head_map.info.get(job.as_str()))
+        .flat_map(|info| info.aliases.iter().map(String::as_str))
+        .collect();
     let transitioned = |from: JobStatus, to: JobStatus| -> Vec<JobAddr> {
         coverage
             .both
@@ -401,7 +408,10 @@ fn build_diff(
         dropped_successes: eval
             .removed
             .iter()
-            .filter(|job| base_status.get(job.as_str()) == Some(&JobStatus::Success))
+            .filter(|job| {
+                !head_aliases.contains(job.as_str())
+                    && base_status.get(job.as_str()) == Some(&JobStatus::Success)
+            })
             .cloned()
             .collect(),
         fixes: transitioned(JobStatus::Failure, JobStatus::Success),
@@ -448,7 +458,9 @@ pub fn compare_loaded(
     let coverage = coverage(base_case, base_map, head_case, head_map)?;
     let eval = eval_diff(&coverage, base_map, head_map);
     let builds = statuses
-        .map(|(base_status, head_status)| build_diff(&coverage, &eval, base_status, head_status));
+        .map(|(base_status, head_status)| {
+            build_diff(&coverage, &eval, head_map, base_status, head_status)
+        });
     Ok((eval, builds))
 }
 

--- a/tools/wasinix/src/ci/evalmap.rs
+++ b/tools/wasinix/src/ci/evalmap.rs
@@ -46,6 +46,9 @@ pub struct JobInfo {
     pub rel: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+    /// Previous or alternate job addresses that this job preserves.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     /// Capabilities a CI request must enable before scheduling this job.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,

--- a/tools/wasinix/src/registries/python.rs
+++ b/tools/wasinix/src/registries/python.rs
@@ -375,9 +375,12 @@ pub struct PlanDiff {
 
 /// attr is the wasmerPackages key (jq-1.6.0 for a history entry); owner and
 /// name are the identity it publishes under (wasmer/jq).
-const WEBC_DRVS: &str = "ws: builtins.mapAttrs (_: p: \
-    {drv = p.pkg.drvPath; owner = p.pkg.id.owner; name = p.pkg.id.name; \
-    version = p.pkg.id.baseVersion;}) ws";
+fn webc_drvs_apply() -> String {
+    crate::support::nix::canonical_webcs_apply(
+        "_: p: { drv = p.pkg.drvPath; owner = p.pkg.id.owner; \
+         name = p.pkg.id.name; version = p.pkg.id.baseVersion; }",
+    )
+}
 
 fn dists(flake: &Flake<'_>) -> Result<BTreeMap<String, Value>> {
     // distsJson is a JSON string, not a structure: it is written for
@@ -460,8 +463,9 @@ pub fn plan_diff(base_dir: &str) -> Result<PlanDiff> {
         .map(|(_, dist)| dist.clone())
         .collect();
 
-    let head_webcs = eval(&head, "wasmerPackages", Some(WEBC_DRVS))?;
-    let base_webcs = eval(&base, "wasmerPackages", Some(WEBC_DRVS))?;
+    let webc_apply = webc_drvs_apply();
+    let head_webcs = eval(&head, "wasmerPackages", Some(&webc_apply))?;
+    let base_webcs = eval(&base, "wasmerPackages", Some(&webc_apply))?;
     let webcs = head_webcs
         .as_object()
         .into_iter()

--- a/tools/wasinix/src/registries/wasmer.rs
+++ b/tools/wasinix/src/registries/wasmer.rs
@@ -65,20 +65,31 @@ fn run(cmd: &mut Command) -> Result<()> {
         .map_err(|error| Error::Request(error.to_string()))
 }
 
-/// The shipped webc names, each answering to its overlay attr as well.
+/// Canonical shipped webc names with every accepted alias.
 fn webc_domain() -> Result<Domain> {
+    let apply = crate::support::nix::canonical_webcs_apply(
+        "_: p: { overlay = p.overlayName; aliases = p.passthru.wasmer.aliases or []; }",
+    );
     let named = crate::support::nix::eval(
         &Flake::default(),
         "wasmerPackages",
-        Some("ws: builtins.mapAttrs (_: p: p.overlayName) ws"),
+        Some(&apply),
     )?;
     let mut domain = Domain::new(".#wasmerPackages");
-    for (webc, overlay) in named.as_object().into_iter().flatten() {
+    for (webc, info) in named.as_object().into_iter().flatten() {
+        let mut aliases = vec![info["overlay"].as_str().unwrap_or_default().to_string()];
+        aliases.extend(
+            info["aliases"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|alias| alias.as_str().map(str::to_string)),
+        );
         domain.add_path(
             vec!["wasmerPackages".into(), webc.clone()],
             webc,
             None,
-            vec![overlay.as_str().unwrap_or_default().to_string()],
+            aliases,
         );
     }
     Ok(domain)
@@ -866,11 +877,9 @@ pub fn materialize(options: ServeOptions) -> Result<PathBuf> {
     if !options.packages.is_empty() || build_all {
         // One eval answers both what exists and which packages carry a
         // dependency tree (depTree is null for the leaf packages).
-        let deps = crate::support::nix::eval(
-            &Flake::default(),
-            "wasmerPackages",
-            Some("ws: builtins.mapAttrs (_: p: p.pkg.depTree != null) ws"),
-        )?;
+        let apply = crate::support::nix::canonical_webcs_apply("_: p: p.pkg.depTree != null");
+        let deps =
+            crate::support::nix::eval(&Flake::default(), "wasmerPackages", Some(&apply))?;
         let names: Vec<String> = if build_all {
             deps.as_object()
                 .into_iter()

--- a/tools/wasinix/src/support/nix.rs
+++ b/tools/wasinix/src/support/nix.rs
@@ -20,9 +20,10 @@ pub fn canonical_webcs_apply(map: &str) -> String {
     // Revisions from before alias support have no packageKey and contain only
     // canonical entries, which keeps cross-revision comparisons evaluable.
     format!(
-        "ws: builtins.mapAttrs ({map}) \
-         (builtins.filterAttrs (name: p: !(p.passthru.wasmer ? packageKey) \
-         || name == p.passthru.wasmer.packageKey) ws)"
+        "ws: builtins.mapAttrs ({map}) (builtins.listToAttrs (builtins.map \
+         (name: {{ inherit name; value = ws.${{name}}; }}) (builtins.filter \
+         (name: let p = ws.${{name}}; in !(p.passthru.wasmer ? packageKey) \
+         || name == p.passthru.wasmer.packageKey) (builtins.attrNames ws))))"
     )
 }
 
@@ -355,4 +356,32 @@ pub fn eval_installable(installable: &str, apply: Option<&str>) -> Result<Value>
 /// Evaluate `legacyPackages.<system>.<attr>`, optionally through `--apply`.
 pub fn eval(flake: &Flake<'_>, attr: &str, apply: Option<&str>) -> Result<Value> {
     eval_installable(&format!("{}#legacyPackages.{SYSTEM}.{attr}", flake.0), apply)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_webcs_apply, Invocation};
+
+    #[test]
+    fn canonical_webc_filter_runs_in_nix() {
+        let apply = canonical_webcs_apply("name: _: name");
+        let expression = [
+            "let ws = { \
+             canonical.passthru.wasmer.packageKey = \"canonical\"; \
+             alias.passthru.wasmer.packageKey = \"canonical\"; \
+             legacy.passthru.wasmer = {}; \
+             }; in (",
+            &apply,
+            ") ws",
+        ]
+        .concat();
+        let value = Invocation::expr("eval", expression)
+            .json()
+            .run_json("canonical webc filter")
+            .unwrap();
+        let entries = value.as_object().unwrap();
+        assert_eq!(entries["canonical"], "canonical");
+        assert_eq!(entries["legacy"], "legacy");
+        assert!(!entries.contains_key("alias"));
+    }
 }

--- a/tools/wasinix/src/support/nix.rs
+++ b/tools/wasinix/src/support/nix.rs
@@ -16,6 +16,16 @@ use crate::support::process::CommandStatus;
 
 pub const SYSTEM: &str = "x86_64-linux";
 
+pub fn canonical_webcs_apply(map: &str) -> String {
+    // Revisions from before alias support have no packageKey and contain only
+    // canonical entries, which keeps cross-revision comparisons evaluable.
+    format!(
+        "ws: builtins.mapAttrs ({map}) \
+         (builtins.filterAttrs (name: p: !(p.passthru.wasmer ? packageKey) \
+         || name == p.passthru.wasmer.packageKey) ws)"
+    )
+}
+
 /// The shared binary cache, spelled once: rotating the key or moving the
 /// bucket is an edit here and nowhere else. The workflows read the same
 /// values through the nix-config emitter.

--- a/tools/wasinix/src/support/nix.rs
+++ b/tools/wasinix/src/support/nix.rs
@@ -376,6 +376,8 @@ mod tests {
         ]
         .concat();
         let value = Invocation::expr("eval", expression)
+            .option("experimental-features", "nix-command")
+            .args(["--store", "dummy://"])
             .json()
             .run_json("canonical webc filter")
             .unwrap();

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -838,6 +838,61 @@ mod compare {
     }
 
     #[test]
+    fn an_alias_preserves_a_renamed_job_without_hiding_a_failed_replacement() {
+        let base = map(&[("wasmerPackages.python313", "/nix/store/old.drv")]);
+        let mut head = map(&[(
+            "wasmerPackages.python-3.13.15",
+            "/nix/store/new.drv",
+        )]);
+        head.info.insert(
+            JobAddr("wasmerPackages.python-3.13.15".into()),
+            JobInfo {
+                aliases: vec!["wasmerPackages.python313".into()],
+                ..Default::default()
+            },
+        );
+        let base_case = case(&["wasmerPackages.python313"]);
+        let head_case = case(&["wasmerPackages.python-3.13.15"]);
+        let base_status = status(&[("wasmerPackages.python313", JobStatus::Success)]);
+
+        let (eval, builds) = compare_cases(
+            &base_case,
+            &base,
+            &base_status,
+            &head_case,
+            &head,
+            &status(&[(
+                "wasmerPackages.python-3.13.15",
+                JobStatus::Success,
+            )]),
+        )
+        .unwrap();
+        assert_eq!(
+            eval.added,
+            addrs(&["wasmerPackages.python-3.13.15"])
+        );
+        assert_eq!(eval.removed, addrs(&["wasmerPackages.python313"]));
+        assert!(builds.dropped_successes.is_empty());
+
+        let (_, builds) = compare_cases(
+            &base_case,
+            &base,
+            &base_status,
+            &head_case,
+            &head,
+            &status(&[(
+                "wasmerPackages.python-3.13.15",
+                JobStatus::Failure,
+            )]),
+        )
+        .unwrap();
+        assert_eq!(
+            builds.new_failures,
+            addrs(&["wasmerPackages.python-3.13.15"])
+        );
+    }
+
+    #[test]
     fn a_non_signal_derivation_is_not_reported_as_rebuilt() {
         let mut head = map(&[("job", "/nix/store/moved.drv")]);
         head.info.insert(

--- a/tools/wasinix/src/update/history.rs
+++ b/tools/wasinix/src/update/history.rs
@@ -136,13 +136,15 @@ fn wheel_path(attr: &str) -> Result<String> {
 /// overlay attr (gitMinimal) while the package evaluates by webc name (git), so
 /// either resolves.
 fn cli_map() -> Result<BTreeMap<String, (String, String)>> {
+    let apply = crate::support::nix::canonical_webcs_apply(
+        "webc: p: { overlay = p.overlayName; \
+         aliases = p.passthru.wasmer.aliases or []; \
+         history = p.passthru.wasmer.history or false; }",
+    );
     let packages = eval(
         &Flake::default(),
         "wasmerPackages",
-        Some(
-            "ws: builtins.mapAttrs (webc: p: { overlay = p.overlayName; \
-             history = p.passthru.wasmer.history or false; }) ws",
-        ),
+        Some(&apply),
     )?;
     let mut map = BTreeMap::new();
     for (webc, info) in packages.as_object().into_iter().flatten() {
@@ -152,7 +154,12 @@ fn cli_map() -> Result<BTreeMap<String, (String, String)>> {
         let overlay = info["overlay"].as_str().unwrap_or_default().to_string();
         let entry = (overlay.clone(), webc.clone());
         map.insert(normalize(&overlay), entry.clone());
-        map.insert(normalize(webc), entry);
+        map.insert(normalize(webc), entry.clone());
+        for alias in info["aliases"].as_array().into_iter().flatten() {
+            if let Some(alias) = alias.as_str() {
+                map.insert(normalize(alias), entry.clone());
+            }
+        }
     }
     Ok(map)
 }

--- a/tools/wasinix/src/update/retention.rs
+++ b/tools/wasinix/src/update/retention.rs
@@ -76,10 +76,14 @@ pub(crate) fn retention_add_spec(served: &Served) -> String {
 const WHEEL_APPLY: &str = "ws: builtins.mapAttrs (_: s: builtins.mapAttrs (name: w: \
     { version = w.version; history_spec = \"pythonWheels.${name}\"; \
     retention = w.passthru.wasix.retention or null; }) s) ws";
-const CLI_APPLY: &str = "ws: builtins.mapAttrs (name: p: { overlay = p.overlayName; \
-    history_spec = \"wasmerPackages.${name}\"; \
-    history = p.passthru.wasmer.history or false; version = p.version; \
-    retention = p.passthru.wasix.retention or null; }) ws";
+fn cli_apply() -> String {
+    crate::support::nix::canonical_webcs_apply(
+        "name: p: { overlay = p.overlayName; \
+         history_spec = \"wasmerPackages.${name}\"; \
+         history = p.passthru.wasmer.history or false; version = p.version; \
+         retention = p.passthru.wasix.retention or null; }",
+    )
+}
 
 /// Current served versions, excluding the history entries themselves.
 pub fn current_versions(repo: &Path) -> Result<Versions> {
@@ -119,7 +123,8 @@ pub fn current_versions(repo: &Path) -> Result<Versions> {
         }
     }
 
-    let clis = eval(&Flake::default(), "wasmerPackages", Some(CLI_APPLY))?;
+    let cli_apply = cli_apply();
+    let clis = eval(&Flake::default(), "wasmerPackages", Some(&cli_apply))?;
     for (_, info) in clis.as_object().into_iter().flatten() {
         if info["history"].as_bool().unwrap_or(false) {
             continue;


### PR DESCRIPTION
## Context

Rename to the current active name on the wasmer registry.

## Impact

Since this changes the webc, may cause mass rebuild of python tests.

## Behavior checked

n/a
