### PR TITLE
feat(SRE-1672): Add action to wake up AWS nix builder before running

### DIFF
--- a/.github/actions/wake-builder/action.yml
+++ b/.github/actions/wake-builder/action.yml
@@ -1,0 +1,128 @@
+name: Wake the nix builder
+description:
+  Start the idle-stopped EC2 nix builder and return once sshd answers, leaving
+  an ssh key on disk for the build that follows. Authentication is GitHub OIDC
+  against the aux AWS account, and the role trusts only the nixbuilds
+  environment, so the calling job must declare it or the token is refused.
+inputs:
+  role-to-assume:
+    description: ARN of the nixbuilds-wake role (terraform output nixbuilds_wake)
+    required: true
+  instance-id:
+    description:
+      Instance to start. Named explicitly because the role grants no lookup —
+      ec2:DescribeInstances cannot be scoped to one instance
+    required: true
+  host:
+    description:
+      Address to connect to. The builder holds an Elastic IP, so this is a
+      constant and survives the stop
+    required: true
+  ssh-key:
+    description: Private key the builder accepts
+    required: true
+  host-key:
+    description:
+      The builder's public key as a known_hosts line. Without it the first
+      connection trusts whatever key the host presents
+    default: ""
+  user:
+    description: Account to connect as
+    default: nixremote
+  region:
+    description: Region the instance lives in
+    default: eu-west-3
+outputs:
+  ssh-key-path:
+    description: Where the private key was written
+    value: ${{ steps.ssh.outputs.key-path }}
+  known-hosts-path:
+    description: Where the known_hosts file was written
+    value: ${{ steps.ssh.outputs.known-hosts-path }}
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to AWS
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.region }}
+        role-session-name: wasinix-wake-nixbuilds
+
+    - name: Start the builder
+      shell: bash
+      env:
+        INSTANCE_ID: ${{ inputs.instance-id }}
+      run: |
+        # The only AWS call this job is permitted to make. It is idempotent on
+        # a box that is already running, so no state check precedes it. A box
+        # caught mid-shutdown rejects it until it reaches "stopped"; that is
+        # the one retryable failure, every other one is real.
+        for _ in $(seq 30); do
+          if err=$(aws ec2 start-instances --instance-ids "$INSTANCE_ID" 2>&1); then
+            exit 0
+          fi
+          case "$err" in
+            *IncorrectInstanceState*)
+              echo "builder is still stopping, retrying"
+              sleep 10
+              ;;
+            *)
+              echo "$err" >&2
+              exit 1
+              ;;
+          esac
+        done
+        echo "builder never left the stopping state" >&2
+        exit 1
+
+    - name: Install the builder ssh key
+      id: ssh
+      shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        HOST_KEY: ${{ inputs.host-key }}
+        HOST: ${{ inputs.host }}
+      run: |
+        key="$RUNNER_TEMP/nixbuilds_key"
+        known="$RUNNER_TEMP/nixbuilds_known_hosts"
+        install -m 600 /dev/null "$key"
+        printf '%s\n' "$SSH_KEY" > "$key"
+        : > "$known"
+        if [ -n "$HOST_KEY" ]; then
+          printf '%s %s\n' "$HOST" "$HOST_KEY" > "$known"
+        else
+          echo "::warning::no host-key given; trusting the key the builder presents"
+        fi
+        echo "key-path=$key" >> "$GITHUB_OUTPUT"
+        echo "known-hosts-path=$known" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for sshd
+      shell: bash
+      env:
+        HOST: ${{ inputs.host }}
+        USER_NAME: ${{ inputs.user }}
+        KEY: ${{ steps.ssh.outputs.key-path }}
+        KNOWN: ${{ steps.ssh.outputs.known-hosts-path }}
+        HOST_KEY: ${{ inputs.host-key }}
+      run: |
+        # sshd answering is the readiness signal that matters here: the build
+        # is an ssh-ng connection, not an SSM session, so nothing is gained by
+        # asking AWS what it thinks the instance is doing. A cold boot is
+        # ~60-90s; the ceiling is five minutes.
+        strict=accept-new
+        if [ -n "$HOST_KEY" ]; then strict=yes; fi
+        for _ in $(seq 60); do
+          if ssh -i "$KEY" \
+              -o UserKnownHostsFile="$KNOWN" \
+              -o StrictHostKeyChecking="$strict" \
+              -o BatchMode=yes \
+              -o ConnectTimeout=5 \
+              "$USER_NAME@$HOST" true 2>/dev/null; then
+            echo "builder is up"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "builder did not answer on ssh within five minutes" >&2
+        exit 1

