### PR TITLE
python-registry: publish a native-only view of the index

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -126,6 +126,22 @@ A new `wheels.nix` entry lands in the registry automatically. Its test suite
 integrity and pip-installs representative packages, resolving their deps from
 the index too, then imports them under wasmer.
 
+`native/simple/` is the same index over the projects that ship a platform-tagged
+wheel, which are the ones nothing else can supply. Point a resolver at that as
+its priority index and PyPI as the primary one:
+
+```sh
+uv pip compile pyproject.toml --universal \
+  --extra-index-url <index>/native/simple --index-url https://pypi.org/simple
+pip install -r requirements.txt --platform wasix_wasm32 --only-binary :all: --target site
+```
+
+uv binds a package to the first index that carries it, so listing the pure
+dependencies too would pin them to our versions and reject whatever version the
+consuming project asks for. The native view carries no wheels of its own; its
+pages link to the copies under `simple/`, which keeps serving the full closure
+for use as a standalone index.
+
 ## Rels
 
 Every wheel is published as `<version>+wasix.<rel>`, a PEP 440 local version.

--- a/pkgs/python-registry/check-integrity.py
+++ b/pkgs/python-registry/check-integrity.py
@@ -16,6 +16,7 @@ from urllib.parse import unquote
 # (plus a size span), so the filename comes from the href, not the link text.
 ANCHOR = re.compile(r'<a href="([^"#]+)#sha256=([0-9a-f]{64})"([^>]*)>')
 CORE_METADATA = re.compile(r'data-core-metadata="sha256=([0-9a-f]{64})"')
+PROJECT_LINK = re.compile(r'<a href="([^"]+)/">')
 
 
 def sha256_of(path: Path) -> str:
@@ -24,6 +25,48 @@ def sha256_of(path: Path) -> str:
 
 def fail(msg: str) -> None:
     sys.exit(f"registry integrity: {msg}")
+
+
+def anchors(page: str) -> dict[str, str]:
+    return {unquote(href): digest for href, digest, _ in ANCHOR.findall(page)}
+
+
+def check_native_view(root: Path, wheels: set[tuple[str, str]]) -> None:
+    """The native view must list exactly the projects with a platform-tagged
+    wheel, and reach the copies simple/ holds rather than carrying its own.
+
+    Being the priority index is what binds a resolver to our versions, so a pure
+    project listed here would block PyPI from supplying the version a consuming
+    project asks for."""
+    simple = root / "simple"
+    native_dir = root / "native" / "simple"
+    expected = {
+        project
+        for project, fname in wheels
+        if fname[: -len(".whl")].rsplit("-", 1)[-1] != "any"
+    }
+    listed = set(PROJECT_LINK.findall((native_dir / "index.html").read_text()))
+    on_disk = {d.name for d in native_dir.iterdir() if d.is_dir()}
+    if listed != on_disk:
+        fail(f"native root index vs project dirs differ: {sorted(listed ^ on_disk)}")
+    if listed != expected:
+        fail(
+            "native view lists the wrong projects; a pure one here blocks PyPI: "
+            f"{sorted(listed ^ expected)}"
+        )
+
+    for project in sorted(listed):
+        page = (native_dir / project / "index.html").read_text()
+        # the native anchors are relative to simple/, so compare by filename
+        anchored = {href.rsplit("/", 1)[-1]: d for href, d in anchors(page).items()}
+        served = anchors((simple / project / "index.html").read_text())
+        if anchored != served:
+            fail(
+                f"native/{project}: files differ from simple/: {sorted(set(anchored) ^ set(served))}"
+            )
+        for href in re.findall(r'<a href="([^"#]+)#sha256=', page):
+            if not (native_dir / project / unquote(href)).resolve().is_file():
+                fail(f"native/{project}: {href} does not resolve into simple/")
 
 
 def main() -> None:
@@ -36,6 +79,7 @@ def main() -> None:
         fail(f"root index vs project dirs differ: {sorted(listed ^ on_disk)}")
 
     total = 0
+    served: set[tuple[str, str]] = set()
     for pdir in sorted(simple.iterdir()):
         if not pdir.is_dir():
             continue
@@ -57,6 +101,7 @@ def main() -> None:
             if not metadata.is_file() or sha256_of(metadata) != core.group(1):
                 fail(f"{pdir.name}: metadata sidecar missing or mismatched for {fname}")
             anchored.add(fname)
+            served.add((pdir.name, fname))
             total += 1
         wheels_on_disk = {f.name for f in pdir.glob("*.whl")}
         if anchored != wheels_on_disk:
@@ -66,6 +111,7 @@ def main() -> None:
 
     if total == 0:
         fail("no wheels indexed at all")
+    check_native_view(Path(sys.argv[1]), served)
     print(f"registry OK: {len(on_disk)} projects, {total} wheels")
 
 

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -12,6 +12,7 @@ Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
   <out>/simple/<project>/index.html     file list with #sha256= anchors
   <out>/simple/<project>/<wheel>        the wheel itself (relative hrefs)
   <out>/simple/<project>/<wheel>.metadata   its core metadata, for resolvers
+  <out>/native/simple/...               the same index over native projects only
 """
 
 import argparse
@@ -162,6 +163,11 @@ def _wheel_attrs(md_digest: str, rp: str | None) -> str:
 def _parse_wheel(fname: str) -> tuple[str, str]:
     parts = fname[: -len(".whl")].split("-")
     return parts[1], parts[-3]  # version, python tag
+
+
+def is_native(fname: str) -> bool:
+    """Whether the wheel is built for a platform rather than being pure python."""
+    return fname[: -len(".whl")].rsplit("-", 1)[-1] != "any"
 
 
 def _ver_key(ver: str) -> tuple[int, ...]:
@@ -401,8 +407,11 @@ def page(title: str, anchors: list[str]) -> str:
 _REPO = "https://github.com/wasix-org/wasinix"
 
 
-def project_page(project: str, files: list[tuple]) -> str:
+def project_page(project: str, files: list[tuple], href_prefix: str = "") -> str:
     """Human-friendly file list for one project, grouped by version.
