### PR TITLE
python-registry: serve what PyPI cannot at simple/, everything at all/simple/

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -123,7 +123,7 @@ PEP 503 "simple" index: `.#pythonRegistry` (`pkgs/python-registry/`). Serve the
 output from any static file host, or install directly:
 
 ```sh
-pip install --index-url file://$(readlink -f result)/simple <pkg>
+pip install --index-url file://$(readlink -f result)/all/simple <pkg>
 ```
 
 A new `wheels.nix` entry lands in the registry automatically. Its test suite
@@ -143,21 +143,25 @@ Alongside `simple/`, the index root carries `packages.json`: one JSON object per
 line naming a published wheel, which is how `wasmerio/wasmer-compat` decides
 which projects the index covers.
 
-`native/simple/` is the same index over the projects that ship a platform-tagged
-wheel, which are the ones nothing else can supply. Point a resolver at that as
-its priority index and PyPI as the primary one:
+`simple/` lists the projects PyPI cannot supply: those shipping a
+platform-tagged wheel, and those with an overlay entry here, whose build differs
+from upstream's. Point a resolver at it as the priority index beside PyPI:
 
 ```sh
 uv pip compile pyproject.toml --universal \
-  --extra-index-url <index>/native/simple --index-url https://pypi.org/simple
+  --extra-index-url <index>/simple --index-url https://pypi.org/simple
 pip install -r requirements.txt --platform wasix_wasm32 --only-binary :all: --target site
 ```
 
-uv binds a package to the first index that carries it, so listing the pure
-dependencies too would pin them to our versions and reject whatever version the
-consuming project asks for. The native view carries no wheels of its own; its
-pages link to the copies under `simple/`, which keeps serving the full closure
-for use as a standalone index.
+uv binds a package to the first index that carries it, so listing a project PyPI
+could have supplied pins it to our version and rejects whatever version the
+consuming project asks for. Listing one we patched too narrowly is the opposite
+defect: the resolver takes upstream's build and drops the patch.
+
+`all/simple/` lists every wheel published here, for installing the closure from
+this index alone with no PyPI at all. It carries no wheels of its own; its pages
+link to the copies under `simple/<project>/`, where every wheel lives whether or
+not its project is listed in `simple/`.
 
 Cross-installing for wasix from a host needs pip. `pip --platform wasix_wasm32`
 selects the tagged wheels, while uv's `--python-platform` is a closed enum with
@@ -242,7 +246,7 @@ explicitly or already released. Changed wheels become an ephemeral per-PR Edge
 app serving an overlay index:
 
 ```sh
-pip install --index-url <preview>/simple --extra-index-url <prod>/simple
+pip install --index-url <preview>/all/simple --extra-index-url <prod>/all/simple
 ```
 
 which prefers the preview wheels by their longer local version. The app is

--- a/pkgs/lib/default.nix
+++ b/pkgs/lib/default.nix
@@ -286,6 +286,19 @@ in rec {
           '';
         };
       merged = extendDrv old effectiveTweaks;
+      # Rewriting the source or the build changes what the wheel contains, so
+      # PyPI's copy of this version is not a substitute and the registry has to
+      # serve ours (pkgs/python-registry). Skipping a test does not.
+      supersedesPyPI = lib.any (a: effectiveTweaks ? ${a}) [
+        "src"
+        "version"
+        "pname"
+        "patches"
+        "prePatch"
+        "postPatch"
+        "preBuild"
+        "postBuild"
+      ];
     in
       merged
       # buildPythonPackage derives passthru.requiredPythonModules when it is
@@ -301,6 +314,10 @@ in rec {
             requiredPythonModules =
               pkg.pythonModule.pkgs.requiredPythonModules
               ((old // merged).propagatedBuildInputs or []);
+            wasix =
+              (old.passthru.wasix or {})
+              // (merged.passthru.wasix or {})
+              // lib.optionalAttrs supersedesPyPI {inherit supersedesPyPI;};
           };
       });
 

--- a/pkgs/python-registry/check-integrity.py
+++ b/pkgs/python-registry/check-integrity.py
@@ -74,13 +74,16 @@ def check_views(root: Path, wheels: list[tuple[str, Path]]) -> None:
     Being the priority index is what binds a resolver to our versions, so a
     project listed here that PyPI could have supplied blocks the version a
     consuming project asks for. A project missing here is the opposite defect:
