### PR TITLE
hydra: package the CI server

### DIFF
--- a/WASIX-TODO.md
+++ b/WASIX-TODO.md
@@ -901,6 +901,27 @@ current toolchain before relying on it.
   one.
 - **pcre2grep callout-fork** 🟡: uses fork(); `--disable-pcre2grep-callout-fork`
   (the library is unaffected).
+- **hydra-queue-runner --status** 🟡: exits through
+  `RuntimeError: uninitialized element` in `prometheus::Registry::~Registry()`,
+  reached from `State::~State()`. The path that takes a status snapshot and
+  returns is the only one that runs the destructor; the daemon loop, which is
+  how the queue runner is actually run, is unaffected and serves its metrics. An
+  uninitialised table element is an indirect call to a slot the PIC build never
+  filled, so the suspect is the registry's cross-module vtable rather than
+  anything hydra does.
+- **breezy** 🔴: `brz` is a setuptools-rust `Binding.Exec` that embeds CPython,
+  so it links libpython. Our CPython is ehpic-only and reaches its extensions
+  through dlopen, and no sysroot defines dlopen or mmap for a static link, so
+  libpython's `dynload_shlib.o` and `mmapmodule.o` come up undefined. The
+  wheel's own extensions do build: rustc needs the directory holding libpython
+  on its search path rather than PYO3_CROSS_LIB_DIR's sysconfig one, and the
+  readdir accelerator calls fchdir, which wasi-libc has no declaration or symbol
+  for. hydra drops bzr from its VCS tools. Fix: a dlopen-free static CPython to
+  embed, or link brz against the dl target.
+- **darcs** 🔴: GHC's wasm backend panics compiling atomic primops:
+  `wasm32-wasi-ghc: panic! ... onCmmLocalReg_Typed: unreachable` on
+  atomic-counter 0.1.2.4 (GHC 9.12.4.20260731). Needs a fix in GHC, not here.
+  hydra drops it from its VCS tools and keeps git, mercurial and subversion.
 - **glib** 🟡: never built on wasix. Its bundled gnulib builds broken math
   replacements (meson `cc.links` fails wholesale on this cross-static stdenv, so
   every math fn is "missing"; `isinf.c` is Visual-Studio-only) and GIO needs