--- a/.github/workflows/wake-builder.yml
+++ b/.github/workflows/wake-builder.yml
@@ -1,0 +1,49 @@
+name: Wake builder
+
+# On demand only. The builder stops itself when idle, so this exists to prove
+# the wake path works — and to warm the box before a session that wants it
+# already up. A build workflow wakes it as a step, not by calling this.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: nixbuilds
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  # the OIDC token exchanged for the nixbuilds-wake role
+  id-token: write
+
+jobs:
+  wake:
+    name: Wake the nix builder
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # This is the access control: the role in aux trusts exactly
+    # `repo:wasix-org/wasinix:environment:nixbuilds`, so a job without this
+    # line cannot assume it whatever branch it runs on.
+    environment: nixbuilds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Wake
+        id: wake
+        uses: ./.github/actions/wake-builder
+        with:
+          role-to-assume: ${{ vars.NIXBUILDS_WAKE_ROLE_ARN }}
+          instance-id: ${{ vars.NIXBUILDS_INSTANCE_ID }}
+          host: ${{ vars.NIXBUILDS_HOST }}
+          host-key: ${{ vars.NIXBUILDS_HOST_KEY }}
+          ssh-key: ${{ secrets.NIXBUILDS_SSH_KEY }}
+
+      - name: Report what woke up
+        env:
+          HOST: ${{ vars.NIXBUILDS_HOST }}
+          KEY: ${{ steps.wake.outputs.ssh-key-path }}
+          KNOWN: ${{ steps.wake.outputs.known-hosts-path }}
+        run: |
+          ssh -i "$KEY" -o UserKnownHostsFile="$KNOWN" -o BatchMode=yes \
+            "nixremote@$HOST" 'nproc; free -g | head -2; df -h /nix | tail -1' \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -99,3 +99,55 @@ one sanitizer at the render edge: fences sized past the payload, HTML and cell
 escaping that neutralizes line breaks and backslashes. A managed surface is one
 marked comment, upserted by an author-checked first-match lookup, so a marker
 planted in someone else's comment is never adopted.
+
+## The remote builder in CI
+
+The EC2 nix builder (`docs/building.md`) stops itself when it has been idle for
+fifteen minutes: it is a 32-core box whose value is its warm store, so it is
+paid for only while it builds. A workflow that wants it must start it first.
+
+`.github/actions/wake-builder` does that in one step. It exchanges the job's
+GitHub OIDC token for an AWS role, starts the instance, and returns once sshd
+answers — the readiness signal that matters, since the build is an `ssh-ng`
+connection. It leaves the private key and `known_hosts` on disk and names both
+in its outputs, so the step that builds can point `--on` at the box.
+
+```yaml
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    environment: nixbuilds # the role trusts this and nothing else
+    steps:
+      - uses: ./.github/actions/wake-builder
+        with:
+          role-to-assume: ${{ vars.NIXBUILDS_WAKE_ROLE_ARN }}
+          instance-id: ${{ vars.NIXBUILDS_INSTANCE_ID }}
+          host: ${{ vars.NIXBUILDS_HOST }}
+          host-key: ${{ vars.NIXBUILDS_HOST_KEY }}
+          ssh-key: ${{ secrets.NIXBUILDS_SSH_KEY }}
+```
+
+`environment: nixbuilds` is the access control, not a label. The role in AWS
+trusts exactly one subject — `repo:wasix-org/wasinix:environment:nixbuilds` —
+so a job without that line cannot assume it whatever branch it runs on, and a
+fork pull request cannot at all, because forks are never issued an OIDC token.
+Anything put on the environment as a required reviewer therefore gates the
+builder too.
+
+No AWS key is stored anywhere, and the role can do exactly one thing:
+`ec2:StartInstances` on that single instance. It cannot look the machine up,
+which is why the address is configuration here — the box holds an Elastic IP
+and keeps it across stops.
+
+`wake-builder.yml` runs the same step on `workflow_dispatch` and reports what
+woke up. Use it to check the path, or to warm the box before a session.
+
+Three of the four `vars` come from `infrastructure/aws/clusters/aux`:
+`terraform output -json nixbuilds_wake` prints the role ARN, the instance id
+and the host. `NIXBUILDS_HOST_KEY` is the builder's own public key, read off
+the box (`ssh-keyscan` against it once, or `/etc/ssh/ssh_host_ed25519_key.pub`);
+omitting it makes the first connection trust whatever key answers.
+`NIXBUILDS_SSH_KEY` is the private key the builder accepts, and is the one
+value that belongs in secrets rather than vars.


### PR DESCRIPTION
## Context
Leaving the nix build machine idle is costly, so I've introduced auto-stop on the machine. The auto stop
is triggered by either the developer being disconnected for 15 minutes, or by all CPU cores being
below 30% utilization. This way we can connect -> start job -> disconnect.

## Impact
The credits was used needlessly.

## Behavior checked
Primary behaviour was bills going up.