-    the resolver silently takes upstream's build of something we patched."""
+    the resolver silently takes upstream's build of something we patched.
+
+    A tweak that only skips a test leaves the wheel identical to upstream's, so
+    it does not qualify; pkgs/lib/default.nix decides that."""
     simple = root / "simple"
     provenance = json.loads((root / "provenance.json").read_text())
     expected = {
         m["name"]
         for fname, m in provenance.items()
-        if fname[: -len(".whl")].rsplit("-", 1)[-1] != "any" or m.get("source")
+        if fname[: -len(".whl")].rsplit("-", 1)[-1] != "any" or m.get("supersedes")
     }
     listed = set(PROJECT_LINK.findall((simple / "index.html").read_text()))
     paged = {

--- a/pkgs/python-registry/check-integrity.py
+++ b/pkgs/python-registry/check-integrity.py
@@ -67,42 +67,43 @@ def anchors(page: str) -> dict[str, str]:
     return {unquote(href): digest for href, digest, _ in ANCHOR.findall(page)}
 
 
-def check_native_view(root: Path, wheels: list[tuple[str, Path]]) -> None:
-    """The native view must list exactly the projects with a platform-tagged
-    wheel, and reach the copies simple/ holds rather than carrying its own.
+def check_views(root: Path, wheels: list[tuple[str, Path]]) -> None:
+    """simple/ must list exactly what PyPI cannot supply, and reach the wheels
+    all/simple/ lists rather than carrying copies of its own.
 
-    Being the priority index is what binds a resolver to our versions, so a pure
-    project listed here would block PyPI from supplying the version a consuming
-    project asks for."""
+    Being the priority index is what binds a resolver to our versions, so a
+    project listed here that PyPI could have supplied blocks the version a
+    consuming project asks for. A project missing here is the opposite defect:
+    the resolver silently takes upstream's build of something we patched."""
     simple = root / "simple"
-    native_dir = root / "native" / "simple"
+    provenance = json.loads((root / "provenance.json").read_text())
     expected = {
-        project
-        for project, path in wheels
-        if path.name[: -len(".whl")].rsplit("-", 1)[-1] != "any"
+        m["name"]
+        for fname, m in provenance.items()
+        if fname[: -len(".whl")].rsplit("-", 1)[-1] != "any" or m.get("source")
     }
-    listed = set(PROJECT_LINK.findall((native_dir / "index.html").read_text()))
-    on_disk = {d.name for d in native_dir.iterdir() if d.is_dir()}
-    if listed != on_disk:
-        fail(f"native root index vs project dirs differ: {sorted(listed ^ on_disk)}")
+    listed = set(PROJECT_LINK.findall((simple / "index.html").read_text()))
+    paged = {
+        d.name for d in simple.iterdir() if d.is_dir() and (d / "index.html").is_file()
+    }
+    if listed != paged:
+        fail(f"simple root index vs project pages differ: {sorted(listed ^ paged)}")
     if listed != expected:
         fail(
-            "native view lists the wrong projects; a pure one here blocks PyPI: "
-            f"{sorted(listed ^ expected)}"
+            "simple/ lists the wrong projects; one PyPI could supply blocks the "
+            f"version a consumer asks for, and a missing one hides our patch: {sorted(listed ^ expected)}"
         )
 
+    served = {}
+    for project, path in wheels:
+        served.setdefault(project, set()).add(path.name)
     for project in sorted(listed):
-        page = (native_dir / project / "index.html").read_text()
-        # the native anchors are relative to simple/, so compare by filename
-        anchored = {href.rsplit("/", 1)[-1]: d for href, d in anchors(page).items()}
-        served = anchors((simple / project / "index.html").read_text())
-        if anchored != served:
+        page = (simple / project / "index.html").read_text()
+        anchored = {unquote(href) for href, _, _ in ANCHOR.findall(page)}
+        if anchored != served[project]:
             fail(
-                f"native/{project}: files differ from simple/: {sorted(set(anchored) ^ set(served))}"
+                f"simple/{project}: anchors vs wheels differ: {sorted(anchored ^ served[project])}"
             )