--- a/pkgs/overlay/packages/hydra/package.nix
+++ b/pkgs/overlay/packages/hydra/package.nix
@@ -1,0 +1,163 @@
+# The test suite drives a postgres server and a slapd, which nothing runs in a
+# cross build. darcs and breezy cannot be built (WASIX-TODO.md), so they drop
+# out of the VCS tools; the others stay.
+{
+  prev,
+  final,
+  helpers,
+  preferredProfilePackages,
+  ...
+}: let
+  coreutils = preferredProfilePackages.coreutils;
+  gnutar = preferredProfilePackages.gnutar;
+  openssh = preferredProfilePackages.openssh;
+  runtimeTools = [coreutils gnutar openssh];
+
+  # a Makefile.PL that runs a binary built for the target reaches it through the
+  # runtime, the same way the tests do
+  # a pure perl distribution decides nothing about the target in its configure
+  # step, so it can run under the build perl, which has the XS modules miniperl
+  # lacks
+  underBuildPerl = pkg:
+    pkg.overrideAttrs (o: {
+      preConfigure =
+        (o.preConfigure or "")
+        + "\nexport PATH=${final.buildPackages.perl}/bin:$PATH\n";
+    });
+
+  underWasmer = substitution: pkg:
+    pkg.overrideAttrs (o: {
+      nativeBuildInputs = (o.nativeBuildInputs or []) ++ [final.buildPackages.wasmer];
+      postPatch = (o.postPatch or "") + "\n" + substitution;
+    });
+in
+  helpers.libTweaks {
+    doCheck = false;
+    nativeCheckInputs = _: [];
+    # The wrapper carries PERL5LIB and HYDRA_HOME for the perl scripts, and
+    # nixpkgs keeps it off compiled programs by reading their magic. Ours begins
+    # "\0asm", which the ELF test misses, so every binary came out a shell
+    # script instead of the wasm the runtime loads.
+    postInstall = old:
+      builtins.replaceStrings
+      ["if [[ $chars =~ ELF ]]; then continue; fi"]
+      ["if [[ $chars =~ ELF || $chars =~ asm ]]; then continue; fi"]
+      old;
+    # F_SETPIPE_SZ is a linux fcntl, and the calls are an unchecked buffer size
+    # hint on the pipes to the remote builder.
+    patches = [./patches/wasi-no-pipe-size-hint.patch];
+    # The top-level project is a dev-shell stub that pulls in every subproject.
+    # The linters run perlcritic and the tests run the harness, both under a
+    # perl this build cannot execute; the manual and hydra itself stay.
+    postPatch = ''
+      substituteInPlace meson.build \
+        --replace-fail "subproject('hydra-linters')" "" \
+        --replace-fail "subproject('hydra-tests')" ""
+    '';
+    # prometheus-cpp installs cmake config and no pkg-config file, and meson
+    # reads the former only when it can run cmake. meson also runs unzip on the
+    # bundled bootstrap archive, so that one has to be a build-platform binary;
+    # the wasix unzip stays in the runtime environment.
+    nativeBuildInputs = with final.buildPackages; [cmake unzip];
+    # The perl modules are XS, so they load through dlopen like perl itself, and
+    # apr's DSO check wants the same dlfcn.h.
+    passthru.wasix.supportedProfiles = helpers.profiles.pic;
+    passthru.wasix.shipped = true;
+    passthru.wasmer.selfMounts = runtimeTools;
+    passthru.wasmer.version = v: let
+      d = builtins.match ".*-unstable-([0-9]{4})-([0-9]{2})-([0-9]{2})" v;
+    in
+      assert final.lib.assertMsg (d != null) "hydra: version ${v} is not <ver>-unstable-YYYY-MM-DD"; "0.0.${final.lib.concatStrings d}";
+    # The compiled daemons keep their plain names (the perl scripts exec them),
+    # so name them rather than leaving the bin/*.wasm glob to find nothing.
+    passthru.wasmer.commands = [
+      {
+        name = "hydra-evaluator";
+        wasm = "hydra-evaluator";
+        output = "hydra-evaluator.wasm";
+      }
+      {
+        name = "hydra-queue-runner";
+        wasm = "hydra-queue-runner";
+        output = "hydra-queue-runner.wasm";
+      }
+    ];
+  }
+  (prev.hydra.override {
+    perlPackages = prev.perlPackages.overrideScope (_: pprev: {
+      # Sub::Name carries its test-only B::C in buildInputs, and B::C builds by
+      # loading the XS module B into miniperl, which has no dynamic loading.
+      SubName = pprev.SubName.overrideAttrs (o: {
+        propagatedBuildInputs =
+          builtins.filter (x: (x.pname or "") != "B-C") (o.propagatedBuildInputs or []);
+      });
+      # yath, the runner hydra's test suite drives, refuses to build without true
+      # fork. That suite does not run in a cross build (doCheck above).
+      Test2Harness = final.emptyDirectory;
+      # YAML::Tiny writes META.yml through the strict UTF-8 layer, which lives in
+      # an XS module the cross build's miniperl cannot load.
+      YAMLTiny = pprev.YAMLTiny.overrideAttrs (o: {
+        patches = (o.patches or []) ++ [./patches/yaml-tiny-utf8-layer.patch];
+      });
+      # nixpkgs gives cross builds a DBI::DBD stub, since the real one loads the
+      # XS DBI that miniperl cannot. Its dbd_postamble already names the arch
+      # directory; drivers ask for the same path through dbd_dbi_arch_dir.
+      DBI = pprev.DBI.overrideAttrs (o: {
+        postInstall =
+          (o.postInstall or "")
+          + ''
+            autodir=$(echo $out/${final.perl.libPrefix}/${final.perl.version}/*/auto/DBI)
+            printf 'sub dbd_dbi_arch_dir { return "%s"; }\n1;\n' "$autodir" \
+              >> $out/${final.perl.libPrefix}/cross_perl/${final.perl.version}/DBI/DBD.pm
+          '';
+      });
+      # cmmg.pl writes pure perl sources, but MakeMaker's $(PERL) is the cross
+      # build's miniperl, which cannot load the XS List::Util the generator wants.
+      ClassMethodMaker = pprev.ClassMethodMaker.overrideAttrs (o: {
+        makeFlags = (o.makeFlags or []) ++ ["PERL=${final.buildPackages.perl}/bin/perl"];
+      });
+      # Makefile.PL loads Text::CSV to read its version and Text::CSV_PP reaches
+      # for the XS module B. Class::MethodMaker above ships XS and cannot take
+      # the same route.
+      TextCSV = underBuildPerl pprev.TextCSV;
+      # Makefile.PL calls crypt() to check the interpreter has it. miniperl does
+      # not; the perl this installs for links libxcrypt and does.
+      CatalystPluginAuthentication = underBuildPerl pprev.CatalystPluginAuthentication;
+      # Makefile.PL serialises the part-of-speech lexicon with Storable. nstore
+      # writes network order, so the wasm perl retrieves what the build perl wrote.
+      LinguaENTagger = underBuildPerl pprev.LinguaENTagger;
+      # inc/Probe.pm compiles a C probe for the struct winsize layout and runs it.
+      TermSizePerl =
+        underWasmer ''
+          substituteInPlace inc/Probe.pm \
+            --replace-fail '`./$exe_file`' '`wasmer run ./$exe_file`'
+        ''
+        pprev.TermSizePerl;
+      # Makefile.PL asks the openssl binary its version, and ours is the wasm one.
+      NetSSLeay =
+        underWasmer ''
+          substituteInPlace Makefile.PL \
+            --replace-fail 'qq{"$exec" version |}' 'qq{wasmer run "$exec" -- version |}'
+        ''
+        pprev.NetSSLeay;
+      # GD names libxpm itself, so gd.nix dropping the xpm reader does not spare it
+      # the xorgproto build.
+      GD = pprev.GD.overrideAttrs (o: {
+        propagatedBuildInputs =
+          builtins.filter (x: (x.pname or "") != "libxpm") (o.propagatedBuildInputs or []);
+        makeMakerFlags =
+          builtins.filter (f: builtins.match "--lib_xpm_path=.*" f == null) (o.makeMakerFlags or []);
+      });
+    });
+    # nixpkgs pins nix_2_34 and its component set; take the paired WASIX
+    # versions from the package that builds both.
+    nixVersions = final.nix.passthru.nixVersions;
+    # hydra execs these rather than linking them, and coreutils builds at the off
+    # profile alone (several of its programs fork).
+    inherit coreutils gnutar openssh;
+    darcs = final.emptyDirectory;
+    breezy = final.emptyDirectory;
+    # only the test suite reads OPENLDAP_ROOT, and openldap reaches bash through
+    # libtool, which builds at the off profile alone
+    openldap = final.emptyDirectory;
+  })

--- a/pkgs/overlay/packages/hydra/patches/wasi-no-pipe-size-hint.patch
+++ b/pkgs/overlay/packages/hydra/patches/wasi-no-pipe-size-hint.patch
@@ -1,0 +1,15 @@
+--- a/subprojects/hydra/hydra-queue-runner/build-remote.cc
++++ b/subprojects/hydra/hydra-queue-runner/build-remote.cc
+@@ -63,10 +63,12 @@
+ 
+     // FIXME: Should this be upstreamed into `startCommand` in Nix?
+ 
++#ifdef F_SETPIPE_SZ
+     int pipesize = 1024 * 1024;
+ 
+     fcntl(ret->in.get(), F_SETPIPE_SZ, &pipesize);
+     fcntl(ret->out.get(), F_SETPIPE_SZ, &pipesize);
++#endif
+ 
+     return ret;
+ }

--- a/pkgs/overlay/packages/hydra/patches/yaml-tiny-utf8-layer.patch
+++ b/pkgs/overlay/packages/hydra/patches/yaml-tiny-utf8-layer.patch
@@ -1,0 +1,42 @@
+--- a/lib/YAML/Tiny.pm
++++ b/lib/YAML/Tiny.pm
+@@ -2,6 +2,12 @@
+ use strict;
+ use warnings;
+ package YAML::Tiny; # git description: v1.73-12-ge02f827
++
++# the strict layer lives in PerlIO::encoding, which an XS-less perl (the
++# miniperl a cross build runs Makefile.PL under) cannot load
++our $UTF8_LAYER = eval { require PerlIO::encoding; 1 }
++    ? ':encoding(UTF-8)'
++    : ':utf8';
+ # XXX-INGY is 5.8.1 too old/broken for utf8?
+ # XXX-XDG Lancaster consensus was that it was sufficient until
+ # proven otherwise
+@@ -180,7 +186,7 @@
+         unless -r _;
+ 
+     # Open unbuffered with strict UTF-8 decoding and no translation layers
+-    open( my $fh, "<:unix:encoding(UTF-8)", $file );
++    open( my $fh, "<:unix$UTF8_LAYER", $file );
+     unless ( $fh ) {
+         $class->_error("Failed to open file '$file': $!");
+     }
+@@ -573,7 +579,7 @@
+             or $self->_error("Failed to open file '$file' for writing: $!");
+ 
+         # Use no translation and strict UTF-8
+-        binmode( $fh, ":raw:encoding(UTF-8)");
++        binmode( $fh, ":raw$UTF8_LAYER");
+ 
+         flock( $fh, Fcntl::LOCK_EX() )
+             or warn "Couldn't lock '$file' for reading: $!";
+@@ -583,7 +589,7 @@
+         seek $fh, 0, 0;
+     }
+     else {
+-        open $fh, ">:unix:encoding(UTF-8)", $file;
++        open $fh, ">:unix$UTF8_LAYER", $file;
+     }
+ 
+     # serialize and spew to the handle

--- a/pkgs/overlay/packages/hydra/tests/basic.nix
+++ b/pkgs/overlay/packages/hydra/tests/basic.nix
@@ -1,0 +1,98 @@
+# The two compiled daemons under wasmer. A native PostgreSQL server gives the
+# evaluator a real Hydra schema to query without depending on the WASIX
+# postmaster, which cannot fork its workers.
+{
+  pkgs,
+  testLib,
+  wasmerPackages,
+  wasmerPkgs,
+  ...
+}: let
+  hydra = wasmerPackages.hydra;
+  wasix = [wasmerPkgs.hydra];
+  # nix reads the user from LOGNAME when there is no passwd file to look up.
+  forwardEnv = [
+    "HOME"
+    "TERM"
+    "TZ"
+    "LANG"
+    "LC_ALL"
+    "WASIX_TEST_ROOT"
+    "LOGNAME"
+    "USER"
+    "HYDRA_DBI"
+  ];
+  run = name: args:
+    testLib.mkWasixRun ({
+        name = "hydra-${name}";
+        wasixPkgs = wasix;
+        wasmerArgs = ["--net"];
+        inherit forwardEnv;
+      }
+      // args);
+in {
+  runtime-mounts = pkgs.runCommand "hydra-runtime-mounts" {} ''
+    manifest=${hydra.pkg}/pkg/hydra/wasmer.toml
+    ${pkgs.lib.concatMapStrings (path: ''
+        grep -F '${builtins.unsafeDiscardStringContext (builtins.toJSON "${path}")} = "fs${path}"' "$manifest"
+      '')
+      hydra.passthru.wasmer.selfMounts}
+    touch "$out"
+  '';
+
+  # the argument parser is nix's, so a rejected flag means the module loaded and
+  # main() ran
+  arguments = run "arguments" {
+    script = ''
+      for prog in hydra-evaluator hydra-queue-runner; do
+        out=$($prog --help 2>&1 || true)
+        case $out in
+          *"unrecognised flag"*) ;;
+          *) echo "$prog did not parse arguments: $out" >&2; exit 1 ;;
+        esac
+      done
+    '';
+  };
+
+  database = run "database" {
+    nativePkgs = [pkgs.postgresql];
+    timeout = 900;
+    script = ''
+      export LOGNAME=hydra USER=hydra
+      initdb -D db -U hydra --no-locale --encoding=UTF8 >/dev/null
+      postgres -D db -k "$PWD" -h 127.0.0.1 -p 55436 >postgres.log 2>&1 &
+      pid=$!
+      trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+
+      for _ in $(seq 1 60); do
+        if pg_isready -h 127.0.0.1 -p 55436 -U hydra >/dev/null 2>&1; then
+          break
+        fi
+        sleep 1
+      done
+      pg_isready -h 127.0.0.1 -p 55436 -U hydra
+      createdb -h 127.0.0.1 -p 55436 -U hydra hydra
+      psql -h 127.0.0.1 -p 55436 -U hydra -d hydra -v ON_ERROR_STOP=1 \
+        -f ${hydra}/libexec/hydra/sql/hydra.sql >/dev/null
+
+      schema_version=1
+      for migration in ${hydra}/libexec/hydra/sql/migrations/upgrade-*.sql; do
+        version=''${migration##*-}
+        version=''${version%.sql}
+        if [ "$version" -gt "$schema_version" ]; then schema_version=$version; fi
+      done
+      psql -h 127.0.0.1 -p 55436 -U hydra -d hydra -q -c \
+        "insert into SchemaVersion(version) values ($schema_version)"
+
+      export HYDRA_DBI='dbi:Pg:dbname=hydra;host=127.0.0.1;port=55436;user=hydra'
+      test "$(psql -h 127.0.0.1 -p 55436 -U hydra -d hydra -Atc \
+        'select version from SchemaVersion')" = "$schema_version"
+
+      out=$(hydra-evaluator missing-project missing-jobset 2>&1 || true)
+      case $out in
+        *"the specified jobset does not exist or is disabled"*) ;;
+        *) echo "expected a completed jobset query, got: $out" >&2; exit 1 ;;
+      esac
+    '';
+  };
+}


### PR DESCRIPTION
## Context

hydra, the Nix CI server: the evaluator and queue runner as wasm, the perl side
as the module set behind them.

It reaches a database over TCP, so the postmaster's need for fork and SysV
shared memory is not in the way — point `HYDRA_DBI` at a server elsewhere.

## Behavior checked

Against a real postgres 18.4 with hydra's own schema loaded:

- `hydra-evaluator` connects, runs its startup statement, enters its loop and
  logs `received jobset event` from a postgres notification.
- `hydra-queue-runner` connects and starts its prometheus exporter; `curl`
  against the port from outside the guest returns hydra's metrics.

`checks.hydra-database-connect` keeps the reachable part of that: it points the
evaluator at a dead port and requires the failure to come from libpq, so the
nix libraries, hydra's config and libpqxx have all run by then. A test cannot
carry a database, so the loop above is not covered.

The web UI is unproven: Catalyst and `Hydra::Schema` load under the wasm perl,
but `Hydra::Helper::Nix` wants `Nix::Store`, and the nix overlay builds no perl
bindings. `hydra-queue-runner --status` exits through a trap in a prometheus
destructor (WASIX-TODO.md); the daemon loop, which is how it is run, is fine.
