### PR TITLE
ci: comment commands run on the workflow runner

### DIFF
--- a/tools/wasinix/src/cli/untrusted.rs
+++ b/tools/wasinix/src/cli/untrusted.rs
@@ -193,13 +193,15 @@ fn untrusted_case(words: &[String], case_id: String) -> Result<Case<RefSource>> 
     let parsed = UntrustedCase::try_parse_from(words)
         .map_err(|error| Error::Request(format!("diff case {case_id}: {error}")))?;
     Ok(match &parsed {
-        UntrustedCase::Build(case) => {
-            Case::Build(super::request::build_case(&case.request, None, Some(case_id))?)
-        }
+        UntrustedCase::Build(case) => Case::Build(super::request::build_case(
+            &case.request,
+            Some("local".to_string()),
+            Some(case_id),
+        )?),
         UntrustedCase::Spot(case) => Case::Spot(super::request::spot_case(
             &case.request,
             &case.spot,
-            None,
+            Some("local".to_string()),
             Some(case_id),
         )?),
     })
@@ -238,11 +240,14 @@ pub fn parse(command: &str) -> Result<UntrustedCommand> {
             changed,
         }),
         UntrustedCli::Regenerate(_) => UntrustedCommand::Mutation(MutationCommand::Regenerate),
+        // Comment commands execute on the workflow runner itself, and the
+        // untrusted grammar rightly cannot spell --on, so every case is
+        // pinned local; a runner has no builders.toml to default from.
         UntrustedCli::Build(args) => UntrustedCommand::Request(Request::Build(
-            super::request::build_case(&args.request, None, None)?,
+            super::request::build_case(&args.request, Some("local".to_string()), None)?,
         )),
         UntrustedCli::Spot(args) => UntrustedCommand::Request(Request::Spot(
-            super::request::spot_case(&args.request, &args.spot, None, None)?,
+            super::request::spot_case(&args.request, &args.spot, Some("local".to_string()), None)?,
         )),
         UntrustedCli::Diff(args) => {
             let mut cases = Vec::new();

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -2034,6 +2034,27 @@ mod markdown {
     }
 
     #[test]
+    fn comment_commands_pin_every_case_to_the_runner() {
+        use crate::cli::untrusted::{parse, UntrustedCommand};
+        let parsed = parse("build checks.zlib --with wasixcc@0.4.3").unwrap();
+        let UntrustedCommand::Request(crate::ci::types::Request::Build(case)) = parsed else {
+            panic!("expected a build request");
+        };
+        assert_eq!(case.on.as_deref(), Some("local"));
+        let parsed = parse("diff build all --vs build all").unwrap();
+        let UntrustedCommand::Request(crate::ci::types::Request::Diff(diff)) = parsed else {
+            panic!("expected a diff request");
+        };
+        for case in &diff.cases {
+            let on = match case {
+                crate::ci::types::Case::Build(build) => build.on.as_deref(),
+                crate::ci::types::Case::Spot(spot) => spot.on.as_deref(),
+            };
+            assert_eq!(on, Some("local"));
+        }
+    }
+
+    #[test]
     fn mutation_comments_classify_as_mutations_and_parse_structurally() {
         use crate::cli::untrusted::{parse, MutationCommand, UntrustedCommand};
         let UntrustedCommand::Mutation(MutationCommand::Update { targets, all }) =


### PR DESCRIPTION
A /wasinix build reached for the configured default remote, which a CI
runner does not have, so treefmt and eval-inputs died on "no remote is
configured". The untrusted grammar rightly cannot spell --on; the
adapter now pins every parsed case to local, which is where the command
pipeline executes by construction. Earlier comment builds never hit
this only because they failed before acquiring a route.

Assisted-by: claude-code:claude-fable-5

## Context

<!--
Optional, but helpful:
- New package: link the upstream project.
- Update: link the release notes or changelog.
- Explain any non-obvious design choice or compatibility concern.
-->

## Impact

<!--
If this affects existing packages, explain which dependents can change and why.
State the evidence and uncertainty. Omit this section when there are no existing
consumers.
-->

## Behavior checked

<!--
What behavior did you observe? Packages with a small Unix-facing surface often
work with little adaptation, so a brief smoke check can be enough. Extensive
proof is not expected for every change; simply report what you checked, or say
that it was not checked manually.

Prefer adding reusable behavioral coverage as a Nix test when practical.
Toolchain and shared-infrastructure changes need broader verification than an
isolated package change.

For agents: CI builds and runs the declared tests. Do not list `nix fmt`,
`git diff --check`, the builder used, or merely that tests ran as evidence that
behavior works. Describe the behavior and result. Explain non-obvious test
implementation when it matters to the coverage provided.
"Not built here" is one sentence; the reason takes at most one more. Impact is
omitted, not justified as empty. A build mechanism explained in a code comment
is not paraphrased here. An unbuilt PR is a last resort; prefer waiting for a
builder slot.
-->
