### PR TITLE
python3: enable ipv6 and pymalloc, ship pip

### DIFF
--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -240,6 +240,14 @@
           postInstall = ''
             for n in python${pyVer} python3 python; do ln -sf python${pyVer}.wasm "$out/bin/$n"; done
 
+            # `python -m pip` works under wasix, but ensurepip installs it by running
+            # the target interpreter, which a cross build cannot do. The wheel it
+            # bundles is pure python, so unpack that instead.
+            whl=$(echo "$out"/lib/python${pyVer}/ensurepip/_bundled/pip-*.whl)
+            [ -f "$whl" ] || { echo "no bundled pip wheel in $out" >&2; exit 1; }
+            ${final.buildPackages.python3}/bin/python3 -m zipfile -e "$whl" \
+              "$out/lib/python${pyVer}/site-packages"
+
             for f in \
               "$out"/lib/pkgconfig/python-*.pc \
               "$out"/lib/python${pyVer}/_sysconfigdata*.py \

--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -38,6 +38,9 @@
             # WASIX has it, and without this a passive getaddrinfo still returns
             # AF_INET6 while socketmodule cannot parse it: "bind(): bad family".
             "--enable-ipv6"
+            # configure disables pymalloc for WASI along with Emscripten. It works
+            # here, and allocation-heavy code runs ~15% faster with it.
+            "--with-pymalloc"
             # nixpkgs presets ac_cv_x87_double_rounding=yes for every cross build, an
             # x86-only assumption; at "yes" pycore_pymath.h drops Python/dtoa.c and
             # repr(1.1) prints 1.1000000000000001. A configure argument beats nixpkgs' env.

