### PR TITLE
python: add a pip command

### DIFF
--- a/pkgs/overlays/p/python3/tests/pip-usable.nix
+++ b/pkgs/overlays/p/python3/tests/pip-usable.nix
@@ -17,6 +17,9 @@ helpers.forEachPython packages.preferred ({
       python${pyVer} -m pip --version | tee out.log
       grep -q '^pip ' out.log
 
+      pip --version | tee command.log
+      grep -q '^pip ' command.log
+
       cp ${./pip-usable-check.py} check.py
       python${pyVer} check.py | tee install.log
       grep -q PIP_OK install.log

--- a/pkgs/overlays/p/python3/wasix.nix
+++ b/pkgs/overlays/p/python3/wasix.nix
@@ -352,7 +352,11 @@
             entrypoint = "python${pyVer}";
             # Consumers address the atom as <package>:python; each command
             # shares it while Wasmer exposes the usual names under /bin.
-            commands = map pythonCommand ["python${pyVer}" "python3" "python"];
+            commands =
+              map pythonCommand ["python${pyVer}" "python3" "python"]
+              # The unpacked pip wheel has no atom of its own, so `pip` is the
+              # interpreter with -m pip prepended.
+              ++ [(pythonCommand "pip" // {mainArgs = ["-m" "pip"];})];
             autoSelfMount = true;
             # autoSelfMount only scans bin/*.wasm, but bash is baked into subprocess.py and
             # tzdata into _sysconfigdata (else zoneinfo raises "No time zone found").


### PR DESCRIPTION
## Context

Adds `pip` as a command to `python` which simply dispatches to `python -m pip`.

## Impact

Minimal

## Behavior checked

Added test
