### PR TITLE
hydra: restore shipped package

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -524,6 +524,7 @@
     wasmer = wasmerRuntime;
     packagesDir = ./overlay/packages;
     inherit pythonRegistry;
+    emulatedCheckFor = drv: emulatedChecks.checkFor {inherit drv;};
     # Shipped CLIs run only a declared emulatedCheck, never an auto-detected
     # one: they already carry curated suites or the liveness smoke, and their
     # build layouts do not fit the generic runner. Libraries keep the

--- a/pkgs/overlay/default.nix
+++ b/pkgs/overlay/default.nix
@@ -172,13 +172,18 @@
       toolchain = profileToolchain;
     };
   });
+
+  perlPackages = final.perl.pkgs.overrideScope (import ./perl-packages {
+    inherit final helpers wasixRunStub;
+  });
 in
   packages
   // rustSupport
   // goSupport
   // wrapperFix
   // lib.optionalAttrs isWasixHost {
-    inherit haskellPackages;
+    inherit haskellPackages perlPackages;
+    perl5Packages = perlPackages;
     # nixpkgs builds this by calling bash's expression again rather than
     # overriding the `bash` attr, so it would miss every wasix tweak and fail to
     # compile. It backs `runtimeShellPackage`, which any package wanting a

--- a/pkgs/overlay/packages/file/package.nix
+++ b/pkgs/overlay/packages/file/package.nix
@@ -1,0 +1,11 @@
+{
+  prev,
+  helpers,
+  ...
+}:
+helpers.libTweaks {
+  patches = [./patches/read-complete-magic-database.patch];
+  # check-local runs tests/test, so capture builds the helper directly.
+  wasixCheckPrebuild = ''make -C tests -j"''${NIX_BUILD_CORES:-1}" test'';
+}
+prev.file

