### PR TITLE
python-registry: give the published wheel its own derivation

### DIFF
--- a/pkgs/python-publish.nix
+++ b/pkgs/python-publish.nix
@@ -1,0 +1,73 @@
+# The publishable form of a built wheel, akin to a package's .webc: the same
+# artifact restated under its publication release (+wasix.N) and, where the
+# entry is built for fewer interpreters than the index serves, the
+# Requires-Python bound that says so.
+#
+# Shared because both sides need it: the wheel set exposes it as `.published`,
+# and the registry calls it for the closure members that have no worklist entry
+# of their own. A rel bump rewrites this cheap derivation, never the wheel.
+{
+  pkgs,
+  lib,
+}: let
+  rels = builtins.fromJSON (builtins.readFile ../rels.json);
+
+  interpreters = {
+    py313 = "3.13";
+    py314 = "3.14";
+  };
+
+  # A py3-none-any wheel carries no interpreter tag, so without this bound
+  # nothing stops a resolver on another interpreter from taking it and then
+  # failing on a dep only the built-for one has. `noarch` is the opposite mark
+  # (build once, serve everywhere), so it never bounds.
+  requiresPythonOf = variants:
+    if variants == null || lib.elem "noarch" variants
+    then null
+    else let
+      allowed =
+        lib.sort lib.versionOlder
+        (map (v: interpreters.${v}) (lib.intersectLists variants (lib.attrNames interpreters)));
+      served = lib.sort lib.versionOlder (lib.attrValues interpreters);
+      nextMinor = v: let
+        parts = lib.splitString "." v;
+      in "${lib.head parts}.${toString (lib.toInt (lib.elemAt parts 1) + 1)}";
+      contiguous =
+        lib.foldl' (acc: v: {
+          ok = acc.ok && (acc.want == null || acc.want == v);
+          want = nextMinor v;
+        }) {
+          ok = true;
+          want = null;
+        }
+        allowed;
+    in
+      if allowed == served
+      then null
+      else
+        lib.throwIf (!contiguous.ok)
+        "python-publish: variants ${toString variants} skip an interpreter, which no single Requires-Python bound can express"
+        ">=${lib.head allowed},<${nextMinor (lib.last allowed)}";
+in {
+  # `suffix` marks PR-preview wheels, whose longer local version sorts above the
+  # published one when the preview index is used as an extra index.
+  publishOf = {
+    drv,
+    # The wheel set passes this directly: it marks the entry before the passthru
+    # carrying it exists, so reading it back off `drv` would silently see none.
+    variants ? (drv.passthru.wasix.variants or null),
+    suffix ? null,
+  }: let
+    name = drv.pname or drv.name;
+    rel = (rels."pythonRegistry.wheels.${name}" or {}).${drv.version} or 1;
+    requiresPython = requiresPythonOf variants;
+  in
+    pkgs.runCommand "${name}-${drv.version}+wasix.${toString rel}-published" {
+      nativeBuildInputs = [pkgs.python3];
+    } ''
+      python3 ${./python-registry/publish-wheel.py} ${drv.dist} "$out" \
+        --rel ${toString rel} \
+        ${lib.optionalString (requiresPython != null) "--requires-python '${requiresPython}'"} \
+        ${lib.optionalString (suffix != null) "--version-suffix '${suffix}'"}
+    '';
+}

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -18,13 +18,11 @@
   pythonWebc,
   mkTestGroup,
 }: let
-  # Publication release numbers (PEP 440 local version +wasix.N), from the global rels.json at the
-  # repo root: keyed by attr path (pythonRegistry.wheels.<pname>) then upstream version, so an
-  # upstream bump resets to 1 by key miss. Shared across python versions (same upstream version),
-  # the cp tag keeps filenames distinct. Bump when republishing a changed build; published
-  # filenames are immutable, so publish.py retains the original artifact on name reuse.
+  # The wheels carry their own release (pkgs/python-publish.nix); this reads
+  # rels.json only to report keys no served version claims.
   rels = builtins.fromJSON (builtins.readFile ../../rels.json);
   relPrefix = "pythonRegistry.wheels.";
