### PR TITLE
civetweb: init

### DIFF
--- a/pkgs/overlay/packages/civetweb.nix
+++ b/pkgs/overlay/packages/civetweb.nix
@@ -1,0 +1,18 @@
+# CGI runs its interpreter through fork, which wasix does not implement outside
+# the off profile, and loading the SSL library through dlopen pulls <dlfcn.h>,
+# which the non-PIC EH sysroots do not ship. Linking openssl replaces the
+# dlopen; prometheus-cpp's metrics exposer serves no CGI.
+{
+  prev,
+  final,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  buildInputs = [final.openssl];
+  cmakeFlags = [
+    "-DCIVETWEB_DISABLE_CGI=ON"
+    "-DCIVETWEB_ENABLE_SSL_DYNAMIC_LOADING=OFF"
+  ];
+}
+prev.civetweb

--- a/pkgs/overlay/packages/civetweb.nix
+++ b/pkgs/overlay/packages/civetweb.nix
@@ -10,9 +10,14 @@
 }:
 helpers.libTweaks {
   buildInputs = [final.openssl];
+  # CivetServer.cpp throws, so the C++ wrapper needs an EH profile.
+  passthru.wasix.supportedProfiles = helpers.profiles.withEh;
   cmakeFlags = [
     "-DCIVETWEB_DISABLE_CGI=ON"
     "-DCIVETWEB_ENABLE_SSL_DYNAMIC_LOADING=OFF"
+    # LTO leaves bitcode in the archive instead of wasm objects, and the abi
+    # check reads the objects' target features.
+    "-DCIVETWEB_CXX_ENABLE_LTO=OFF"
   ];
 }
 prev.civetweb


### PR DESCRIPTION
## Context

CGI spawns its interpreter through fork, and dynamic SSL loading needs
<dlfcn.h>; neither exists in the profiles prometheus-cpp builds in. Both are
civetweb options rather than code to patch. Linking openssl keeps TLS rather
than dropping it with the loader.
