### PR TITLE
python-registry: publish an interpreter-specific wheel under its own tag

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -181,6 +181,14 @@ After a green build of main, `publish-index` uploads new filenames to the volume
 and deploys the fresh snapshot to GitHub Pages. The volume service is defined by
 `python-registry/app.yaml`.
 
+A wheel built by both interpreters is published once, under the one filename its
+`py3-none-any` tag earns it. Where the two builds differ, that name cannot hold
+both and the registry build fails naming the package. Mark it
+`passthru.wasix.interpreterSpecific` in its overlay entry and each build is
+published as `cp313-none-any` / `cp314-none-any` instead, which a resolver
+prefers over the generic tag, so an artifact already published under the generic
+name stops being selected without being withdrawn.
+
 Each `manifests/<wheel>.json` records `wasinix_rev`, `attr`, and `drv_path`.
 Rebuild it with `nix build github:wasix-org/wasinix/<wasinix_rev>#<attr>`.
 

--- a/pkgs/overlay/python-packages/multiprocess.nix
+++ b/pkgs/overlay/python-packages/multiprocess.nix
@@ -1,0 +1,12 @@
+# multiprocess for wasix. It vendors the stdlib multiprocessing of the
+# interpreter it was built for, so the two builds carry different sources and
+# cannot share one py3-none-any filename.
+{
+  pyprev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  passthru = pyprev.multiprocess.passthru // {wasix = {interpreterSpecific = true;};};
+}
+pyprev.multiprocess

--- a/pkgs/overlay/python-packages/ruamel-base.nix
+++ b/pkgs/overlay/python-packages/ruamel-base.nix
@@ -1,0 +1,11 @@
+# ruamel.base for wasix. setuptools names its namespace-package .pth after the
+# interpreter, so the two builds differ by that filename alone.
+{
+  pyprev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  passthru = pyprev.ruamel-base.passthru // {wasix = {interpreterSpecific = true;};};
+}
+pyprev.ruamel-base

--- a/pkgs/overlay/python-packages/transformers.nix
+++ b/pkgs/overlay/python-packages/transformers.nix
@@ -1,0 +1,11 @@
+# transformers for wasix. Its extras resolve per interpreter, so the METADATA
+# the two builds publish differs and cannot share one py3-none-any filename.
+{
+  pyprev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  passthru = pyprev.transformers.passthru // {wasix = {interpreterSpecific = true;};};
+}
+pyprev.transformers

--- a/pkgs/python-publish.nix
+++ b/pkgs/python-publish.nix
@@ -57,6 +57,9 @@ in {
     # carrying it exists, so reading it back off `drv` would silently see none.
     variants ? (drv.passthru.wasix.variants or null),
     suffix ? null,
+    # cp313/cp314 for a package whose build follows the interpreter, so its two
+    # builds are published under names a resolver can tell apart.
+    pythonTag ? null,
   }: let
     name = drv.pname or drv.name;
     rel = (rels."pythonRegistry.wheels.${name}" or {}).${drv.version} or 1;
@@ -68,6 +71,7 @@ in {
       python3 ${./python-registry/publish-wheel.py} ${drv.dist} "$out" \
         --rel ${toString rel} \
         ${lib.optionalString (requiresPython != null) "--requires-python '${requiresPython}'"} \
+        ${lib.optionalString (pythonTag != null) "--python-tag ${pythonTag}"} \
         ${lib.optionalString (suffix != null) "--version-suffix '${suffix}'"}
     '';
 }

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -48,8 +48,17 @@
       name = drv.pname or drv.name;
       version = drv.version;
       relKey = "${relPrefix}${name}";
