### PR TITLE
wasinix: publish the index pages from the python verb

### DIFF
--- a/tools/wasinix/src/cli/registries.rs
+++ b/tools/wasinix/src/cli/registries.rs
@@ -142,6 +142,14 @@ pub enum PythonCommand {
         registry: Option<String>,
         #[arg(long)]
         dry_run: bool,
+        /// Upload the index pages even when no wheel is new, for a change in
+        /// how a project is listed
+        #[arg(long)]
+        refresh_listings: bool,
+        /// Withdraw the listing of a project that no longer belongs in simple/,
+        /// so it stops shadowing PyPI
+        #[arg(long)]
+        withdraw_stale: bool,
     },
     /// Deploy a built preview index as an ephemeral Edge app
     Preview {
@@ -304,12 +312,16 @@ pub fn run_python(command: PythonCommand) -> Result<CommandStatus> {
             rev,
             registry,
             dry_run,
+            refresh_listings,
+            withdraw_stale,
         } => python::publish_index(python::Index {
             registry_path: index,
             registry: python::registry(registry.as_deref()),
             rev,
             effects: Effects::from_dry_run(dry_run),
             repo: crate::support::git::repo_root()?,
+            refresh_listings,
+            withdraw_stale,
         }),
         PythonCommand::Preview {
             site,
@@ -404,6 +416,8 @@ pub fn run_meta_publish(effects: Effects) -> Result<CommandStatus> {
                     rev: String::new(),
                     effects,
                     repo,
+                    refresh_listings: false,
+                    withdraw_stale: false,
                 })
             }),
         ),

--- a/tools/wasinix/src/registries/python.rs
+++ b/tools/wasinix/src/registries/python.rs
@@ -64,6 +64,11 @@ pub struct Index {
     pub effects: crate::support::effects::Effects,
     /// The checkout, which holds the app config and the publisher.
     pub repo: PathBuf,
+    /// Upload the pages even when no wheel is new: they answer to the index
+    /// generator rather than to the wheel set.
+    pub refresh_listings: bool,
+    /// Withdraw the pages of projects that no longer belong in simple/.
+    pub withdraw_stale: bool,
 }
 
 /// The rclone config section the credentials come as. A volume without an S3
@@ -164,6 +169,12 @@ pub fn publish_index(request: Index) -> Result<CommandStatus> {
         .args(["--rev", &request.rev]);
     if request.effects.is_dry_run() {
         publish.arg("--dry-run");
+    }
+    if request.refresh_listings {
+        publish.arg("--refresh-listings");
+    }
+    if request.withdraw_stale {
+        publish.arg("--withdraw-stale");
     }
     publish
         .env("RCLONE_CONFIG", &config)


### PR DESCRIPTION
#193 gave publish.py `--refresh-listings` and `--withdraw-stale`, but `wasinix
python publish` could not reach either, so deploying a listing change meant
invoking the publisher by hand with the volume's bucket id pasted in. The verb
already resolves the app config, its rclone credentials and the bucket, so it
just needed to forward them.

```
wasinix python publish --withdraw-stale --dry-run
```

`--withdraw-stale` implies the refresh, since withdrawing a listing without
regenerating the rest would leave the index inconsistent. `--refresh-listings`
on its own redeploys the pages and deletes nothing.

Both flags are additive and default off, so the workflow's own publish behaves
exactly as it does today.
