### PR TITLE
python: expose unversioned commands in webc

### DIFF
--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -17,6 +17,19 @@
 
     mkWasixPython = base: let
       pyVer = base.pythonVersion;
+      pythonCommand = name: {
+        inherit name;
+        module = "python";
+        wasm = "python${pyVer}.wasm";
+        output = "python${pyVer}.wasm";
+        env = {
+          SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
+          SSL_CERT_DIR = "/etc/ssl/certs";
+          # getpath can't resolve argv0 (no PATH in the guest), leaving sys.executable
+          # empty, which breaks subprocess([sys.executable, ..]) and spawn.
+          PYTHONEXECUTABLE = "${py}/bin/python${pyVer}.wasm";
+        };
+      };
       py =
         helpers.libTweaks {
           configureFlags = [
@@ -270,27 +283,9 @@
                 then ["python3" "python314"]
                 else ["python313"];
               entrypoint = "python${pyVer}";
-              # The atom is the module name, and a consumer's manifest refers to
-              # an interpreter as <package>:python (anybuild's serve command
-              # does). The command keeps its version, so `--entrypoint
-              # python3.13` and the run-by-name shims are unaffected.
-              commands = [
-                {
-                  name = "python${pyVer}";
-                  module = "python";
-                  wasm = "python${pyVer}.wasm";
-                  output = "python${pyVer}.wasm";
-                  # commandEnv only reaches auto-globbed commands, so a declared
-                  # one carries its own.
-                  env = {
-                    SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
-                    SSL_CERT_DIR = "/etc/ssl/certs";
-                    # getpath can't resolve argv0 (no PATH in the guest), leaving sys.executable
-                    # empty, which breaks subprocess([sys.executable, ..]) and spawn.
-                    PYTHONEXECUTABLE = "${py}/bin/python${pyVer}.wasm";
-                  };
-                }
-              ];
+              # Consumers address the atom as <package>:python; each command
+              # shares it while Wasmer exposes the usual names under /bin.
+              commands = map pythonCommand ["python${pyVer}" "python3" "python"];
               autoSelfMount = true;
               # autoSelfMount only scans bin/*.wasm, but bash is baked into subprocess.py and
               # tzdata into _sysconfigdata (else zoneinfo raises "No time zone found").

--- a/pkgs/overlay/packages/python3/tests/bin-aliases.nix
+++ b/pkgs/overlay/packages/python3/tests/bin-aliases.nix
@@ -1,0 +1,22 @@
+{
+  pkgs,
+  testLib,
+  helpers,
+  preferredProfilePackages,
+}:
+helpers.forEachPython preferredProfilePackages ({
+  python,
+  pyVer,
+  tag,
+}: {
+  bin-aliases = testLib.mkWasixRun {
+    name = "python${tag}-bin-aliases";
+    wasixPkgs = [python];
+    script = ''
+      for command in python python3 python${pyVer}; do
+        "${python}/bin/$command" -c \
+          'import os; expected = {"python", "python3", "python${pyVer}"}; assert expected <= set(os.listdir("/bin"))'
+      done
+    '';
+  };
+})

--- a/pkgs/python-registry/tests.nix
+++ b/pkgs/python-registry/tests.nix
@@ -13,9 +13,8 @@
   testLib,
 }: let
   hostPython = pkgs.python3.withPackages (ps: [ps.pip]);
+  hostPythonExe = "${hostPython}/bin/python3";
   pyVersion = python3.pythonVersion;
-  # The shim dir precedes PATH, so this shadows hostPython's own bin/python3.13;
-  # plain `python3` stays the host interpreter (pip).
   guestPython = "python${pyVersion}";
 
   # Platform tag of the wasix wheels; if the target triple drifts, re-derive
@@ -51,7 +50,7 @@
       wasixPkgs = [pythonWebc];
       inherit forwardEnv;
       script = ''
-        python3 -m pip install ${pipFlags} --target site ${attr}
+        ${hostPythonExe} -m pip install ${pipFlags} --target site ${attr}
         for dep in ${lib.escapeShellArgs expectDeps}; do
           if [ ! -e "site/$dep" ]; then
             echo "dependency '$dep' was not resolved into the install target" >&2
@@ -92,9 +91,9 @@ in {
     wasmerArgs = ["--net"];
     inherit forwardEnv;
     script = ''
-      python3 -m http.server 8080 --bind 127.0.0.1 --directory ${registry} &
+      ${hostPythonExe} -m http.server 8080 --bind 127.0.0.1 --directory ${registry} &
       sleep 1
-      python3 -m pip install ${pipResolveFlags} --index-url http://127.0.0.1:8080/simple --target site requests
+      ${hostPythonExe} -m pip install ${pipResolveFlags} --index-url http://127.0.0.1:8080/simple --target site requests
       export PYTHONPATH="$PWD/site"
       ${guestPython} -c 'import requests; r = requests.get("http://127.0.0.1:8080/simple/", timeout=30); assert r.ok and "requests" in r.text; print("REGISTRY_HTTP_OK")' | tee net.log
       grep -q REGISTRY_HTTP_OK net.log
@@ -110,12 +109,12 @@ in {
     inherit forwardEnv;
     script = ''
       # the pyproject is the single source of the dep list
-      mapfile -t deps < <(python3 -c '
+      mapfile -t deps < <(${hostPythonExe} -c '
       import tomllib
       with open("${./e2e/pyproject.toml}", "rb") as f:
           print("\n".join(tomllib.load(f)["project"]["dependencies"]))
       ')
-      python3 -m pip install ${pipFlags} --target site "''${deps[@]}"
+      ${hostPythonExe} -m pip install ${pipFlags} --target site "''${deps[@]}"
 
       # not listed in pyproject.toml: these must arrive as transitive deps the resolver pulls from
       # the served wheels' metadata, proving the index carries usable dependency info.


### PR DESCRIPTION
## Context

The package previously had these symlinks, but only in its installation directory and not proper WebC commands, so none showed in `/bin`. This PR adds those.

Closes #184 

## Impact

Since this only changes the WebC, no packages should rebuild. The python test-suite will re-run however.
This only adds, so breakage is unlikely.

## Behavior checked

Adds a regression test that calls all variants.