--- a/pkgs/overlay/packages/python3/package.nix
+++ b/pkgs/overlay/packages/python3/package.nix
@@ -34,6 +34,10 @@
         helpers.libTweaks {
           configureFlags = [
             "--enable-wasm-dynamic-linking"
+            # configure hardcodes ipv6=no for WASI, whose libc has no AF_INET6.
+            # WASIX has it, and without this a passive getaddrinfo still returns
+            # AF_INET6 while socketmodule cannot parse it: "bind(): bad family".
+            "--enable-ipv6"
             # nixpkgs presets ac_cv_x87_double_rounding=yes for every cross build, an
             # x86-only assumption; at "yes" pycore_pymath.h drops Python/dtoa.c and
             # repr(1.1) prints 1.1000000000000001. A configure argument beats nixpkgs' env.

--- a/pkgs/overlay/packages/python3/tests/ipv6-bind-check.py
+++ b/pkgs/overlay/packages/python3/tests/ipv6-bind-check.py
@@ -1,0 +1,59 @@
+# A passive getaddrinfo offers AF_INET6 first, so a server binding its first
+# result binds the v6 wildcard. Without ENABLE_IPV6 socketmodule can neither
+# decode that address nor bind it, and the bind raises "bind(): bad family".
+import socket
+import sys
+import threading
+
+if not socket.has_ipv6:
+    print("IPV6_FAIL: socket.has_ipv6 is False")
+    sys.exit(1)
+
+# port 0: both interpreters' runs share the host's network namespace, so a
+# fixed port collides when they overlap
+infos = socket.getaddrinfo(
+    None, 0, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, socket.AI_PASSIVE
+)
+families = [fam for fam, _, _, _, _ in infos]
+if socket.AF_INET6 not in families:
+    print(f"IPV6_FAIL: no AF_INET6 in passive getaddrinfo -> {families}")
+    sys.exit(1)
+
+fam, typ, proto, _, sa = next(i for i in infos if i[0] == socket.AF_INET6)
+if not isinstance(sa[0], str):
+    print(f"IPV6_FAIL: AF_INET6 address did not decode -> {sa!r}")
+    sys.exit(1)
+
+srv = socket.socket(fam, typ, proto)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(sa)
+srv.listen(1)
+port = srv.getsockname()[1]
+
+# an IPv4 client has to reach the v6 wildcard, or binding it strands every
+# caller that resolves to IPv4
+echoed = []
+
+
+def serve():
+    conn, _ = srv.accept()
+    echoed.append(conn.recv(16))
+    conn.sendall(b"pong")
+    conn.close()
+
+
+t = threading.Thread(target=serve, daemon=True)
+t.start()
+
+cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+cli.settimeout(10)
+cli.connect(("127.0.0.1", port))
+cli.sendall(b"ping")
+reply = cli.recv(16)
+cli.close()
+t.join(timeout=10)
+
+if echoed != [b"ping"] or reply != b"pong":
+    print(f"IPV6_FAIL: round trip over IPv4 gave {echoed!r} / {reply!r}")
+    sys.exit(1)
+print("IPV6_OK")

--- a/pkgs/overlay/packages/python3/tests/ipv6-bind.nix
+++ b/pkgs/overlay/packages/python3/tests/ipv6-bind.nix
@@ -1,0 +1,24 @@
+{
+  pkgs,
+  testLib,
+  helpers,
+  preferredProfilePackages,
+}:
+helpers.forEachPython preferredProfilePackages ({
+  python,
+  pyVer,
+  tag,
+}: {
+  # CPython's configure disables ipv6 for WASI, where wasi-libc has no
+  # AF_INET6; WASIX has it, and getaddrinfo hands out AF_INET6 either way.
+  ipv6-bind = testLib.mkWasixRun {
+    name = "python${tag}-ipv6-bind";
+    wasixPkgs = [python];
+    wasmerArgs = ["--net"];
+    script = ''
+      cp ${./ipv6-bind-check.py} check.py
+      python${pyVer} check.py | tee out.log
+      grep -q IPV6_OK out.log
+    '';
+  };
+})

--- a/pkgs/overlay/packages/python3/tests/pip-usable-check.py
+++ b/pkgs/overlay/packages/python3/tests/pip-usable-check.py
@@ -1,0 +1,53 @@
+# pip has to install, not just import: that drives zipfile, importlib.metadata
+# and the filesystem, which is where a wasix interpreter tends to give out. It
+# runs in-process, so a failure here is pip's and not subprocess spawning's.
+import runpy
+import sys
+import zipfile
+from pathlib import Path
+
+wheel = Path("dummy-1.0-py3-none-any.whl")
+with zipfile.ZipFile(wheel, "w") as z:
+    z.writestr("dummy/__init__.py", "VALUE = 41\n")
+    z.writestr(
+        "dummy-1.0.dist-info/WHEEL",
+        "Wheel-Version: 1.0\nGenerator: t\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    )
+    z.writestr(
+        "dummy-1.0.dist-info/METADATA",
+        "Metadata-Version: 2.1\nName: dummy\nVersion: 1.0\n",
+    )
+    z.writestr("dummy-1.0.dist-info/RECORD", "")
+
+target = Path("site")
+sys.argv = [
+    "pip",
+    "install",
+    "--no-index",
+    "--no-cache-dir",
+    "--disable-pip-version-check",
+    "--target",
+    str(target),
+    str(wheel),
+]
+try:
+    runpy.run_module("pip", run_name="__main__")
+except SystemExit as e:
+    if e.code:
+        print(f"PIP_FAIL: pip install exited {e.code}")
+        sys.exit(1)
+
+# read what pip laid down rather than importing it: importing after an
+# in-process install is deprecated, and pip 26.3 makes it an error
+mod = target / "dummy" / "__init__.py"
+dist = target / "dummy-1.0.dist-info"
+if not mod.is_file() or not dist.is_dir():
+    print(f"PIP_FAIL: install left {sorted(p.name for p in target.iterdir())}")
+    sys.exit(1)
+
+ns = {}
+exec(compile(mod.read_text(), str(mod), "exec"), ns)
+if ns.get("VALUE") != 41:
+    print(f"PIP_FAIL: installed module gave {ns.get('VALUE')}")
+    sys.exit(1)
+print("PIP_OK")

--- a/pkgs/overlay/packages/python3/tests/pip-usable.nix
+++ b/pkgs/overlay/packages/python3/tests/pip-usable.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  testLib,
+  helpers,
+  preferredProfilePackages,
+}:
+helpers.forEachPython preferredProfilePackages ({
+  python,
+  pyVer,
+  tag,
+}: {
+  # ensurepip cannot run in a cross build, so the bundled wheel is unpacked at
+  # install time; without that `import pip` is gone even though it runs fine.
+  pip-usable = testLib.mkWasixRun {
+    name = "python${tag}-pip-usable";
+    wasixPkgs = [python];
+    script = ''
+      python${pyVer} -m pip --version | tee out.log
+      grep -q '^pip ' out.log
+
+      cp ${./pip-usable-check.py} check.py
+      python${pyVer} check.py | tee install.log
+      grep -q PIP_OK install.log
+    '';
+  };
+})


### PR DESCRIPTION
## Context

CPython's `configure` special-cases WASI, correctly for wasi-libc and wrongly
for WASIX, which has more of POSIX than the case arm assumes.

**ipv6.** `case $ac_sys_system in WASI) ipv6=no` disables it outright, so the
build disagrees with itself: `ENABLE_IPV6` is off while `HAVE_GETADDRINFO` is
on. `getaddrinfo` then returns `AF_INET6` results that `socketmodule` can
neither decode nor bind, and a server doing the ordinary passive bind loop takes
the first result and dies:

```
family=2 addr=(2, b'')          <- AF_INET6 first, address not decoded
family=1 addr=('0.0.0.0', 8099)
binding the first result... OSError: bind(): bad family
```

That is the anybuild failure. With the flag: `('::', 8099, 0, 0)`, and it binds.

**pymalloc.** Disabled for WASI alongside Emscripten, so every small allocation
went to `malloc`.

**pip.** `ensurepip` installs pip by running the target interpreter, which a
cross build cannot do, so `--without-ensurepip` left the wheel it bundles
sitting unused in the output. pip itself runs fine under wasix.

## Impact

Both are one configure flag. The ipv6 one is a behaviour change worth naming:
`socket.has_ipv6` becomes True, so servers resolving the wildcard address now
bind `::` rather than failing. That is only safe because the v6 wildcard accepts
IPv4 callers here, which is checked below rather than assumed.

## Behavior checked

Against the runtime this repo pins and patches, not a stray build of the same
version:

- `AF_INET6` socket/bind/listen all succeed at the C level.
- `IPV6_V6ONLY` defaults to 0, and an IPv4 client reaches a socket bound to
  `::`. Without this, enabling ipv6 would trade a loud crash for a silent one.
- Full round trip on the rebuilt interpreter: bind the first passive result,
  connect over IPv4, data both ways.
- pymalloc: allocation-heavy microbenchmarks run 14-19% faster (best of seven,
  alternating between builds; single rounds are pure noise on a loaded box).
  stdlib smoke across json/hashlib/decimal/sqlite3/zlib is unaffected.
- pip: `pip 26.2.1 from /lib/python3.14/site-packages/pip`, and it installs a
  wheel into a target dir on the rebuilt interpreter. 6.5M on an 88M
  interpreter.

Both were built with `wasinix spot`, which mixes toolchains by design, so this
is evidence rather than proof; CI builds them honestly.

`python3/tests/` had no socket coverage at all, so nothing would have caught
this. `ipv6-bind` is added for both interpreters and asserts the three things
that actually broke: `has_ipv6`, that the passive `AF_INET6` result decodes to a
string rather than `(2, b'')`, and that binding it leaves the socket reachable
over IPv4. It binds port 0 rather than a fixed port, since both interpreters'
runs share the host's network namespace. Verified to discriminate: `IPV6_FAIL:
socket.has_ipv6 is False` before, `IPV6_OK` after.

`pip-usable` covers the other half: pip has to install a wheel, not merely
import, since that drives zipfile, importlib.metadata and the filesystem. It
runs pip in-process so a failure is pip's rather than subprocess spawning's, and
reads back what pip wrote rather than importing it, because importing after an
in-process install is deprecated and pip 26.3 makes it an error.