-        for href in re.findall(r'<a href="([^"#]+)#sha256=', page):
-            if not (native_dir / project / unquote(href)).resolve().is_file():
-                fail(f"native/{project}: {href} does not resolve into simple/")
 
 
 def parse_metadata(path: Path) -> tuple[SpecifierSet | None, list[Requirement]]:
@@ -219,21 +220,23 @@ def main() -> None:
     root = Path(sys.argv[1])
     wheel_deps = load_module(sys.argv[2])
     simple = root / "simple"
-    listed = set(
-        re.findall(r'<a href="([^"]+)/">', (simple / "index.html").read_text())
-    )
+    every = root / "all" / "simple"
+    # all/simple lists every wheel published; simple/ is the subset a resolver
+    # should see beside PyPI, so the exhaustive walk reads the former
+    listed = set(re.findall(r'<a href="([^"]+)/">', (every / "index.html").read_text()))
     on_disk = {d.name for d in simple.iterdir() if d.is_dir()}
     if listed != on_disk:
-        fail(f"root index vs project dirs differ: {sorted(listed ^ on_disk)}")
+        fail(f"all/simple index vs project dirs differ: {sorted(listed ^ on_disk)}")
 
     wheels = []
     for pdir in sorted(simple.iterdir()):
         if not pdir.is_dir():
             continue
-        page = (pdir / "index.html").read_text()
+        # its anchors point back into simple/, so hrefs are compared by filename
+        page = (every / pdir.name / "index.html").read_text()
         anchored = set()
         for href, digest, attrs in ANCHOR.findall(page):
-            fname = unquote(href)
+            fname = unquote(href).rsplit("/", 1)[-1]
             if "+wasix." not in fname:
                 fail(f"{pdir.name}: {fname} lacks the +wasix.N publication release")
             wheel = pdir / fname
@@ -258,7 +261,7 @@ def main() -> None:
     if not wheels:
         fail("no wheels indexed at all")
     check_packages_json(root, wheels)
-    check_native_view(root, wheels)
+    check_views(root, wheels)
     check_requirements(wheels, wheel_deps)
     print(f"registry OK: {len(on_disk)} projects, {len(wheels)} wheels")
 

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -66,6 +66,8 @@
       attr = ''pythonRegistry.published.${pv}.${name}."${version}"'';
       drvPath = builtins.unsafeDiscardStringContext drv.drvPath;
       source = sourceOf drv;