+  inherit (import ../python-publish.nix {inherit pkgs lib;}) publishOf;
 
   # Repo-relative "path:line" of the package definition, for the index's
   # publish-time source link. Only for positions in this repo: closure wheels
@@ -50,8 +48,8 @@
       name = drv.pname or drv.name;
       version = drv.version;
       relKey = "${relPrefix}${name}";
-      rel = (rels."${relPrefix}${name}" or {}).${version} or 1;
-      dist = "${drv.dist}";
+      # the publishable form, produced by the wheel's own derivation
+      published = "${drv.published or (publishOf {inherit drv;})}";
       # provenance nested by python version and upstream version, so pname collides neither
       # across py313/py314 nor with a served history version of itself:
       # `nix build github:wasix-org/wasinix/<rev>#${attr}` rebuilds it.

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -49,11 +49,12 @@
       version = drv.version;
       relKey = "${relPrefix}${name}";
       # the publishable form, produced by the wheel's own derivation
-      published = "${drv.published or (publishOf {inherit drv;})}";
+      publishedDrv = drv.published or (publishOf {inherit drv;});
+      published = "${publishedDrv}";
       # provenance nested by python version and upstream version, so pname collides neither
       # across py313/py314 nor with a served history version of itself:
       # `nix build github:wasix-org/wasinix/<rev>#${attr}` rebuilds it.
-      attr = ''pythonRegistry.wheels.${pv}.${name}."${version}"^dist'';
+      attr = ''pythonRegistry.published.${pv}.${name}."${version}"'';
       drvPath = builtins.unsafeDiscardStringContext drv.drvPath;
       source = sourceOf drv;
       inherit drv;
@@ -65,7 +66,18 @@
   perVersion = lib.mapAttrs servedOf pythonSets;
   wheelDists = lib.concatLists (lib.attrValues perVersion);
 