+
+    href_prefix points the anchors at another directory, so the native view
+    lists the wheels simple/ already holds rather than copying them.
 
     files: (filename, sha256, metadata_sha256, requires_python, wasinix_rev,
     attr, size, published, source). Resolvers read only the <a> href and data-*
@@ -420,7 +429,7 @@ def project_page(project: str, files: list[tuple]) -> str:
     rels = []
     for ver in sorted(by_ver, key=_ver_key, reverse=True):
         chips = "\n".join(
-            f'        <li><a href="{quote(fname)}#sha256={digest}"'
+            f'        <li><a href="{href_prefix}{quote(fname)}#sha256={digest}"'
             f'{_wheel_attrs(md_digest, rp)} title="{html.escape(fname, quote=True)}">'
             f"{html.escape(_py_label(py))}{_sz(size)}</a></li>"
             for fname, digest, md_digest, rp, py, size in sorted(by_ver[ver])
@@ -530,6 +539,8 @@ def main() -> None:
             f" `publishOnce` in wheels.nix:\n{listed}"
         )
 
+    # project -> the rows its page was built from, reused by the native view
+    pages: dict[str, list[tuple]] = {}
     for project, wheels in sorted(projects.items()):
         pdir = out / "simple" / project
         pdir.mkdir(parents=True)
@@ -557,15 +568,37 @@ def main() -> None:
                 )
             )
         (pdir / "index.html").write_text(project_page(project, files))
+        pages[project] = files
 
     root = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(projects)]
     (out / "simple" / "index.html").write_text(page("Simple index", root))
+
+    # A second PEP 503 view over the projects we are the only possible source
+    # for. Pointed at as the priority index, it binds a resolver to our versions
+    # for exactly those, leaving every pure dependency to PyPI at whatever
+    # version the consuming project asks for (docs/registry.md).
+    native = {
+        project: files
+        for project, files in pages.items()
+        if any(is_native(fname) for fname, *_ in files)
+    }
+    for project, files in sorted(native.items()):
+        ndir = out / "native" / "simple" / project
+        ndir.mkdir(parents=True)
+        (ndir / "index.html").write_text(
+            project_page(
+                project, files, href_prefix=f"../../../simple/{quote(project)}/"
+            )
+        )
+    nroot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(native)]
+    (out / "native" / "simple" / "index.html").write_text(page("Simple index", nroot))
     (out / "index.html").write_text(landing(projects))
     (out / "provenance.json").write_text(
         json.dumps(provenance, indent=2, sort_keys=True) + "\n"
     )
     print(
         f"indexed {sum(map(len, projects.values()))} wheels across {len(projects)} projects"
+        f" ({len(native)} of them native)"
     )
 
 


### PR DESCRIPTION
## Context

A resolver has to reach this index to get a wasix wheel at all, so it is the
priority index, and uv binds a package to the first index that carries it. The
index serves the full runtime closure, 429 projects, of which 201 ship a
platform-tagged wheel. The other 228 are pure python we carry only because
something we build depends on them, and pinning those to our versions rejects
whatever version the consuming project asked for.

That is not hypothetical. Resolving `wasmerio/herman` against the index fails on
three constraints, all pure: it pins `pydantic==2.12.4` where we serve 2.10.6 and
2.13.4, wants `boto3~=1.34.0` where we are at 1.42.31, and wants `openai>=2.54.0`
where we are at 2.45.0. PyPI has all three, and all three would run here
unchanged.

Reaching for `--index-strategy unsafe-best-match` to escape that only moves the
failure: uv then takes the newest version across both indexes, which for a native
package can be one we cannot build. Today that is `cffi 2.1.1`, where nixpkgs has
2.1.0, and the install fails instead of the resolve. Since our versions come from
nixpkgs, we will always trail PyPI on some native package, so that is a permanent
condition rather than a gap to close.

`native/simple/` is the same PEP 503 index over the 201 projects nothing else can
supply. As the priority index it binds a resolver to our versions for exactly
those and leaves the rest to PyPI, which removes both failures at once.

## Impact

A new output; nothing existing changes. `simple/` keeps serving the full closure,
so the standalone `--index-url <index>/simple` path and the e2e test are
untouched.

The view carries no wheels of its own: its pages link to the copies under
`simple/`, so it adds 3.2M of HTML rather than a second 1.2G of wheels. The
integrity walk enforces that it lists exactly the native projects, that each
project's file set matches `simple/`, and that every href resolves.

## Behavior checked

The emitted view carries 201 of 429 projects and no wheel copies.

Against it, `uv pip compile --universal` then `pip install --platform
wasix_wasm32` resolves herman's dependency set: `boto3==1.34.162` and
`openai==2.54.0` come from PyPI at the project's own constraints, while `cffi`,
`cryptography`, `jiter`, `rpds-py` and `pydantic-core` come from here, 10 of 67
packages. The install places 136 entries including 18 extension modules, each a
`wasm32-wasi-threads` object beginning `\0asm`.

The failure the check exists for was exercised directly: adding pure `six` to the
view makes the integrity walk report `native view lists the wrong projects; a
pure one here blocks PyPI: ['six']`.

`soundfile` belongs to the view for a reason worth noting: its wheel is
platform-tagged rather than `any`, which a filename search for `wasix_wasm32`
would have missed.
