### PR TITLE
hydra-core: init

### DIFF
--- a/pkgs/overlay/python-packages/hydra-core.nix
+++ b/pkgs/overlay/python-packages/hydra-core.nix
@@ -1,0 +1,9 @@
+# The grammar parser is regenerated from antlr4's jar, whose path nixpkgs
+# substitutes into a patch. Evaluating the wasm antlr4 fails ("Unsupported
+# platform: wasip1"), and the jar runs on the build platform anyway.
+{
+  pyprev,
+  final,
+  ...
+}:
+pyprev.hydra-core.override {antlr4 = final.buildPackages.antlr4;}

--- a/pkgs/overlay/python-packages/omegaconf.nix
+++ b/pkgs/overlay/python-packages/omegaconf.nix
@@ -1,0 +1,9 @@
+# The grammar parser is regenerated from antlr4's jar, whose path nixpkgs
+# substitutes into a patch. Evaluating the wasm antlr4 fails ("Unsupported
+# platform: wasip1"), and the jar runs on the build platform anyway.
+{
+  pyprev,
+  final,
+  ...
+}:
+pyprev.omegaconf.override {antlr4 = final.buildPackages.antlr4;}

--- a/pkgs/overlay/python-packages/wheels.nix
+++ b/pkgs/overlay/python-packages/wheels.nix
@@ -167,6 +167,7 @@
   {attr = "pytest-asyncio_0";}
   {attr = "rsa";}
   {attr = "textual";}
+  {attr = "hydra-core";}
 
   # ── C extensions with no external C library ────────────────────────────────────
   {attr = "cffi";} # overlay/python-packages/cffi.nix (libffi ffi_closure_alloc)


### PR DESCRIPTION
## Context

[hydra-core](https://github.com/facebookresearch/hydra) 1.3.4, the config
framework, and its dependency omegaconf. Both are pure python; the wheels ride
the usual `wheels.nix` entry.

Both regenerate their ANTLR grammar parser during the build, and nixpkgs
substitutes the antlr4 jar's store path into a patch to do it. That forces the
host-set antlr4 to evaluate, which fails with `Unsupported platform: wasip1`
(its jre has no wasm build). The jar is platform-independent and runs on the
build host, so both packages take antlr4 from `buildPackages`.

## Impact

omegaconf reaches the wheel index as hydra-core's dependency. Nothing shipped
depended on it before: with the old argument it could not have evaluated for
wasm at all.

## Behavior checked

Not built here. The EC2 builder was saturated by another run (load ~290 on 32
cores) and refused the job, so this PR's CI is the first build. Evaluation of
both interpreters' wheels resolves.

Coverage is the standard wheel guard set on py313 and py314: `import hydra,
hydra.version` under wasmer against a store-less site directory, plus the
self-contained, deps, and dynamic checks.