-  # Provenance build targets (pythonRegistry.wheels.py314.numpy."2.5.0").
+  # The published artifacts, addressable so the reproduce command on an index
+  # page names the bytes it describes (pythonRegistry.published.py314.numpy."2.5.0").
+  published =
+    lib.mapAttrs (
+      _: served:
+        lib.mapAttrs (_: ds: lib.listToAttrs (map (d: lib.nameValuePair d.version d.publishedDrv) ds))
+        (lib.groupBy (d: d.name) served)
+    )
+    perVersion;
+
+  # The source wheels behind them; the rel and changelog machinery reads these
+  # (flake.nix), so they stay the buildPythonPackage drvs.
   wheels =
     lib.mapAttrs (
       _: served:
@@ -109,7 +121,7 @@ in
       (o.passthru or {})
       // {
         tests = mkTestGroup "python-registry" tests;
-        inherit wheelVersions wheels;
+        inherit wheelVersions wheels published;
         wasix.updateNotes = lib.optional (staleRels != []) {
           message = "rels.json has stale keys (${lib.concatStringsSep ", " staleRels}); nix run .#update -- nixpkgs drops them";
           when = _: _: true;

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -1,11 +1,11 @@
 """Generate a static PEP 503 "simple" package index from built wheels.
 
 Called by default.nix as: make-index.py <dists.json> <out>, where dists.json is
-[{"name", "version", "rel", "dist" = store path with the .whl}, ...].
+[{"name", "version", "published" = store path with the published .whl}, ...].
 
-Every wheel is republished as <version>+wasix.<rel> (PEP 440 local version,
-the publication release: same upstream version, our Nth build of it), keeping
-filename, dist-info dir, METADATA and RECORD consistent.
+The wheels arrive already carrying their publication release and interpreter
+bound; each is produced by its own derivation (publish-wheel.py), so this only
+indexes what it is given.
 
 Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
   <out>/simple/index.html               project list
@@ -16,16 +16,11 @@ Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
 """
 
 import argparse
-import base64
-import csv
 import hashlib
 import html
-import io
 import json
 import re
-import shutil
 import sys
-import tempfile
 import zipfile
 from pathlib import Path
 from urllib.parse import quote
@@ -54,95 +49,6 @@ def requires_python(metadata: bytes) -> str | None:
         if key.strip().lower() == "requires-python":
             return value.strip()
     return None
-
-
-def record_hash(data: bytes) -> str:
-    # RECORD hash spelling (PEP 376/427): urlsafe base64, no padding
-    return "sha256=" + base64.urlsafe_b64encode(
-        hashlib.sha256(data).digest()
-    ).decode().rstrip("=")
-
-
-def bump_metadata_version(metadata: bytes, version: str, new_version: str) -> bytes:
-    lines = metadata.split(b"\n")
-    for i, line in enumerate(lines):
-        if not line.strip():
-            break  # end of headers, no Version seen
-        key, _, value = line.partition(b":")
-        if key.strip().lower() == b"version":
-            if value.strip().decode() != version:
-                sys.exit(
-                    f"METADATA Version {value.strip().decode()!r} != filename version {version!r}"
-                )
-            lines[i] = f"Version: {new_version}".encode()
-            return b"\n".join(lines)
-    sys.exit("METADATA has no Version header")
-
-
-def rewrite_wheel(
-    src: Path, dest_dir: Path, rel: int, suffix: str | None = None
-) -> Path:
-    """Copy the wheel with +wasix.<rel>[.<suffix>] appended to its version.
-
-    The suffix (pr123.abc1234) marks PR-preview wheels: a longer local version
-    with an equal prefix sorts higher, so pip prefers them over the published
-    wheel when the preview index is used via --extra-index-url.
-    """
-    name, version, rest = src.name.split("-", 2)
-    if "+" in version:
-        sys.exit(f"{src.name}: already carries a local version")
-    new_version = f"{version}+wasix.{rel}" + (f".{suffix}" if suffix else "")
-
-    with zipfile.ZipFile(src) as zin:
-        dist_infos = {
-            n.split("/", 1)[0]
-            for n in zin.namelist()
-            if re.match(r"[^/]+\.dist-info/", n)
-        }
-        if len(dist_infos) != 1:
-            sys.exit(
-                f"{src.name}: expected exactly one *.dist-info dir, found {sorted(dist_infos)}"
-            )
-        old_di = dist_infos.pop()
-        if not old_di.endswith(f"-{version}.dist-info"):
-            sys.exit(
-                f"{src.name}: dist-info dir {old_di!r} does not match filename version {version!r}"
-            )
-        new_di = (
-            old_di.removesuffix(f"-{version}.dist-info") + f"-{new_version}.dist-info"
-        )
-        rename = lambda n: (
-            new_di + n.removeprefix(old_di) if n.startswith(f"{old_di}/") else n
-        )
-
-        entries = [
-            (rename(i.filename), i, zin.read(i.filename)) for i in zin.infolist()
-        ]
-
-    files = {n: data for n, _, data in entries}
-    files[f"{new_di}/METADATA"] = bump_metadata_version(
-        files[f"{new_di}/METADATA"], version, new_version
-    )
-
-    # RECORD: renamed paths, plus the refreshed METADATA hash/size
-    rows = list(csv.reader(io.StringIO(files[f"{new_di}/RECORD"].decode())))
-    for row in rows:
-        row[0] = rename(row[0])
-        if row[0] == f"{new_di}/METADATA":
-            row[1] = record_hash(files[row[0]])
-            row[2] = str(len(files[row[0]]))
-    buf = io.StringIO(newline="")
-    csv.writer(buf, lineterminator="\n").writerows(rows)
-    files[f"{new_di}/RECORD"] = buf.getvalue().encode()
-
-    dest = dest_dir / f"{name}-{new_version}-{rest}"
-    with zipfile.ZipFile(dest, "w") as zout:
-        for newname, info, _ in entries:
-            zi = zipfile.ZipInfo(newname, date_time=info.date_time)
-            zi.compress_type = info.compress_type
-            zi.external_attr = info.external_attr
-            zout.writestr(zi, files[newname])
-    return dest
 
 
 def _wheel_attrs(md_digest: str, rp: str | None) -> str:
@@ -489,15 +395,11 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("dists", type=Path)
     ap.add_argument("out", type=Path)
-    ap.add_argument(
-        "--version-suffix",
-        help="extra local-version segments (pr123.abc1234) for PR-preview indexes",
-    )
     args = ap.parse_args()
     dists = json.loads(args.dists.read_text())
     out = args.out
 
-    # normalized project name -> {wheel filename -> rewritten path}
+    # normalized project name -> {published filename -> its path}
     projects: dict[str, dict[str, Path]] = {}
     # published filename -> {name, attr, drv_path}, folded into each wheel's
     # manifest by publish.py (with the wasinix rev added there).
@@ -505,23 +407,19 @@ def main() -> None:
     # Collected rather than fatal on the first, so one run names every entry that
     # needs `publishOnce` instead of one per rebuild.
     conflicts: list[tuple[str, str]] = []
-    tmp = Path(tempfile.mkdtemp(prefix="wasix-wheels-"))
-    for i, entry in enumerate(dists):
-        wheels = sorted(Path(entry["dist"]).glob("*.whl"))
+    for entry in dists:
+        wheels = sorted(Path(entry["published"]).glob("*.whl"))
         if not wheels:
-            sys.exit(f"no .whl in dist output of '{entry['name']}': {entry['dist']}")
-        entry_dir = tmp / str(i)
-        entry_dir.mkdir()
+            sys.exit(f"no .whl published for '{entry['name']}': {entry['published']}")
         for whl in wheels:
-            moved = rewrite_wheel(whl, entry_dir, entry["rel"], args.version_suffix)
-            project = normalize(moved.name.split("-", 1)[0])
-            prev = projects.setdefault(project, {}).setdefault(moved.name, moved)
-            if prev != moved and prev.read_bytes() != moved.read_bytes():
+            project = normalize(whl.name.split("-", 1)[0])
+            prev = projects.setdefault(project, {}).setdefault(whl.name, whl)
+            if prev != whl and prev.read_bytes() != whl.read_bytes():
                 # A py3-none-any tag asserts the artifact is interpreter
                 # independent, so keep the first and let differing build noise go.
-                if not moved.name.endswith("-py3-none-any.whl"):
-                    conflicts.append((moved.name, entry["attr"]))
-            provenance[moved.name] = {
+                if not whl.name.endswith("-py3-none-any.whl"):
+                    conflicts.append((whl.name, entry["attr"]))
+            provenance[whl.name] = {
                 "name": entry["name"],
                 "rel_key": entry["relKey"],
                 "version": entry["version"],
@@ -546,7 +444,7 @@ def main() -> None:
         pdir.mkdir(parents=True)
         files = []
         for fname, src in sorted(wheels.items()):
-            shutil.copy(src, pdir / fname)
+            (pdir / fname).write_bytes(src.read_bytes())
             metadata = wheel_metadata(src)
             (pdir / f"{fname}.metadata").write_bytes(metadata)
             md_digest = hashlib.sha256(metadata).hexdigest()
@@ -592,6 +490,7 @@ def main() -> None:
         )
     nroot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(native)]
     (out / "native" / "simple" / "index.html").write_text(page("Simple index", nroot))
+
     (out / "index.html").write_text(landing(projects))
     (out / "provenance.json").write_text(
         json.dumps(provenance, indent=2, sort_keys=True) + "\n"

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -414,11 +414,16 @@ def main() -> None:
         for whl in wheels:
             project = normalize(whl.name.split("-", 1)[0])
             prev = projects.setdefault(project, {}).setdefault(whl.name, whl)
-            if prev != whl and prev.read_bytes() != whl.read_bytes():
-                # A py3-none-any tag asserts the artifact is interpreter
-                # independent, so keep the first and let differing build noise go.
-                if not whl.name.endswith("-py3-none-any.whl"):
-                    conflicts.append((whl.name, entry["attr"]))
+            if prev is not whl:
+                if prev.read_bytes() != whl.read_bytes():
+                    # A py3-none-any tag asserts the artifact is interpreter
+                    # independent, so keep the first and let differing build
+                    # noise go.
+                    if not whl.name.endswith("-py3-none-any.whl"):
+                        conflicts.append((whl.name, entry["attr"]))
+                # `prev` is what the page serves, so its provenance is the one
+                # that reproduces these bytes.
+                continue
             provenance[whl.name] = {
                 "name": entry["name"],
                 "rel_key": entry["relKey"],

--- a/pkgs/python-registry/publish-wheel.py
+++ b/pkgs/python-registry/publish-wheel.py
@@ -1,0 +1,180 @@
+"""Restate a built wheel as the artifact the registry publishes.
+
+The build produces a wheel at its upstream version; publishing gives it the
+publication release (PEP 440 local version `+wasix.<rel>`) and, where the entry
+is built for fewer interpreters than the index serves, the Requires-Python bound
+that says so. Filename, dist-info dir, METADATA and RECORD are kept consistent.
+
+Run per wheel by its own derivation (pkgs/python-wheels.nix), so a rel bump
+rewrites this cheap output instead of rebuilding the wheel, and the published
+bytes have a store path of their own.
+
+Usage: publish-wheel.py <dist dir> <out dir> --rel N
+                        [--requires-python BOUND] [--version-suffix S]
+"""
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+
+def record_hash(data: bytes) -> str:
+    # RECORD hash spelling (PEP 376/427): urlsafe base64, no padding
+    return "sha256=" + base64.urlsafe_b64encode(
+        hashlib.sha256(data).digest()
+    ).decode().rstrip("=")
+
+
+def bump_metadata_version(metadata: bytes, version: str, new_version: str) -> bytes:
+    lines = metadata.split(b"\n")
+    for i, line in enumerate(lines):
+        if not line.strip():
+            break  # end of headers, no Version seen
+        key, _, value = line.partition(b":")
+        if key.strip().lower() == b"version":
+            if value.strip().decode() != version:
+                sys.exit(
+                    f"METADATA Version {value.strip().decode()!r} != filename version {version!r}"
+                )
+            lines[i] = f"Version: {new_version}".encode()
+            return b"\n".join(lines)
+    sys.exit("METADATA has no Version header")
+
+
+def tags_pin_interpreter(fname: str) -> bool:
+    """Whether the wheel's own compatibility tags admit one interpreter already.
+
+    An abi3 wheel loads on every later CPython and a pyN tag on any of them, so
+    only an exact cp/pp tag makes a Requires-Python bound redundant.
+    """
+    parts = fname[: -len(".whl")].split("-")
+    pytags, abi = parts[-3].split("."), parts[-2]
+    return abi != "abi3" and len(pytags) == 1 and pytags[0].startswith(("cp", "pp"))
+
+
+def set_requires_python(metadata: bytes, bound: str) -> bytes:
+    """Replace Requires-Python with the interpreters the wheel is served for.
+
+    A py3-none-any wheel carries no interpreter tag, so this bound is all that
+    keeps a resolver on another interpreter from selecting it. It supersedes the
+    upstream floor rather than intersecting it: the wheel exists because it
+    built on an interpreter named here, so this is the stronger constraint.
+    """
+    header = f"Requires-Python: {bound}".encode()
+    lines = metadata.split(b"\n")
+    for i, line in enumerate(lines):
+        if not line.strip():
+            lines.insert(i, header)  # end of headers, none present
+            return b"\n".join(lines)
+        key, _, _ = line.partition(b":")
+        if key.strip().lower() == b"requires-python":
+            lines[i] = header
+            return b"\n".join(lines)
+    sys.exit("METADATA has no header block")
+
+
+def rewrite_wheel(
+    src: Path,
+    dest_dir: Path,
+    rel: int,
+    suffix: str | None = None,
+    requires_python: str | None = None,
+) -> Path:
+    """Copy the wheel with +wasix.<rel>[.<suffix>] appended to its version.
+
+    The suffix (pr123.abc1234) marks PR-preview wheels: a longer local version
+    with an equal prefix sorts higher, so pip prefers them over the published
+    wheel when the preview index is used via --extra-index-url.
+    """
+    name, version, rest = src.name.split("-", 2)
+    if "+" in version:
+        sys.exit(f"{src.name}: already carries a local version")
+    new_version = f"{version}+wasix.{rel}" + (f".{suffix}" if suffix else "")
+
+    with zipfile.ZipFile(src) as zin:
+        dist_infos = {
+            n.split("/", 1)[0]
+            for n in zin.namelist()
+            if re.match(r"[^/]+\.dist-info/", n)
+        }
+        if len(dist_infos) != 1:
+            sys.exit(
+                f"{src.name}: expected exactly one *.dist-info dir, found {sorted(dist_infos)}"
+            )
+        old_di = dist_infos.pop()
+        if not old_di.endswith(f"-{version}.dist-info"):
+            sys.exit(
+                f"{src.name}: dist-info dir {old_di!r} does not match filename version {version!r}"
+            )
+        new_di = (
+            old_di.removesuffix(f"-{version}.dist-info") + f"-{new_version}.dist-info"
+        )
+        rename = lambda n: (
+            new_di + n.removeprefix(old_di) if n.startswith(f"{old_di}/") else n
+        )
+
+        entries = [
+            (rename(i.filename), i, zin.read(i.filename)) for i in zin.infolist()
+        ]
+
+    files = {n: data for n, _, data in entries}
+    files[f"{new_di}/METADATA"] = bump_metadata_version(
+        files[f"{new_di}/METADATA"], version, new_version
+    )
+    if requires_python and not tags_pin_interpreter(src.name):
+        files[f"{new_di}/METADATA"] = set_requires_python(
+            files[f"{new_di}/METADATA"], requires_python
+        )
+
+    # RECORD: renamed paths, plus the refreshed METADATA hash/size
+    rows = list(csv.reader(io.StringIO(files[f"{new_di}/RECORD"].decode())))
+    for row in rows:
+        row[0] = rename(row[0])
+        if row[0] == f"{new_di}/METADATA":
+            row[1] = record_hash(files[row[0]])
+            row[2] = str(len(files[row[0]]))
+    buf = io.StringIO(newline="")
+    csv.writer(buf, lineterminator="\n").writerows(rows)
+    files[f"{new_di}/RECORD"] = buf.getvalue().encode()
+
+    dest = dest_dir / f"{name}-{new_version}-{rest}"
+    with zipfile.ZipFile(dest, "w") as zout:
+        for newname, info, _ in entries:
+            zi = zipfile.ZipInfo(newname, date_time=info.date_time)
+            zi.compress_type = info.compress_type
+            zi.external_attr = info.external_attr
+            zout.writestr(zi, files[newname])
+    return dest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dist", type=Path)
+    ap.add_argument("out", type=Path)
+    ap.add_argument("--rel", type=int, required=True)
+    ap.add_argument("--requires-python")
+    ap.add_argument(
+        "--version-suffix",
+        help="extra local-version segments (pr123.abc1234) for PR-preview wheels",
+    )
+    args = ap.parse_args()
+
+    wheels = sorted(args.dist.glob("*.whl"))
+    if not wheels:
+        sys.exit(f"no .whl in {args.dist}")
+    args.out.mkdir(parents=True, exist_ok=True)
+    for whl in wheels:
+        moved = rewrite_wheel(
+            whl, args.out, args.rel, args.version_suffix, args.requires_python
+        )
+        print(moved.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/python-wheels.nix
+++ b/pkgs/python-wheels.nix
@@ -246,16 +246,35 @@
   # unchanged). Inherited nixpkgs passthru.tests are dropped: they are x86 test
   # suites that would leak into `checks`. Per-package tests/ run only on the
   # primary (current) wheel (name == e.attr), not history versions.
+  inherit (import ./python-publish.nix {inherit pkgs lib;}) publishOf;
+
   mkWheel = name: e: wheel: let
     historyVersion =
       if name == e.attr
       then null
       else lib.removePrefix "${e.attr}-" name;
+    variants =
+      if historyVersion == null
+      then e.variants or allVariants
+      else historyTable.${e.attr}.${historyVersion}.variants or ["py313" "py314"];
   in
     wheel.overrideAttrs (o: {
       passthru =
         removeAttrs (o.passthru or {}) ["tests"]
         // {
+          # The interpreters this entry is built for, and the publishable form
+          # that states them. overrideAttrs only adds passthru, so the wheel
+          # publishOf reads is the same store path either way.
+          wasix = (o.passthru.wasix or {}) // {inherit variants;};
+          published = publishOf {
+            drv = wheel;
+            inherit variants;
+          };
+          publishedWith = suffix:
+            publishOf {
+              drv = wheel;
+              inherit variants suffix;
+            };
           # `skipTest` marks a wheel that cannot be imported on its own, so it
           # gates the tests that run one; the static guards read the artifact
           # and apply to every wheel.

--- a/rels.json
+++ b/rels.json
@@ -5,11 +5,18 @@
   "pythonRegistry.wheels.backports-zstd": {
     "1.6.0": 2
   },
+  "pythonRegistry.wheels.black": {
+    "24.10.0": 2,
+    "25.1.0": 2
+  },
   "pythonRegistry.wheels.brotli": {
     "1.2.0": 2
   },
   "pythonRegistry.wheels.brotlicffi": {
     "1.2.0.0": 2
+  },
+  "pythonRegistry.wheels.bytecode": {
+    "0.16.2": 2
   },
   "pythonRegistry.wheels.certifi": {
     "2026.06.17": 2
@@ -27,7 +34,7 @@
     "1.3.3": 2
   },
   "pythonRegistry.wheels.cryptography": {
-    "43.0.3": 2,
+    "43.0.3": 3,
     "45.0.4": 2,
     "49.0.0": 2
   },
@@ -39,6 +46,9 @@
   },
   "pythonRegistry.wheels.fastuuid": {
     "0.14.0": 2
+  },
+  "pythonRegistry.wheels.fonttools": {
+    "4.63.0": 2
   },
   "pythonRegistry.wheels.frozenlist": {
     "1.8.0": 2
@@ -140,11 +150,19 @@
   "pythonRegistry.wheels.pycurl": {
     "7.46.0": 2
   },
+  "pythonRegistry.wheels.pydantic": {
+    "1.10.26": 2,
+    "2.10.6": 2
+  },
   "pythonRegistry.wheels.pydantic-core": {
     "2.46.4": 2
   },
   "pythonRegistry.wheels.pynacl": {
     "1.6.2": 2
+  },
+  "pythonRegistry.wheels.pyopenssl": {
+    "23.3.0": 2,
+    "24.3.0": 2
   },
   "pythonRegistry.wheels.pypandoc-binary": {
     "1.16.2": 2
@@ -185,6 +203,9 @@
   },
   "pythonRegistry.wheels.uvloop": {
     "0.22.1": 2
+  },
+  "pythonRegistry.wheels.watchdog": {
+    "4.0.2": 2
   },
   "pythonRegistry.wheels.watchfiles": {
     "1.2.0": 2

--- a/tools/wasinix/src/registries/python.rs
+++ b/tools/wasinix/src/registries/python.rs
@@ -416,30 +416,46 @@ pub fn preview_index(
     scratch: &Path,
     site: &Path,
 ) -> Result<()> {
-    let dists = scratch.join("dists.json");
-    crate::support::json::write(&dists, &Value::Array(wheels.to_vec()))?;
-    let mut build = crate::support::nix::Invocation::plain("build")
-        .accepts_flake_config()
-        .arg("--no-link")
-        .workdir(repo);
+    // Each wheel is published a second time under a longer local version. The
+    // suffix is an argument to the wheel's own publish derivation, so a preview
+    // wheel is made the same way a released one is.
+    let mut suffixed = Vec::with_capacity(wheels.len());
     for wheel in wheels {
         let attr = wheel["attr"].as_str().ok_or_else(|| {
             crate::support::error::Error::Request("a changed wheel has no attr".into())
         })?;
-        build = build.operand(format!(
-            ".#legacyPackages.{}.{attr}",
-            crate::support::nix::SYSTEM
-        ));
+        let base = attr.strip_suffix("^dist").unwrap_or(attr);
+        let expr = format!(
+            r#"(builtins.getFlake "path:{repo}").legacyPackages.{system}.{base}.publishedWith "{suffix}""#,
+            repo = repo.display(),
+            system = crate::support::nix::SYSTEM,
+        );
+        let built = crate::support::nix::Invocation::expr("build", expr)
+            .impure()
+            .arg("--no-link")
+            .arg("--print-out-paths")
+            .accepts_flake_config()
+            .workdir(repo)
+            .probe("a failing preview wheel build reports its own stderr")?;
+        if !built.status.is_success() {
+            return request_error("building a preview wheel failed");
+        }
+        let out = String::from_utf8_lossy(&built.stdout).trim().to_string();
+        if out.is_empty() {
+            return request_error("a preview wheel built to no output path");
+        }
+        let mut entry = wheel.clone();
+        entry["published"] = Value::String(out);
+        suffixed.push(entry);
     }
-    if !build.status()?.is_success() {
-        return request_error("building the changed wheels failed");
-    }
+
+    let dists = scratch.join("dists.json");
+    crate::support::json::write(&dists, &Value::Array(suffixed))?;
     let mut index = Command::new("python3");
     index
         .arg(repo.join("pkgs/python-registry/make-index.py"))
         .arg(&dists)
         .arg(site)
-        .args(["--version-suffix", suffix])
         .current_dir(repo);
     crate::support::tools::log(&index);
     if !crate::support::tools::status(&mut index)?.success() {


### PR DESCRIPTION
## Context

A wheel is built once and published many times. The rel (`+wasix.N`) and the
`Requires-Python` bound that says which interpreters an entry was built for are
both facts about the publication, not about the build, yet `make-index.py` was
applying them while assembling the index. That put the wheel's final bytes
inside the indexer, so nothing else could ask for the publishable artifact, and
the index page's `nix build ...#<attr>` line named the wheel's `dist` output:
a different version string and different bytes to the file it sat next to.

This gives the published form its own derivation, `pkgs/python-publish.nix`,
the same way a package gets its `.webc`. `make-index.py` becomes an indexer:
it reads what each entry publishes and writes pages.

## Impact

The bound is introduced here, in its final home. Nine wheels are built for
fewer interpreters than the index serves and gain it, and `fonttools` changes
with the dedup; all ten get a rel bump in the same PR, since their bytes change
under names that are immutable once published.

Verified against a registry built from this PR's own base: 749 wheels before,
749 after, none added or removed, ten changed, and zero changed under an
already-published filename. The native view stays at 201 projects.

`pythonRegistry.published.<py>.<name>."<version>"` is a new attr path holding
the published artifacts, and provenance now points at it. Checked by building
`published.py314.six."1.17.0"` and confirming the file inside is byte-identical
to the one the index serves, which the old `^dist` attr was not.

The line count rises because the rewrite moves out of `make-index.py` into
`publish-wheel.py` and gains a caller in Nix: the wheel set exposes
`.published`, and the registry computes it for closure members that have no
worklist entry. The wheel-rewriting code itself is a wash.

## Behavior checked

All five `python-registry` checks green.
