### PR TITLE
python-packages: make h2 and soundfile installable from the index

### DIFF
--- a/pkgs/overlay/python-packages/soundfile.nix
+++ b/pkgs/overlay/python-packages/soundfile.nix
@@ -10,7 +10,9 @@
   ...
 }:
 helpers.libTweaks {
-  # setup.py derives the bundled libname from these; keep the runtime name below in step
+  # setup.py derives the bundled libname from these; keep the runtime name below in step.
+  # Only `linux` packages _soundfile_data at all, and it also picks the wheel's
+  # platform tag, which the postPatch below corrects.
   env = {
     PYSOUNDFILE_PLATFORM = "linux";
     PYSOUNDFILE_ARCHITECTURE = "wasm32";
@@ -23,6 +25,9 @@ helpers.libTweaks {
     substituteInPlace soundfile.py \
       --replace-fail "raise OSError('no packaged library for this platform')" \
                      "_packaged_libname = 'libsndfile_wasm32.so'"
+    substituteInPlace setup.py \
+      --replace-fail "oses = 'manylinux_2_28_{}'.format(pep600_architecture)" \
+                     "oses = 'wasix_wasm32'"
   '';
 }
 pyprev.soundfile

--- a/pkgs/overlay/python-packages/wheels.nix
+++ b/pkgs/overlay/python-packages/wheels.nix
@@ -137,6 +137,9 @@
   {attr = "h11";}
   {attr = "httpcore";}
   {attr = "httpx";}
+  # httpx[http2]: an extra the closure does not follow, so serving httpx alone
+  # leaves anything asking for http2 unresolvable
+  {attr = "h2";}
   {attr = "anyio";}
   {attr = "starlette";}
   {attr = "fastapi";}


### PR DESCRIPTION
## Context

Two projects the index serves could not be installed from it. Both were found by
the resolve sweep in #156, which asks pip to resolve every served project, and
neither is visible to a check that only builds and imports a wheel.

`httpx[http2]` needs `h2`, and the served closure is the runtime one, which does
not follow extras. Nothing depending on that extra could resolve at all:
`langflow`, `langflow-base`, `langflow-sdk` and `lfx` all do. Whether this was
one instance of a wider hole was checked rather than assumed: served projects
request 7 extras between them, and this is the only one whose requirements the
index does not carry, so one worklist entry closes it.

`soundfile` shipped as `manylinux_2_28_wasm32`, a tag no wasix resolver matches.
Its `setup.py` reads `PYSOUNDFILE_PLATFORM` both to choose the bundled library
name and to spell the wheel tag, and only the `linux` branch packages
`_soundfile_data` at all, so the value has to stay while the tag it implies does
not. `--plat-name` cannot correct it either, as the `bdist_wheel` subclass
overrides `get_tag`, so the patch targets that one line.

## Impact

`h2` is new to the index, pure, and arrives with `hpack` and `hyperframe` in its
closure. `soundfile`'s wheel changes filename rather than contents, from
`soundfile-0.13.1+wasix.1-py2.py3-none-manylinux_2_28_wasm32.whl` to
`...-py2.py3-none-wasix_wasm32.whl`. The old name was never installable, so
nothing can be pinning it, and no rel moves.

## Behavior checked

All six projects that failed the sweep resolve from a registry built with these
two changes: `soundfile`, `langflow`, `langflow-base`, `langflow-sdk`, `lfx` and
`litellm`, each with `pip --platform wasix_wasm32` on 3.13.

The rebuilt `soundfile` wheel still carries `_soundfile_data/libsndfile_wasm32.so`
at 2.8 MB, so correcting the tag did not disturb the bundling the `linux` branch
is there for.

`litellm` was never broken; it failed the sweep's own over-strict rule, fixed
separately in #156.