+      # our build differs from upstream's, so PyPI cannot stand in for it
+      supersedes = drv.passthru.wasix.supersedesPyPI or false;
       inherit drv;
     })
     (lib.filter

--- a/pkgs/python-registry/default.nix
+++ b/pkgs/python-registry/default.nix
@@ -3,7 +3,7 @@
 # and a resolver picks the file matching the running interpreter.
 #
 #   nix build .#pythonRegistry
-#   pip install --index-url file://$(readlink -f result)/simple numpy
+#   pip install --index-url file://$(readlink -f result)/all/simple numpy
 {
   pkgs,
   lib,

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -8,12 +8,12 @@ bound; each is produced by its own derivation (publish-wheel.py), so this only
 indexes what it is given.
 
 Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
-  <out>/simple/index.html               project list
+  <out>/simple/index.html               project list, what PyPI cannot supply
   <out>/simple/<project>/index.html     file list with #sha256= anchors
   <out>/simple/<project>/<wheel>        the wheel itself (relative hrefs)
   <out>/simple/<project>/<wheel>.metadata   its core metadata, for resolvers
   <out>/packages.json                   flat wheel list, for wasmer-compat
-  <out>/native/simple/...               the same index over native projects only
+  <out>/all/simple/...                  the same listing over every wheel here
 """
 
 import argparse
@@ -404,6 +404,49 @@ def write_packages_json(dest: Path, served) -> None:
     )
 
 
+def is_primary(files: list[tuple]) -> bool:
+    """Whether PyPI cannot correctly supply this project.
+
+    Either a wheel is platform-tagged, so PyPI has nothing that loads under
+    wasix, or the package has an overlay entry here, so our build differs from
+    upstream's and taking PyPI's copy would silently drop that difference.
+    """
+    return any(
+        is_native(fname) or source
+        for fname, _digest, _md, _rp, _rev, _attr, _size, _published, source in files
+    )
+
+
+def write_views(out: Path, pages: dict[str, list[tuple]]) -> dict:
+    """Write both PEP 503 listings over the wheels under simple/<project>/.
+
+    simple/ lists what PyPI cannot supply, so a resolver takes it as the
+    priority index beside PyPI and gets our wheel for exactly those, leaving
+    every other dependency to PyPI at the version the consuming project asks
+    for. all/simple/ lists everything published, for installing the closure
+    from here alone (docs/registry.md). Both point at one copy of each wheel.
+    """
+    primary = {project: files for project, files in pages.items() if is_primary(files)}
+    for project, files in sorted(primary.items()):
+        pdir = out / "simple" / project
+        pdir.mkdir(parents=True, exist_ok=True)
+        (pdir / "index.html").write_text(project_page(project, files))
+    proot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(primary)]
+    (out / "simple" / "index.html").write_text(page("Simple index", proot))
+
+    for project, files in sorted(pages.items()):
+        adir = out / "all" / "simple" / project
+        adir.mkdir(parents=True, exist_ok=True)
+        (adir / "index.html").write_text(
+            project_page(
+                project, files, href_prefix=f"../../../simple/{quote(project)}/"
+            )
+        )
+    aroot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(pages)]
+    (out / "all" / "simple" / "index.html").write_text(page("Simple index", aroot))
+    return primary
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("dists", type=Path)
@@ -468,9 +511,9 @@ def main() -> None:
             md_digest = hashlib.sha256(metadata).hexdigest()
             digest = hashlib.sha256(src.read_bytes()).hexdigest()
             served.append((fname, digest))
-            # rev/attr/published/source are publish-time facts (publish.py
-            # fills them from the manifest); size is intrinsic, so shown here
-            # already.
+            # rev/attr/published are publish-time facts (publish.py fills them
+            # from the manifest); size is intrinsic and source decides which
+            # listing the project lands in, so both are known here already.
             files.append(
                 (
                     fname,
@@ -481,34 +524,12 @@ def main() -> None:
                     None,
                     src.stat().st_size,
                     None,
-                    None,
+                    provenance[fname].get("source"),
                 )
             )
-        (pdir / "index.html").write_text(project_page(project, files))
         pages[project] = files
 
-    root = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(projects)]
-    (out / "simple" / "index.html").write_text(page("Simple index", root))
-
-    # A second PEP 503 view over the projects we are the only possible source
-    # for. Pointed at as the priority index, it binds a resolver to our versions
-    # for exactly those, leaving every pure dependency to PyPI at whatever
-    # version the consuming project asks for (docs/registry.md).
-    native = {
-        project: files
-        for project, files in pages.items()
-        if any(is_native(fname) for fname, *_ in files)
-    }
-    for project, files in sorted(native.items()):
-        ndir = out / "native" / "simple" / project
-        ndir.mkdir(parents=True)
-        (ndir / "index.html").write_text(
-            project_page(
-                project, files, href_prefix=f"../../../simple/{quote(project)}/"
-            )
-        )
-    nroot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(native)]
-    (out / "native" / "simple" / "index.html").write_text(page("Simple index", nroot))
+    primary = write_views(out, pages)
 
     (out / "index.html").write_text(landing(projects))
     (out / "provenance.json").write_text(
@@ -517,7 +538,7 @@ def main() -> None:
     write_packages_json(out / "packages.json", served)
     print(
         f"indexed {sum(map(len, projects.values()))} wheels across {len(projects)} projects"
-        f" ({len(native)} of them native)"
+        f" ({len(primary)} of them served to a resolver beside PyPI)"
     )
 
 

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -404,29 +404,22 @@ def write_packages_json(dest: Path, served) -> None:
     )
 
 
-def is_primary(files: list[tuple]) -> bool:
-    """Whether PyPI cannot correctly supply this project.
-
-    Either a wheel is platform-tagged, so PyPI has nothing that loads under
-    wasix, or the package has an overlay entry here, so our build differs from
-    upstream's and taking PyPI's copy would silently drop that difference.
-    """
-    return any(
-        is_native(fname) or source
-        for fname, _digest, _md, _rp, _rev, _attr, _size, _published, source in files
-    )
-
-
-def write_views(out: Path, pages: dict[str, list[tuple]]) -> dict:
+def write_views(out: Path, pages: dict[str, list[tuple]], supersedes: set[str]) -> dict:
     """Write both PEP 503 listings over the wheels under simple/<project>/.
 
-    simple/ lists what PyPI cannot supply, so a resolver takes it as the
+    simple/ lists what PyPI cannot supply: a platform-tagged wheel, or a project
+    in `supersedes`, whose build here differs from upstream's. A resolver takes
+    it as the
     priority index beside PyPI and gets our wheel for exactly those, leaving
     every other dependency to PyPI at the version the consuming project asks
     for. all/simple/ lists everything published, for installing the closure
     from here alone (docs/registry.md). Both point at one copy of each wheel.
     """
-    primary = {project: files for project, files in pages.items() if is_primary(files)}
+    primary = {
+        project: files
+        for project, files in pages.items()
+        if project in supersedes or any(is_native(fname) for fname, *_ in files)
+    }
     for project, files in sorted(primary.items()):
         pdir = out / "simple" / project
         pdir.mkdir(parents=True, exist_ok=True)
@@ -483,6 +476,7 @@ def main() -> None:
                 "attr": entry["attr"],
                 "drv_path": entry["drvPath"],
                 **({"source": entry["source"]} if entry.get("source") else {}),
+                **({"supersedes": True} if entry.get("supersedes") else {}),
             }
 
     if conflicts:
@@ -529,7 +523,10 @@ def main() -> None:
             )
         pages[project] = files
 
-    primary = write_views(out, pages)
+    supersedes = {
+        normalize(entry["name"]) for entry in dists if entry.get("supersedes")
+    }
+    primary = write_views(out, pages, supersedes)
 
     (out / "index.html").write_text(landing(projects))
     (out / "provenance.json").write_text(

--- a/pkgs/python-registry/publish.py
+++ b/pkgs/python-registry/publish.py
@@ -172,7 +172,10 @@ def main():
             for f, m in sorted(wheels.items())
         ]
         pages[project] = files
-    make_index.write_views(staging, pages)
+    # a manifest predating the field has no flag, so a project last published
+    # before it existed stays out of simple/ until its next publish
+    supersedes = {m["project"] for m in manifests.values() if m.get("supersedes")}
+    make_index.write_views(staging, pages, supersedes)
     (staging / "index.html").write_text(make_index.landing(projects))
     make_index.write_packages_json(
         staging / "packages.json",

--- a/pkgs/python-registry/publish.py
+++ b/pkgs/python-registry/publish.py
@@ -10,6 +10,7 @@ lockfiles keep resolving.
 
 Volume layout (= the web root served by the app):
   index.html, simple/...     as in the nix output
+  all/simple/...             the same listing over every wheel published
   packages.json              flat list of everything published so far
   manifests/<wheel>.json     {project, sha256, metadata_sha256, requires_python,
                               size, published (UTC date, frozen at first publish),
@@ -152,6 +153,7 @@ def main():
     projects: dict[str, dict[str, dict]] = {}
     for fname, m in manifests.items():
         projects.setdefault(m["project"], {})[fname] = m
+    pages = {}
     for project, wheels in sorted(projects.items()):
         pdir = staging / "simple" / project
         pdir.mkdir(parents=True, exist_ok=True)
@@ -169,11 +171,8 @@ def main():
             )
             for f, m in sorted(wheels.items())
         ]
-        (pdir / "index.html").write_text(make_index.project_page(project, files))
-    root = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(projects)]
-    (staging / "simple" / "index.html").write_text(
-        make_index.page("Simple index", root)
-    )
+        pages[project] = files
+    make_index.write_views(staging, pages)
     (staging / "index.html").write_text(make_index.landing(projects))
     make_index.write_packages_json(
         staging / "packages.json",

--- a/pkgs/python-registry/resolve-sweep.nix
+++ b/pkgs/python-registry/resolve-sweep.nix
@@ -35,7 +35,7 @@ in {
             --quiet --no-cache-dir --disable-pip-version-check \
             --platform wasix_wasm32 --implementation cp \
             --python-version "$py" --abi "cp''${py//./}" \
-            --only-binary :all: --index-url file://${registry}/simple \
+            --only-binary :all: --index-url file://${registry}/all/simple \
             --dry-run --report /dev/null "$project" >/dev/null 2>&1; then
             return 0
           fi

--- a/pkgs/python-registry/tests.nix
+++ b/pkgs/python-registry/tests.nix
@@ -32,7 +32,7 @@
     "--abi cp${lib.replaceStrings ["."] [""] pyVersion}"
     "--only-binary :all:"
   ];
-  pipFlags = "${pipResolveFlags} --index-url file://${registry}/simple";
+  pipFlags = "${pipResolveFlags} --index-url file://${registry}/all/simple";
 
   # PYTHONPATH is how the pip --target tree reaches the guest interpreter.
   forwardEnv = testLib.defaultForwardEnv ++ ["PYTHONPATH"];
@@ -93,9 +93,9 @@ in {
     script = ''
       ${hostPythonExe} -m http.server 8080 --bind 127.0.0.1 --directory ${registry} &
       sleep 1
-      ${hostPythonExe} -m pip install ${pipResolveFlags} --index-url http://127.0.0.1:8080/simple --target site requests
+      ${hostPythonExe} -m pip install ${pipResolveFlags} --index-url http://127.0.0.1:8080/all/simple --target site requests
       export PYTHONPATH="$PWD/site"
-      ${guestPython} -c 'import requests; r = requests.get("http://127.0.0.1:8080/simple/", timeout=30); assert r.ok and "requests" in r.text; print("REGISTRY_HTTP_OK")' | tee net.log
+      ${guestPython} -c 'import requests; r = requests.get("http://127.0.0.1:8080/all/simple/", timeout=30); assert r.ok and "requests" in r.text; print("REGISTRY_HTTP_OK")' | tee net.log
       grep -q REGISTRY_HTTP_OK net.log
     '';
   };

--- a/tools/wasinix/src/cli/preview.rs
+++ b/tools/wasinix/src/cli/preview.rs
@@ -184,7 +184,7 @@ fn published_body(
             ),
             Markdown::fenced(
                 &format!(
-                    "pip install --index-url {url}/simple --extra-index-url {}/simple <pkg>",
+                    "pip install --index-url {url}/all/simple --extra-index-url {}/all/simple <pkg>",
                     prod.as_deref().unwrap_or("<prod index>")
                 ),
                 "",


### PR DESCRIPTION
uv binds a package to the first index carrying it, so `simple/` as a priority
index beside PyPI pinned every pure dependency to our version. anybuild's
`gunicorn==23.0.0` went unsatisfiable because we serve 26.0.0.

`simple/` now lists only what PyPI cannot supply: platform-tagged wheels, plus
packages whose build here differs from upstream's. `libTweaks` decides the
latter, flagging a tweak that rewrites the source or the build rather than one
that only skips a test; 107 of 193 entries are the latter kind, and serving
those would pin consumers to our version for no reason. The
full listing moves to `all/simple/`. Wheels stay under `simple/<project>/`, so
both listings reach one copy and nothing published moves. No consumers yet, so
the paths are still free to choose.

#171 added a native-only view for this and it never worked twice over:
`publish.py` never staged it, so `/native/simple/` is a 404 in production, and
selecting on the platform tag alone dropped pure-but-patched packages like
`httpx`, handing consumers upstream's unpatched build.

Checked on a fixture, pip resolving for the wasix tags:

| package | `simple/` | `all/simple/` |
| --- | --- | --- |
| six (no overlay entry) | falls through to PyPI | served |
| requests (entry skips tests only) | falls through to PyPI | served |
| greenlet (native) | served | served |
| httpx (pure, patched here) | served | served |

The integrity check now enforces both directions and reads the expected set from
`provenance.json`, since an overlay entry is not filename-visible. Full registry
build left to CI: locally it builds openjdk-21 via hydra-core -> antlr4.