--- a/pkgs/overlay/packages/file/patches/read-complete-magic-database.patch
+++ b/pkgs/overlay/packages/file/patches/read-complete-magic-database.patch
@@ -1,0 +1,5 @@
+--- a/src/apprentice.c
++++ b/src/apprentice.c
+@@ -3368 +3368 @@ apprentice_map(struct magic_set *ms, const char *fn)
+-	if (read(fd, map->p, map->len) != (ssize_t)map->len) {
++	if (sread(fd, map->p, map->len, 0) != (ssize_t)map->len) {

--- a/pkgs/overlay/packages/hydra/package.nix
+++ b/pkgs/overlay/packages/hydra/package.nix
@@ -62,7 +62,7 @@ in
     # The perl modules are XS, so they load through dlopen like perl itself, and
     # apr's DSO check wants the same dlfcn.h.
     passthru.wasix.supportedProfiles = helpers.profiles.pic;
-    passthru.wasix.broken = "31 modules in its target Perl 5.42 dependency closure fail to build";
+    passthru.wasix.shipped = true;
     passthru.wasmer.selfMounts = runtimeTools;
     passthru.wasmer.version = v: let
       d = builtins.match ".*-unstable-([0-9]{4})-([0-9]{2})-([0-9]{2})" v;
@@ -84,7 +84,7 @@ in
     ];
   }
   (prev.hydra.override {
-    perlPackages = prev.perlPackages.overrideScope (_: pprev: {
+    perlPackages = final.perlPackages.overrideScope (_: pprev: {
       # Sub::Name carries its test-only B::C in buildInputs, and B::C builds by
       # loading the XS module B into miniperl, which has no dynamic loading.
       SubName = pprev.SubName.overrideAttrs (o: {

--- a/pkgs/overlay/packages/perl5/tests/basic.nix
+++ b/pkgs/overlay/packages/perl5/tests/basic.nix
@@ -3,6 +3,7 @@
 {
   testLib,
   crossPkgsPic,
+  emulatedCheckFor,
   makeWasmerPackage,
   ...
 }: let
@@ -14,6 +15,8 @@
       inherit script;
     };
 in {
+  module-upstream = emulatedCheckFor crossPkgsPic.perlPackages.SubIdentify;
+
   version = run "version" "perl -v";
 
   print = run "print" ''

--- a/pkgs/overlay/perl-packages/default.nix
+++ b/pkgs/overlay/perl-packages/default.nix
@@ -1,0 +1,48 @@
+{
+  final,
+  helpers,
+  wasixRunStub,
+}: _final: prev: let
+  buildPerl = final.buildPackages.perl;
+  checkPerl = final.buildPackages.writeShellScriptBin "perl" ''
+    args=()
+    # Test::Harness forwards its own library paths to HARNESS_PERL.
+    IFS=: read -r -a perl5lib <<< "''${PERL5LIB-}"
+    cleanPerl5lib=()
+    for path in "''${perl5lib[@]}"; do
+      case "$path" in
+        ${buildPerl}/*) ;;
+        *) cleanPerl5lib+=("$path") ;;
+      esac
+    done
+    export PERL5LIB="$(IFS=:; echo "''${cleanPerl5lib[*]}")"
+    for arg in "$@"; do
+      case "$arg" in
+        -I${buildPerl}/*) ;;
+        *) args+=("$arg") ;;
+      esac
+    done
+    exec ${wasixRunStub}/bin/wasix-run ${final.perl}/bin/perl "''${args[@]}"
+  '';
+in {
+  buildPerlPackage = args:
+    (prev.buildPerlPackage args).overrideAttrs (old: {
+      # The harness needs fork to capture TAP; HARNESS_PERL keeps the tests on WASIX.
+      wasixCheckPrebuild = ":";
+      preCheck = helpers.mergeScript [
+        (old.preCheck or "")
+        ''
+          export PATH=${buildPerl}/bin:$PATH
+          export HARNESS_PERL=${checkPerl}/bin/perl
+          checkFlagsArray+=(
+            "PERL=${buildPerl}/bin/perl"
+            "FULLPERL=${buildPerl}/bin/perl"
+            "PERLRUN=${buildPerl}/bin/perl"
+            "FULLPERLRUN=${buildPerl}/bin/perl"
+            "ABSPERLRUN=${buildPerl}/bin/perl"
+            "FULLPERLRUNINST=${buildPerl}/bin/perl"
+          )
+        ''
+      ];
+    });
+}

--- a/pkgs/wasmer/default.nix
+++ b/pkgs/wasmer/default.nix
@@ -22,6 +22,7 @@
   pythonRegistry,
   # drv -> its declared emulated build-system checks (pkgs/emulated-check.nix).
   emulatedChecksFor ? (_: {}),
+  emulatedCheckFor,
 }: let
   testLib = import ./test-lib.nix {inherit pkgs wasmer;};
   mkTestGroup = import ../lib/test-group.nix {inherit pkgs lib posOf;};
@@ -46,7 +47,7 @@
         then import (dir + "/helpers.nix") {inherit pkgs;}
         else {};
       scope = {
-        inherit pkgs testLib helpers crossPkgs crossPkgsPic makeWasmerPackage pythonRegistry;
+        inherit pkgs testLib helpers crossPkgs crossPkgsPic makeWasmerPackage pythonRegistry emulatedCheckFor;
         preferredProfilePackages = preferredProfilePackagesWithWebc;
         # Shims, for putting another package's commands on PATH. .shim drives the
         # packed .webc, .pkg.shim the source dir.


### PR DESCRIPTION

## Context

Use a native TAP harness to drive WASIX Perl tests, while retaining target execution under Wasmer. Handle partial reads in file so Hydra’s full dependency closure and database-backed evaluator check pass.


## Impact

<!--
If this affects existing packages, explain which dependents can change and why.
State the evidence and uncertainty. Omit this section when there are no existing
consumers.
-->

## Behavior checked

<!--
What behavior did you observe? Packages with a small Unix-facing surface often
work with little adaptation, so a brief smoke check can be enough. Extensive
proof is not expected for every change; simply report what you checked, or say
that it was not checked manually.

Prefer adding reusable behavioral coverage as a Nix test when practical.
Toolchain and shared-infrastructure changes need broader verification than an
isolated package change.

For agents: CI builds and runs the declared tests. Do not list `nix fmt`,
`git diff --check`, the builder used, or merely that tests ran as evidence that
behavior works. Describe the behavior and result. Explain non-obvious test
implementation when it matters to the coverage provided.
"Not built here" is one sentence; the reason takes at most one more. Impact is
omitted, not justified as empty. A build mechanism explained in a code comment
is not paraphrased here. An unbuilt PR is a last resort; prefer waiting for a
builder slot.
-->
