### PR TITLE
toolchain: declare the wasm feature baseline in the rust target spec

### DIFF
--- a/pkgs/cargo-registry/crates.json
+++ b/pkgs/cargo-registry/crates.json
@@ -370,6 +370,9 @@
   "sct": {
     "0.7.0": "sha256-PASe8tu8NtFVBWb9dg/IdPRq95OyeiCnrCBxnEhZXQw="
   },
+  "simd-adler32": {
+    "0.3.7": "sha256-T0eA4V4PunsK1Q/Vjl/QBNlb8V06aiqOQmX3iLkUlsQ="
+  },
   "socket2": {
     "0.4.7": "sha256-LLHzqKDE5Svcq1/OomPq3Ow6WLpHQI1VC1WZnS4kYYk=",
     "0.4.9": "sha256-x0kmAtng3BG2yH3eKF6TpA2HZFBnnR01jlXHrg3htcI=",

--- a/pkgs/cargo-registry/tests.nix
+++ b/pkgs/cargo-registry/tests.nix
@@ -15,11 +15,16 @@
     upstream = "0.13.2";
     marker = "dl";
   };
+  simdProbe = {
+    crate = "simd-adler32";
+    upstream = "0.3.7";
+  };
   entryFor = name: upstream:
     lib.findFirst (c: c.crate == name && c.upstream == upstream)
     (throw "cargo-registry: tests expect a ${name} ${upstream} build")
     manifest.crates;
   probeEntry = entryFor probe.crate probe.upstream;