-      # the publishable form, produced by the wheel's own derivation
-      publishedDrv = drv.published or (publishOf {inherit drv;});
+      # the publishable form, produced by the wheel's own derivation. A package
+      # whose build follows the interpreter is published per set instead, under
+      # a tag naming it, since one none-any filename cannot hold both builds.
+      publishedDrv =
+        if drv.passthru.wasix.interpreterSpecific or false
+        then
+          publishOf {
+            inherit drv;
+            pythonTag = "cp${lib.removePrefix "py" pv}";
+          }
+        else drv.published or (publishOf {inherit drv;});
       published = "${publishedDrv}";
       # provenance nested by python version and upstream version, so pname collides neither
       # across py313/py314 nor with a served history version of itself:

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -416,11 +416,7 @@ def main() -> None:
             prev = projects.setdefault(project, {}).setdefault(whl.name, whl)
             if prev is not whl:
                 if prev.read_bytes() != whl.read_bytes():
-                    # A py3-none-any tag asserts the artifact is interpreter
-                    # independent, so keep the first and let differing build
-                    # noise go.
-                    if not whl.name.endswith("-py3-none-any.whl"):
-                        conflicts.append((whl.name, entry["attr"]))
+                    conflicts.append((whl.name, entry["attr"]))
                 # `prev` is what the page serves, so its provenance is the one
                 # that reproduces these bytes.
                 continue
@@ -438,8 +434,11 @@ def main() -> None:
             f"  {name}  ({attr})" for name, attr in sorted(set(conflicts))
         )
         sys.exit(
-            "wheels of the same name differ between interpreters; mark each entry"
-            f" `publishOnce` in wheels.nix:\n{listed}"
+            "wheels of the same name differ between interpreters, so which one is"
+            " served would be arbitrary. Mark the package"
+            " `passthru.wasix.interpreterSpecific` to publish each build under its"
+            " own tag, or `publishOnce` in wheels.nix to serve one of them:\n"
+            f"{listed}"
         )
 
     # project -> the rows its page was built from, reused by the native view

--- a/pkgs/python-registry/publish-wheel.py
+++ b/pkgs/python-registry/publish-wheel.py
@@ -11,6 +11,7 @@ bytes have a store path of their own.
 
 Usage: publish-wheel.py <dist dir> <out dir> --rel N
                         [--requires-python BOUND] [--version-suffix S]
+                        [--python-tag TAG]
 """
 
 import argparse
@@ -79,12 +80,21 @@ def set_requires_python(metadata: bytes, bound: str) -> bytes:
     sys.exit("METADATA has no header block")
 
 
+def set_wheel_tag(wheel: bytes, tag: str) -> bytes:
+    """Restate the WHEEL Tag: lines as the single tag the filename now carries."""
+    lines = [l for l in wheel.split(b"\n") if not l.lower().startswith(b"tag:")]
+    end = next(i for i, l in enumerate(lines) if not l.strip())
+    lines.insert(end, f"Tag: {tag}".encode())
+    return b"\n".join(lines)
+
+
 def rewrite_wheel(
     src: Path,
     dest_dir: Path,
     rel: int,
     suffix: str | None = None,
     requires_python: str | None = None,
+    python_tag: str | None = None,
 ) -> Path:
     """Copy the wheel with +wasix.<rel>[.<suffix>] appended to its version.
 