+  simdEntry = entryFor simdProbe.crate simdProbe.upstream;
 in {
   # crates.json and the patch tree name the same crates. A mintable crate with
   # no pins resolves to upstream stock with its edits missing, which nothing
@@ -114,13 +119,25 @@ in {
     } ''
       mkdir -p vendor app/src app/.cargo
       tar xzf "${registry}/crates/${probeEntry.crateFile}" -C vendor
+      tar xzf "${registry}/crates/${simdEntry.crateFile}" -C vendor
 
       unpacked="vendor/${probe.crate}-${probeEntry.wasixVersion}"
+      simd="vendor/${simdProbe.crate}-${simdEntry.wasixVersion}"
       # A directory source requires this file; the store path already
       # content-addresses the mint, so an empty map is honest.
-      echo '{"files":{}}' > "$unpacked/.cargo-checksum.json"
+      for crate in "$unpacked" "$simd"; do
+        echo '{"files":{}}' > "$crate/.cargo-checksum.json"
+      done
       grep -q '${probe.marker}' "$unpacked/src/targets.rs" \
         || { echo "cargo-registry: the ${probe.crate} patch is missing from the minted crate" >&2; exit 1; }
+
+      # The WASIX SIMD baseline selects this module in no_std builds.
+      ${lib.getExe' pkgs.wasix-rust "rustc"} \
+        --crate-name simd_adler32 \
+        --crate-type lib \
+        --edition=2018 \
+        --target wasm32-wasmer-wasi \
+        "$simd/src/lib.rs"
 
       cat > app/Cargo.toml <<'EOF'
       [package]

--- a/pkgs/lib/wasix-crate-patches/simd-adler32/0.3.7.patch
+++ b/pkgs/lib/wasix-crate-patches/simd-adler32/0.3.7.patch
@@ -1,0 +1,6 @@
+diff --git a/src/imp/wasm.rs b/src/imp/wasm.rs
+--- a/src/imp/wasm.rs
++++ b/src/imp/wasm.rs
+@@ -146 +146 @@ unsafe fn simd_adler32(adler: Adler32, data: &[u8]) -> Adler32 {
+-    let arr: [u32; 4] = unsafe { std::mem::transmute(v) };
++    let arr: [u32; 4] = unsafe { core::mem::transmute(v) };

--- a/pkgs/lib/wasix-crate-patches/simd-adler32/edits.nix
+++ b/pkgs/lib/wasix-crate-patches/simd-adler32/edits.nix
@@ -1,0 +1,6 @@
+# simd-adler32 0.3.7 selects its wasm SIMD implementation in no_std builds
+# but refers to std there. Upstream 0.3.8 uses core for the same transmute.
+_: {
+  edited = ["=0.3.7"];
+  stock = [">=0.3.8"];
+}

--- a/pkgs/overlays/c/cargo-wasix-unwrapped/cargo-wasix-target-features.patch
+++ b/pkgs/overlays/c/cargo-wasix-unwrapped/cargo-wasix-target-features.patch
@@ -1,0 +1,21 @@
+diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -246,17 +246,6 @@
+     // SAFETY: not safe in multi-threaded environment
+     unsafe { std::env::set_var("RUSTUP_TOOLCHAIN", &toolchain.name) };
+ 
+-    // Set some flags for rustc (only if RUSTFLAGS is not already set)
+-    if std::env::var("RUSTFLAGS").is_err() {
+-        // SAFETY: not safe in multi-threaded environment
+-        unsafe {
+-            env::set_var(
+-                "RUSTFLAGS",
+-                "-C target-feature=+atomics,+simd128,+relaxed-simd,+extended-const,+wide-arithmetic",
+-            );
+-        }
+-    }
+-
+     // Point the `cc` crate (and anything else honoring its conventions) at
+     // the wasixcc toolchain when it's installed. The variables are scoped to
+     // the target — `cc` checks `CC_<target>` before `TARGET_CC` and `CC` —

--- a/pkgs/overlays/c/cargo-wasix-unwrapped/package.nix
+++ b/pkgs/overlays/c/cargo-wasix-unwrapped/package.nix
@@ -23,6 +23,10 @@ exposePackage (packageSet.callPackage ({
 
       cargoHash = "sha256-0bQGbrYpqusf1yviMHihhtxyu2ACqiCHgmWtZbhsBn4=";
 
+      # cargo-wasix's own RUSTFLAGS write is skipped whenever a package sets
+      # RUSTFLAGS, so the wasm feature baseline lives in the rust target spec.
+      patches = [./cargo-wasix-target-features.patch];
+
       # The integration suite creates empty CARGO_HOMEs then invokes cargo-wasix,
       # which downloads the WASIX target. Its download_toolchain unit test also
       # contacts GitHub. Keep the remaining offline library unit tests.

--- a/pkgs/overlays/w/wasix-flang/package.nix
+++ b/pkgs/overlays/w/wasix-flang/package.nix
@@ -8,6 +8,14 @@
 }:
 exposePackage (packageSet.callPackage ({wasix-llvm, ...}:
     wasix-llvm.passthru.llvm.flang-unwrapped.overrideAttrs (old: {
+      # Flang's largest translation units exhaust the builder when Ninja uses
+      # all cores, so only compile rules use a bounded pool.
+      cmakeFlags =
+        (old.cmakeFlags or [])
+        ++ [
+          "-DCMAKE_JOB_POOLS=compile=8"
+          "-DCMAKE_JOB_POOL_COMPILE=compile"
+        ];
       # flang derives the target ABI from the host: no wasm case in Target.cpp, i64
       # _FortranA* lengths from RTBuilder.h, and a 3-arg main WASI's crt never calls.
       patches =

--- a/pkgs/overlays/w/wasix-llvm/package.nix
+++ b/pkgs/overlays/w/wasix-llvm/package.nix
@@ -76,7 +76,6 @@ exposePackage (packageSet.callPackage ({pkgs}: let
       version = llvmVersion;
       src = monorepoSrc;
       inherit monorepoSrc;
-      doCheck = false;
     })).overrideScope
     (
       final: prev: {
@@ -86,9 +85,17 @@ exposePackage (packageSet.callPackage ({pkgs}: let
         # release_version above is untouched by this). `pos` restamps
         # meta.position to this file, where the pin lives (mkDerivation derives
         # meta.position from pos, clobbering a meta.position attr).
-        libllvm = prev.libllvm.overrideAttrs (_old: {
+        libllvm = prev.libllvm.overrideAttrs (old: {
           inherit version;
           __intentionallyOverridingVersion = true;
+          # llvm-exegesis measures a snippet through the perf counters from
+          # lit.local.cfg, so discovering these tests hangs where the PMU
+          # exposes no LBR sampling.
+          postPatch =
+            old.postPatch
+            + ''
+              rm -rf test/tools/llvm-exegesis
+            '';
         });
         lld = prev.lld.overrideAttrs (_old: {
           inherit version;

--- a/pkgs/overlays/w/wasix-rust/package.nix
+++ b/pkgs/overlays/w/wasix-rust/package.nix
@@ -192,7 +192,13 @@ in
     inherit version src;
 
     patches =
-      [./wasix-cc-linker.patch]
+      [
+        ./wasix-cc-linker.patch
+        # The wasm feature baseline belongs in the target spec, not in
+        # RUSTFLAGS: it has to reach builds that never route through
+        # cargo-wasix, such as maturin's own `cargo rustc`.
+        ./wasix-target-features.patch
+      ]
       ++ optionals hostedOnWasix [
         ./wasix-host-tools.patch
         ./wasix-process-fds.patch

--- a/pkgs/overlays/w/wasix-rust/tests/target-features.nix
+++ b/pkgs/overlays/w/wasix-rust/tests/target-features.nix
@@ -1,0 +1,42 @@
+# The wasm feature baseline for the WASIX rust targets. It is declared in the
+# target spec, so it reaches every rustc invocation instead of only the ones
+# cargo-wasix gets to set RUSTFLAGS for.
+{
+  entry,
+  pkgs,
+  ...
+}: let
+  inherit (pkgs) lib;
+  features = [
+    "atomics"
+    "bulk-memory"
+    "mutable-globals"
+    "sign-ext"
+    "nontrapping-fptoint"
+    "simd128"
+    "relaxed-simd"
+    "extended-const"
+    "wide-arithmetic"
+  ];
+  targets = [
+    "wasm32-wasmer-wasi"
+    "wasm32-wasmer-wasi-dl"
+  ];
+in {
+  target-features = pkgs.runCommand "wasix-rust-target-features" {} ''
+    fail=0
+    for target in ${lib.escapeShellArgs targets}; do
+      cfg=$(${lib.getExe' entry.package "rustc"} --print cfg --target "$target")
+      for feature in ${lib.escapeShellArgs features}; do
+        grep -qxF "target_feature=\"$feature\"" <<<"$cfg" || {
+          echo "FAIL: $target does not enable $feature" >&2
+          fail=1
+        }
+      done
+    done
+
+    [ "$fail" -eq 0 ] || exit 1
+    mkdir -p "$out"
+    echo "wasm feature baseline present on the wasix rust targets" > "$out/result"
+  '';
+}

--- a/pkgs/overlays/w/wasix-rust/wasix-target-features.patch
+++ b/pkgs/overlays/w/wasix-rust/wasix-target-features.patch
@@ -1,0 +1,15 @@
+diff --git a/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs b/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs
+--- a/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs
++++ b/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs
+@@ -170,8 +170,9 @@
+     options.entry_name = "__main_void".into();
+ 
+     // WASIX enables more WASM features
+-    options.features =
+-        "+bulk-memory,+atomics,+mutable-globals,+sign-ext,+nontrapping-fptoint".into();
++    options.features = "+bulk-memory,+atomics,+mutable-globals,+sign-ext,+nontrapping-fptoint,\
++                        +simd128,+relaxed-simd,+extended-const,+wide-arithmetic"
++        .into();
+ 
+     Target {
+         llvm_target: "wasm32-wasi".into(),


### PR DESCRIPTION
## Context

`cargo-wasix` set the target features through `RUSTFLAGS`, and only when `RUSTFLAGS` was unset, so any package setting `env.RUSTFLAGS` built without them and maturin's `cargo rustc` never saw them at all. The target spec already carries the rest of the baseline and applies to every entry point.

Also carries the `wasix-llvm` fix, since nothing can rebuild the toolchain without it.

## Impact

std gains simd128, relaxed-simd, extended-const and wide-arithmetic, which it never had; so do packages that set `RUSTFLAGS` and every maturin-built wheel.

## Behavior checked

Built. The rebuilt toolchain reports all four features on both `wasm32-wasmer-wasi` and `wasm32-wasmer-wasi-dl` with nothing set in the environment, where the same query on the unpatched toolchain reports none of them; the new check asserts exactly that. LLVM's own suite passes without the exegesis directory: 66194 passed, 0 failed, 2237 unsupported.