@@ -95,6 +105,13 @@ def rewrite_wheel(
     name, version, rest = src.name.split("-", 2)
     if "+" in version:
         sys.exit(f"{src.name}: already carries a local version")
+    if python_tag:
+        _, abi, platform = rest[: -len(".whl")].split("-")
+        if (abi, platform) != ("none", "any"):
+            sys.exit(
+                f"{src.name}: only a none-any wheel can be retagged, not {abi}-{platform}"
+            )
+        rest = f"{python_tag}-none-any.whl"
     new_version = f"{version}+wasix.{rel}" + (f".{suffix}" if suffix else "")
 
     with zipfile.ZipFile(src) as zin:
@@ -124,6 +141,7 @@ def rewrite_wheel(
         ]
 
     files = {n: data for n, _, data in entries}
+    rewritten = {f"{new_di}/METADATA"}
     files[f"{new_di}/METADATA"] = bump_metadata_version(
         files[f"{new_di}/METADATA"], version, new_version
     )
@@ -131,12 +149,17 @@ def rewrite_wheel(
         files[f"{new_di}/METADATA"] = set_requires_python(
             files[f"{new_di}/METADATA"], requires_python
         )
+    if python_tag:
+        files[f"{new_di}/WHEEL"] = set_wheel_tag(
+            files[f"{new_di}/WHEEL"], rest[: -len(".whl")]
+        )
+        rewritten.add(f"{new_di}/WHEEL")
 
-    # RECORD: renamed paths, plus the refreshed METADATA hash/size
+    # RECORD: renamed paths, plus refreshed hash/size for what was rewritten
     rows = list(csv.reader(io.StringIO(files[f"{new_di}/RECORD"].decode())))
     for row in rows:
         row[0] = rename(row[0])
-        if row[0] == f"{new_di}/METADATA":
+        if row[0] in rewritten:
             row[1] = record_hash(files[row[0]])
             row[2] = str(len(files[row[0]]))
     buf = io.StringIO(newline="")
@@ -160,6 +183,11 @@ def main() -> None:
     ap.add_argument("--rel", type=int, required=True)
     ap.add_argument("--requires-python")
     ap.add_argument(
+        "--python-tag",
+        help="retag a none-any wheel for one interpreter (cp313), so the two "
+        "builds of an interpreter-specific package get distinct filenames",
+    )
+    ap.add_argument(
         "--version-suffix",
         help="extra local-version segments (pr123.abc1234) for PR-preview wheels",
     )
@@ -171,7 +199,12 @@ def main() -> None:
     args.out.mkdir(parents=True, exist_ok=True)
     for whl in wheels:
         moved = rewrite_wheel(
-            whl, args.out, args.rel, args.version_suffix, args.requires_python
+            whl,
+            args.out,
+            args.rel,
+            args.version_suffix,
+            args.requires_python,
+            args.python_tag,
         )
         print(moved.name)
 


### PR DESCRIPTION
Stacked on #174, whose publish derivation this extends.

## Context

Three wheels are tagged `py3-none-any` but are not interpreter independent, so
the two builds claim one filename and which one reached users was decided by
`pythonSets` ordering:

- `multiprocess` vendors the stdlib `multiprocessing` of the interpreter it was
  built for. 15 source files differ, including the body of
  `get_all_start_methods`. py314 users were installing 3.13's sources.
- `transformers` resolves its extras per interpreter, so py313's METADATA
  advertises `ray` and `ja` and py314's does not.
- `ruamel-base` differs only in the name of a setuptools namespace `.pth`.

`make-index.py` detected all three and discarded the finding, on the grounds
that a `py3-none-any` tag "asserts the artifact is interpreter independent". The
tag is the package's claim, and these three disprove it.

## Impact

A package marked `passthru.wasix.interpreterSpecific` in its overlay entry is
published per set as `cp313-none-any` / `cp314-none-any`. Both builds are
served, and each interpreter resolves its own.

That works alongside what is already published. A resolver ranks
`cp313-none-any` first of all tags and `py3-none-any` fourteenth, so the
ambiguous artifact already in the append-only volume stops being selected
without having to be withdrawn, which the volume could not do anyway.

The exemption is gone, so this rule enforces itself: a package that starts
diverging fails the registry build and names itself.

## Behavior checked

749 -> 752 wheels. Three names are no longer emitted, six are, and **nothing
changed under an already-published filename**. Provenance holds at 752/752,
each attr rebuilding the exact bytes beside it. All five `python-registry`
checks green.

Resolution was checked directly rather than inferred from the tag table. Given
an index carrying `cp313-none-any`, `cp314-none-any` and the stale
`py3-none-any` all three at once, which is the state the live volume will be
in, pip on 3.13 selects the cp313 wheel and pip on 3.14 selects the cp314 one.

The retagged wheels are internally consistent: the `WHEEL` `Tag:` line matches
the filename, and RECORD verifies against every member.
