### PR TITLE
project: nest WASIX views and declare inherited packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ nix develop                       # shell with wasixcc + cargo-wasix on PATH
 nix build .#legacyPackages.x86_64-linux.packages.native.wasix-sysroot
 
 # example targets under legacyPackages (the system is explicit):
-nix build .#legacyPackages.x86_64-linux.packages.preferred.git     # source package
+nix build .#legacyPackages.x86_64-linux.packages.wasix.preferred.git     # source package
 nix build .#legacyPackages.x86_64-linux.artifacts.webc.git         # its WebC
 nix build .#legacyPackages.x86_64-linux.packages.native.anybuild   # native shared recipe
 nix build .#legacyPackages.x86_64-linux.packages.native.wasixcc    # the C/C++ driver

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ Packages declare support through `passthru.wasix`:
 
 CI policy is separate under `passthru.wasinix.ci`; `profiles` selects the
 supported subset built continuously. `packages.wasix.<profile>` exposes every
-supported build, while `packages.preferred.<name>` projects each package's
+supported build, while `packages.wasix.preferred.<name>` projects each package's
 preferred profile. The latter is useful for runtime commands and artifacts but
 is not a coherent package set for linked dependencies.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,8 @@ defines a complete package and runs in native and WASIX package sets. A flat
 when the actual host platform is WASIX. This distinction also applies to
 nixpkgs' native build-package splices, so WASIX adaptations never leak into host
 tools. Patches, tests, and other package inputs stay in the owning directory.
+Existing nixpkgs packages requiring no adaptation are registered by the
+extension's `inherited` attribute set instead of empty units.
 
 Python adaptations and their history live under
 `pkgs/python-overlays/<first-character>/`. Shared Python machinery remains in

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -29,10 +29,24 @@ The results are `packages.native.<name>` and `packages.wasix.<profile>.<name>`.
 
 ## Adapting a nixpkgs package for WASIX
 
+When the preceding nixpkgs package needs no adaptation, declare it in the
+package overlay's `inherited` attribute set. Each value is its `passthru.wasix`
+compatibility declaration:
+
+```nix
+inherited = {
+  libfoo = {};
+  libbar.supportedProfiles = ["eh" "ehpic"];
+};
+```
+
+An inherited package is registered and retained like any other project package.
+Move it to an inventory unit once it needs a WASIX-specific transformation.
+
 The regular inventory uses one-character buckets. A WASIX-only adaptation uses
 one of these forms:
 
-- No support files: `pkgs/overlays/<first-character>/<name>.nix`.
+- No colocated support files: `pkgs/overlays/<first-character>/<name>.nix`.
 - Patches or tests: `pkgs/overlays/<first-character>/<name>/wasix.nix` with
   sibling `patches/` and `tests/` directories.
 - Version families: one directory whose unit returns several derivations with

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -25,7 +25,7 @@ request `scope`, `variant`, and `packageSet` in `package.nix` and return the
 appropriate derivation from one visible definition.
 
 The results are `packages.native.<name>` and `packages.wasix.<profile>.<name>`.
-`packages.preferred.<name>` remains the convenient canonical WASIX build.
+`packages.wasix.preferred.<name>` remains the convenient canonical WASIX build.
 
 ## Adapting a nixpkgs package for WASIX
 
@@ -46,8 +46,9 @@ A package file is a function over one argument set:
 
 `package` is the preceding value of the discovered attribute.
 `packages.sameProfile.<dep>` is the immediate recursive package set, already
-using the WASIX stdenv for the current profile. `packages.preferred.<tool>` is
-for runtime tools that may deliberately use another profile.
+using the WASIX stdenv for the current profile.
+`packages.wasix.preferred.<tool>` is for runtime tools that may deliberately use
+another profile.
 
 Use `packages.sameProfile` for linked dependencies. Reaching into an absolute
 profile view from a package unit pins a profile the package does not control.
@@ -156,7 +157,7 @@ Crates not in nixpkgs, crate edits, and the overlay registry: `docs/rust.md`.
    passthru.wasmer.commands = [
      {
        name = "bash";
-       dependency = wasmerDependencies.any packages.preferred.bash;
+       dependency = wasmerDependencies.any packages.wasix.preferred.bash;
      }
    ];
    ```
@@ -167,11 +168,11 @@ Crates not in nixpkgs, crate edits, and the overlay registry: `docs/rust.md`.
 
    ```nix
    passthru.wasmer.dependencies = [
-     packages.preferred.foo
-     (wasmerDependencies.any packages.preferred.bar)
-     (wasmerDependencies.exact packages.preferred.baz)
-     (wasmerDependencies.compatibleMajor packages.preferred.qux)
-     (wasmerDependencies.compatibleMinor packages.preferred.quux)
+     packages.wasix.preferred.foo
+     (wasmerDependencies.any packages.wasix.preferred.bar)
+     (wasmerDependencies.exact packages.wasix.preferred.baz)
+     (wasmerDependencies.compatibleMajor packages.wasix.preferred.qux)
+     (wasmerDependencies.compatibleMinor packages.wasix.preferred.quux)
    ];
    ```
 
@@ -261,7 +262,8 @@ has exercised none of its rewriting.
 
 - Nix only sees git-tracked files, so `git add -N` a new one before building
   (`docs/building.md`).
-- Off-only packages fail in other profiles on purpose; use `packages.preferred`.
+- Off-only packages fail in other profiles on purpose; use
+  `packages.wasix.preferred`.
 - `configure` misdetecting features can be wasm-opt failing on test programs:
   add `disableWasmOptInConfigureHook` to `nativeBuildInputs`.
 - Odd runtime behaviour, such as unexpected exit codes or output formatting, is

--- a/docs/project-api.md
+++ b/docs/project-api.md
@@ -197,6 +197,10 @@ loader for repositories that keep one package unit per file:
     packages = {
       directory = ./pkgs/overlays;
       lane = "packages";
+      inherited = {
+        libfoo = {};
+        libbar.supportedProfiles = ["eh" "ehpic"];
+      };
     };
     python = {
       directory = ./pkgs/python-overlays;
@@ -244,6 +248,11 @@ The regular package inventory accepts three forms:
 - `<bucket>/<name>/package.nix`: a complete package definition, with native and
   WASIX behavior in one file.
 
+The package declaration's `inherited` attribute set registers preceding nixpkgs
+packages which require no WASIX adaptation. Each value is merged into the
+package's `passthru.wasix`. An inherited name cannot also have an inventory
+unit, and every inherited name must exist in the preceding package set.
+
 `wasix.nix` is instantiated only when the actual package-set host platform is
 WASIX, including across nixpkgs' build-package splices. `package.nix` is
 instantiated in native and WASIX sets and may branch on its `scope` argument. A
@@ -264,6 +273,7 @@ wheel declarations remain under `pkgs/python/lib/` and `pkgs/python/wheels/`.
 The loader performs only these jobs:
 
 - discover package units;
+- register declared inherited packages;
 - turn them into an overlay for their lane;
 - preserve source positions for diagnostics;
 - reject duplicate attributes between discovered units;
@@ -970,6 +980,7 @@ introduces them:
 
 The directory loader derives package-unit names from their sharded paths and
 values from their returned attrsets. Its eval-only tests must cover complete and
-WASIX-only units, a singleton adaptation depending on the immediate recursive
-set, a multi-package unit, rejection of a bare derivation, wrong buckets,
-conflicting entry forms, obsolete `recipe.nix`, and loose support files.
+WASIX-only units, inherited packages, a singleton adaptation depending on the
+immediate recursive set, a multi-package unit, rejection of a bare derivation,
+wrong buckets, conflicting entry forms, obsolete `recipe.nix`, and loose support
+files.

--- a/docs/project-api.md
+++ b/docs/project-api.md
@@ -292,7 +292,7 @@ Every constructor receives that same context and requests only the fields it
 uses. The context includes:
 
 - `packages.sameProfile`: the immediate recursive package set.
-- `packages.preferred`: the attribute-wise projection of each package's
+- `packages.wasix.preferred`: the attribute-wise projection of each package's
   preferred WASIX profile.
 - `packageSet`: the immediate undecorated nixpkgs or Python fixpoint.
 - `scope` and `variant`: the actual package-set scope and its profile or
@@ -419,9 +419,11 @@ The structured views are:
 {
   packages = {
     native = ...;
-    wasix.<profile> = ...;
+    wasix = {
+      <profile> = ...;
+      preferred = ...;
+    };
     python.<interpreter> = ...;
-    preferred = ...;
   };
 
   packages.native.wasixcc.profiles.<profile>.stdenv = ...;
@@ -446,10 +448,10 @@ The CLI accepts `--project FLAKE#PROJECT-ATTR`; it defaults to
 `.#legacyPackages.x86_64-linux`. This reference selects the structured project,
 independently of the pinned Wasinix flake supplying the CLI and optional tools.
 
-`packages.preferred` is generally available but is not a coherent nixpkgs
+`packages.wasix.preferred` is generally available but is not a coherent nixpkgs
 package set: two attributes may select different profiles. Linked dependencies
 use the immediate `packages.sameProfile` context. Runtime commands, non-linked
-tools, and default artifacts may deliberately use `packages.preferred`.
+tools, and default artifacts may deliberately use `packages.wasix.preferred`.
 
 ## Package metadata
 
@@ -608,8 +610,8 @@ the entry being constructed or checked:
 ```nix
 packages.sameProfile.openssl
 packages.sameProfile.openssl.versions."1.1.1w"
-packages.preferred.bash
-packages.preferred.bash.versions."5.2"
+packages.wasix.preferred.bash
+packages.wasix.preferred.bash.versions."5.2"
 ```
 
 A release records the artifact identity rather than modifying the source package
@@ -769,12 +771,12 @@ internal catalog entry being projected, and entry-relative conveniences such as
 fields. The fields below are common projection dependencies, not a test-owned
 API:
 
-- `packages.native`, `packages.wasix`, `packages.python`, and
-  `packages.preferred`, with retained history under each package's `versions`;
+- `packages.native`, `packages.wasix.<profile>`, `packages.wasix.preferred`, and
+  `packages.python`, with retained history under each package's `versions`;
 - `packages.sameProfile` for entry callbacks, where the entry supplies a package
   scope and variant;
-- `packageSets`, the undecorated native, WASIX, Python, and preferred package
-  sets;
+- `packageSets`, the undecorated native, WASIX profile and preferred, and Python
+  package sets;
 - `pythonVariants`, including the configured variants, their interpreter
   packages, and the preferred variant;
 - `catalog` and `tests`;

--- a/flake.nix
+++ b/flake.nix
@@ -199,7 +199,7 @@
         wasinix
         project.packages.native.cargo-wasix
         project.packages.native.wasixcc
-        project.packages.preferred.ncurses
+        project.packages.wasix.preferred.ncurses
         pkgs.gnumake
         pkgs.pkg-config
         project.packages.native.wasmer

--- a/pkgs/artifacts/python.nix
+++ b/pkgs/artifacts/python.nix
@@ -17,8 +17,8 @@
     select,
   }: let
     pythonName = pythonVariants.specs.${interpreter}.interpreterPackage;
-    python = packageSets.preferred.${pythonName};
-    pythonArtifact = packages.preferred.${pythonName};
+    python = packageSets.wasix.preferred.${pythonName};
+    pythonArtifact = packages.wasix.preferred.${pythonName};
   in
     mkPythonWheels {
       inherit pyKey select;
@@ -112,7 +112,7 @@ in {
     publishOnce = map (entry': entry'.attr) (lib.filter (entry': entry'.publishOnce or false) wheelList);
     pythonSets =
       lib.mapAttrs (interpreter: spec: {
-        python3 = packageSets.preferred.${spec.interpreterPackage};
+        python3 = packageSets.wasix.preferred.${spec.interpreterPackage};
         pythonWheels =
           wheelsFor packages interpreter (wheelArtifactKind interpreter)
           // lib.optionalAttrs (interpreter == preferred) (wheelsFor packages interpreter "wheel-noarch");
@@ -126,8 +126,8 @@ in {
       && builtins.elem entry.artifactKind wheelArtifactKinds)
     (builtins.attrValues catalog.entries));
     registry = mkPythonRegistry {
-      python3 = packageSets.preferred.${preferredPython};
-      pythonWebc = packages.preferred.${preferredPython}.artifacts.webc.shim;
+      python3 = packageSets.wasix.preferred.${preferredPython};
+      pythonWebc = packages.wasix.preferred.${preferredPython}.artifacts.webc.shim;
       inherit pythonSets;
     };
   in {

--- a/pkgs/overlays/a/anybuild/package.nix
+++ b/pkgs/overlays/a/anybuild/package.nix
@@ -11,7 +11,7 @@
       entrypoint = "anybuild";
       dependencies = [
         {
-          package = packages.preferred.bash;
+          package = packages.wasix.preferred.bash;
           version = "*";
         }
       ];

--- a/pkgs/overlays/a/anybuild/tests/python-templates.nix
+++ b/pkgs/overlays/a/anybuild/tests/python-templates.nix
@@ -24,7 +24,7 @@
   examples = "${pkgs.anybuild.src}/examples";
   pythonRegistry = artifacts.registry.python;
   wasmerRuntime = runners.rawWasm.withRuntime.wasmer;
-  bash = packages.preferred.bash.artifacts;
+  bash = packages.wasix.preferred.bash.artifacts;
 
   # Templates whose install steps produce a cross-compiled site-packages: the
   # python provider serves the app off a wasix venv, while mkdocs only uses
@@ -44,11 +44,11 @@
   interpreters = {
     "3.13" = {
       host = pkgs.python313;
-      webc = packages.preferred.python313.artifacts;
+      webc = packages.wasix.preferred.python313.artifacts;
     };
     "3.14" = {
       host = pkgs.python314;
-      webc = packages.preferred.python314.artifacts;
+      webc = packages.wasix.preferred.python314.artifacts;
     };
   };
 

--- a/pkgs/overlays/b/bash/wasix.nix
+++ b/pkgs/overlays/b/bash/wasix.nix
@@ -48,7 +48,7 @@ in
         # A shell with nothing to run is not a shell: wasmer mounts each
         # dependency command under /bin, which is where DEFAULT_PATH_VALUE
         # points.
-        dependencies = [packages.preferred.coreutils];
+        dependencies = [packages.wasix.preferred.coreutils];
         commands = [
           {name = "bash";}
           {

--- a/pkgs/overlays/b/brotli.nix
+++ b/pkgs/overlays/b/brotli.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/b/bzip2.nix
+++ b/pkgs/overlays/b/bzip2.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/c/clang/wasix.nix
+++ b/pkgs/overlays/c/clang/wasix.nix
@@ -46,7 +46,7 @@ exposeWasixPackage (
           "clang"
           "clang++"
         ];
-        dependencies = [packages.preferred.lld];
+        dependencies = [packages.wasix.preferred.lld];
         fs = {
           "/sysroot" = packages.native."wasix-sysroot".profiles.exnrefEh.sysroot;
           "/lib/clang/${major}/include" = "${monorepoSrc}/clang/lib/Headers";

--- a/pkgs/overlays/c/cli/package.nix
+++ b/pkgs/overlays/c/cli/package.nix
@@ -16,7 +16,7 @@
     gnused
     gnutar
   ];
-  wasixTools = with packages.preferred; [
+  wasixTools = with packages.wasix.preferred; [
     curl
     findutils
     gnugrep
@@ -45,7 +45,7 @@
             {
               name = "bash";
               dependency = {
-                package = packages.preferred.bash;
+                package = packages.wasix.preferred.bash;
                 version = "*";
               };
             }

--- a/pkgs/overlays/c/curl/wasix.nix
+++ b/pkgs/overlays/c/curl/wasix.nix
@@ -34,7 +34,7 @@ exposeWasixPackage (
       # wcurl is a target-side wrapper script; it execs /bin/bash, mounted from the
       # bash webc dependency at load (like git's SHELL_PATH=/bin/bash). curl-config
       # stays a build-host dev script in -dev (git's build runs it for link flags).
-      passthru.wasmer.dependencies = [packages.preferred.bash];
+      passthru.wasmer.dependencies = [packages.wasix.preferred.bash];
       # patchShebangs bakes the build bash into wcurl, which cross curl forbids in
       # $bin (outputChecks.disallowedReferences); repoint it at the mounted
       # /bin/bash. No -e guard on purpose: if a curl bump drops wcurl, sed errors

--- a/pkgs/overlays/d/dbt-sa-cli/package.nix
+++ b/pkgs/overlays/d/dbt-sa-cli/package.nix
@@ -54,7 +54,7 @@ exposePackage (
     doCheck = false;
 
     # 113 MB of wasm from an 819-crate workspace, and the wheel takes it through
-    # packages.preferred, so one profile is the build anyone consumes.
+    # packages.wasix.preferred, so one profile is the build anyone consumes.
     passthru.wasix = {
       supportedProfiles = ["eh" "ehpic"];
       preferredProfile = "eh";

--- a/pkgs/overlays/e/editline.nix
+++ b/pkgs/overlays/e/editline.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/e/expat.nix
+++ b/pkgs/overlays/e/expat.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/f/flang/wasix.nix
+++ b/pkgs/overlays/f/flang/wasix.nix
@@ -91,7 +91,7 @@ exposeWasixPackage (
           # The Fortran job is flang's own, but the driver hands codegen to a
           # clang -cc1 command, so this needs a clang to spawn as clang needs an
           # lld.
-          dependencies = [packages.preferred.clang];
+          dependencies = [packages.wasix.preferred.clang];
         };
       };
 

--- a/pkgs/overlays/g/giflib.nix
+++ b/pkgs/overlays/g/giflib.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/g/git/wasix.nix
+++ b/pkgs/overlays/g/git/wasix.nix
@@ -11,10 +11,10 @@
 exposeWasixPackage (
   let
     lib = packages.sameProfile.lib;
-    bash = packages.preferred.bash;
-    nano = packages.preferred.nano;
-    coreutils = packages.preferred.coreutils;
-    gawk = packages.preferred.gawk;
+    bash = packages.wasix.preferred.bash;
+    nano = packages.wasix.preferred.nano;
+    coreutils = packages.wasix.preferred.coreutils;
+    gawk = packages.wasix.preferred.gawk;
   in
     (package.override {
       # gettext lands in nativeBuildInputs too, so the bare argument splices to
@@ -63,8 +63,8 @@ exposeWasixPackage (
               nano
               coreutils
               gawk
-              packages.preferred.gnugrep
-              packages.preferred.gnused
+              packages.wasix.preferred.gnugrep
+              packages.wasix.preferred.gnused
             ];
             # git execs its libexec helpers at absolute /nix/store paths; mount
             # whatever git.wasm embeds (bash is no longer embedded).

--- a/pkgs/overlays/h/hydra/wasix.nix
+++ b/pkgs/overlays/h/hydra/wasix.nix
@@ -10,9 +10,9 @@
 }:
 exposeWasixPackage (
   let
-    coreutils = packages.preferred.coreutils;
-    gnutar = packages.preferred.gnutar;
-    openssh = packages.preferred.openssh;
+    coreutils = packages.wasix.preferred.coreutils;
+    gnutar = packages.wasix.preferred.gnutar;
+    openssh = packages.wasix.preferred.openssh;
     runtimeTools = [coreutils gnutar openssh];
 
     # a Makefile.PL that runs a binary built for the target reaches it through the

--- a/pkgs/overlays/j/jansson.nix
+++ b/pkgs/overlays/j/jansson.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/lcms2.nix
+++ b/pkgs/overlays/l/lcms2.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/libb2.nix
+++ b/pkgs/overlays/l/libb2.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/libblake3.nix
+++ b/pkgs/overlays/l/libblake3.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/libdeflate.nix
+++ b/pkgs/overlays/l/libdeflate.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/libiconv.nix
+++ b/pkgs/overlays/l/libiconv.nix
@@ -1,4 +1,0 @@
-# WASIX libc provides iconv; keep the nixpkgs shim rather than GNU libiconv.
-# The shim ships no archive because the symbols live in libc.
-{exposeWasixExtendedPackage}:
-exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/libyaml.nix
+++ b/pkgs/overlays/l/libyaml.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/l/lz4.nix
+++ b/pkgs/overlays/l/lz4.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/m/mpfr.nix
+++ b/pkgs/overlays/m/mpfr.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/n/nlohmann_json.nix
+++ b/pkgs/overlays/n/nlohmann_json.nix
@@ -1,3 +1,0 @@
-# nix uses nlohmann_json for JSON handling.
-{exposeWasixExtendedPackage}:
-exposeWasixExtendedPackage {}

--- a/pkgs/overlays/o/oniguruma.nix
+++ b/pkgs/overlays/o/oniguruma.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/o/openjpeg.nix
+++ b/pkgs/overlays/o/openjpeg.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/p/perl5/wasix.nix
+++ b/pkgs/overlays/p/perl5/wasix.nix
@@ -20,7 +20,7 @@ exposeWasixPackage (
       } (extendPackage (package.override {
           # The coreutils pwd executable is a runtime path baked into Cwd, and coreutils
           # builds at the off profile only.
-          coreutils = packages.preferred.coreutils;
+          coreutils = packages.wasix.preferred.coreutils;
           # the module set is built against `self`, so without this every perl module
           # compiles against an interpreter carrying none of the above
           self = perl;

--- a/pkgs/overlays/p/popt.nix
+++ b/pkgs/overlays/p/popt.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/p/postgresql/wasix.nix
+++ b/pkgs/overlays/p/postgresql/wasix.nix
@@ -127,8 +127,8 @@ exposeWasixPackage (
           # popen() runs `/bin/sh -c`, which initdb and pg_ctl use to start the
           # server. icu-data carries the collation archive icu compiles a path to.
           dependencies = [
-            packages.preferred.bash
-            packages.preferred.icu-data
+            packages.wasix.preferred.bash
+            packages.wasix.preferred.icu-data
           ];
           fs = {
             # WASIX has no passwd database, and initdb names the bootstrap

--- a/pkgs/overlays/p/python3/tests/bin-aliases.nix
+++ b/pkgs/overlays/p/python3/tests/bin-aliases.nix
@@ -4,7 +4,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   python,
   pythonCommands,
   pyVer,

--- a/pkgs/overlays/p/python3/tests/ctypes-findlib.nix
+++ b/pkgs/overlays/p/python3/tests/ctypes-findlib.nix
@@ -3,7 +3,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   pythonCommands,
   pyVer,
   tag,

--- a/pkgs/overlays/p/python3/tests/ipv6-bind.nix
+++ b/pkgs/overlays/p/python3/tests/ipv6-bind.nix
@@ -3,7 +3,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   pythonCommands,
   pyVer,
   tag,

--- a/pkgs/overlays/p/python3/tests/mp-context.nix
+++ b/pkgs/overlays/p/python3/tests/mp-context.nix
@@ -3,7 +3,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   pythonCommands,
   pyVer,
   tag,

--- a/pkgs/overlays/p/python3/tests/pip-usable.nix
+++ b/pkgs/overlays/p/python3/tests/pip-usable.nix
@@ -3,7 +3,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   pythonCommands,
   pyVer,
   tag,

--- a/pkgs/overlays/p/python3/tests/spawn-passfds.nix
+++ b/pkgs/overlays/p/python3/tests/spawn-passfds.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (pkgs) lib;
 in
-  helpers.forEachPython packages.preferred ({
+  helpers.forEachPython packages.wasix.preferred ({
     pythonCommands,
     pyVer,
     tag,

--- a/pkgs/overlays/p/python3/tests/subprocess-opts.nix
+++ b/pkgs/overlays/p/python3/tests/subprocess-opts.nix
@@ -3,7 +3,7 @@
   helpers,
   packages,
 }:
-helpers.forEachPython packages.preferred ({
+helpers.forEachPython packages.wasix.preferred ({
   pythonCommands,
   pyVer,
   tag,

--- a/pkgs/overlays/p/python3/wasix.nix
+++ b/pkgs/overlays/p/python3/wasix.nix
@@ -222,7 +222,7 @@
         # ac_sys_system stays WASI. Setup.local forces the modules configure marks n/a.
         postPatch = ''
                   substituteInPlace Lib/subprocess.py \
-                    --replace-fail '${lib.getExe' packages.sameProfile.buildPackages.bashNonInteractive "sh"}' '${lib.getExe' packages.preferred.bash "sh"}'
+                    --replace-fail '${lib.getExe' packages.sameProfile.buildPackages.bashNonInteractive "sh"}' '${lib.getExe' packages.wasix.preferred.bash "sh"}'
 
                   substituteInPlace configure.ac \
                     --replace-fail ' -lwasi-emulated-signal -lwasi-emulated-getpid -lwasi-emulated-process-clocks' \
@@ -356,7 +356,7 @@
             autoSelfMount = true;
             # autoSelfMount only scans bin/*.wasm, but bash is baked into subprocess.py and
             # tzdata into _sysconfigdata (else zoneinfo raises "No time zone found").
-            selfMounts = [packages.preferred.bash packages.sameProfile.buildPackages.tzdata];
+            selfMounts = [packages.wasix.preferred.bash packages.sameProfile.buildPackages.tzdata];
             # Without a bundled CA set, https raises SSLCertVerificationError.
             fs."/etc/ssl" = "${packages.sameProfile.cacert}/etc/ssl";
           };

--- a/pkgs/overlays/t/tinyxml-2.nix
+++ b/pkgs/overlays/t/tinyxml-2.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/overlays/t/toml11.nix
+++ b/pkgs/overlays/t/toml11.nix
@@ -1,3 +1,0 @@
-# nix uses toml11 for TOML parsing.
-{exposeWasixExtendedPackage}:
-exposeWasixExtendedPackage {}

--- a/pkgs/overlays/w/wasinix/tests/cargo-publish.nix
+++ b/pkgs/overlays/w/wasinix/tests/cargo-publish.nix
@@ -17,7 +17,7 @@
         pkgs.gzip
         pkgs.writableTmpDirAsHomeHook
       ];
-      server = packages.preferred.cargo-registry;
+      server = packages.wasix.preferred.cargo-registry;
     } ''
       set -u
       port=8733

--- a/pkgs/overlays/w/wasinix/tests/serve-all.nix
+++ b/pkgs/overlays/w/wasinix/tests/serve-all.nix
@@ -16,7 +16,7 @@
         pkgs.gzip
         pkgs.writableTmpDirAsHomeHook
       ];
-      server = packages.preferred.cargo-registry;
+      server = packages.wasix.preferred.cargo-registry;
       bashWebc = artifacts.webc.bash;
     } ''
       export WASMER_DIR="$PWD/.wasmer"

--- a/pkgs/overlays/x/xz.nix
+++ b/pkgs/overlays/x/xz.nix
@@ -1,1 +1,0 @@
-{exposeWasixExtendedPackage}: exposeWasixExtendedPackage {}

--- a/pkgs/project/default.nix
+++ b/pkgs/project/default.nix
@@ -520,7 +520,7 @@ in rec {
           packageSet = final;
           packages = {
             native = nativeForContext;
-            inherit wasix preferred;
+            wasix = wasix // {inherit preferred;};
             python = python // lib.optionalAttrs (preferredPythonInterpreter != null) {preferred = python.${preferredPythonInterpreter};};
             sameProfile = projectedPackageSet scope variant final;
           };
@@ -656,14 +656,14 @@ in rec {
       harnessesView = harnessesFor callbackArgs;
       runnersView = runnersFor callbackArgs;
       probesView.ifd = nativeRaw.writeText "wasinix-ifd-probe" "ok";
+      preferredPackageSet = lib.genAttrs allWasixNames (name: let
+        profile = preferredProfileNameFor name;
+      in
+        wasixRaw.${profile}.${name});
       packageSetsView = {
         native = nativeRaw;
-        wasix = wasixRaw;
+        wasix = wasixRaw // {preferred = preferredPackageSet;};
         python = pythonRaw;
-        preferred = lib.genAttrs allWasixNames (name: let
-          profile = preferredProfileNameFor name;
-        in
-          wasixRaw.${profile}.${name});
       };
       pythonVariants = {
         all = lib.attrNames pythonSpecs;
@@ -1112,7 +1112,8 @@ in rec {
       in
         projectedPackageFor "wasix" {inherit profile;} wasixRaw.${profile} name wasixRaw.${profile}.${name});
       packageViews = {
-        inherit native wasix preferred;
+        inherit native;
+        wasix = wasix // {inherit preferred;};
         python = python // lib.optionalAttrs (preferredPythonInterpreter != null) {preferred = python.${preferredPythonInterpreter};};
       };
       artifactsView = lib.foldl' lib.recursiveUpdate {} (map (entry:

--- a/pkgs/project/default.nix
+++ b/pkgs/project/default.nix
@@ -49,8 +49,10 @@
     then
       projectLib.loadPackageOverlay ({
           inherit contextFor;
+          definition = declared.definition or null;
           dir = declared.directory;
           expose = declared.expose or [];
+          inherited = declared.inherited or {};
           lane = declared.lane or "packages";
           inherit scope;
         }

--- a/pkgs/project/extension.nix
+++ b/pkgs/project/extension.nix
@@ -2,6 +2,43 @@
   overlays = loadPackageOverlays {
     packages = {
       directory = ../overlays;
+      definition = {
+        file = ./extension.nix;
+        directory = null;
+      };
+      inherited = {
+        brotli = {};
+        bzip2 = {};
+        editline = {};
+        expat = {};
+        giflib = {};
+        jansson = {};
+        lcms2 = {};
+        libb2 = {};
+        libblake3 = {};
+        libdeflate = {};
+
+        # WASIX libc provides iconv; keep the nixpkgs shim rather than GNU libiconv.
+        # The shim ships no archive because the symbols live in libc.
+        libiconv = {};
+
+        libyaml = {};
+        lz4 = {};
+        mpfr = {};
+
+        # nix uses nlohmann_json for JSON handling.
+        nlohmann_json = {};
+
+        oniguruma = {};
+        openjpeg = {};
+        popt = {};
+        tinyxml-2 = {};
+
+        # nix uses toml11 for TOML parsing.
+        toml11 = {};
+
+        xz = {};
+      };
       lane = "packages";
     };
     python = {

--- a/pkgs/project/lib.nix
+++ b/pkgs/project/lib.nix
@@ -542,9 +542,11 @@ in rec {
 
   loadPackageOverlay = {
     contextFor,
+    definition ? null,
     dir,
     extendPackageFor ? extendPackage,
     expose ? [],
+    inherited ? {},
     lane ? "packages",
     scope ? null,
   }: final: prev: let
@@ -582,6 +584,34 @@ in rec {
         };
     instantiate = instantiatePackage;
     discoveredUnits = discoverShardedUnits {inherit dir lane;};
+    inheritedDeclarations =
+      lib.throwIf (!lib.isAttrs inherited || lib.isDerivation inherited)
+      "package directory ${toString dir} has a non-attribute inherited declaration"
+      inherited;
+    inheritedDeclarationNames = lib.attrNames inheritedDeclarations;
+    invalidInheritedDeclarations = lib.attrNames (lib.filterAttrs (_: value: !lib.isAttrs value || lib.isDerivation value) inheritedDeclarations);
+    inheritedUnitConflicts = lib.intersectLists inheritedDeclarationNames (map (unit: unit.name) discoveredUnits);
+    inheritedResult = previous: name:
+      if !(builtins.hasAttr name previous)
+      then throw "${name}: inherited package requires a preceding package"
+      else {
+        ${name} = previous.${name}.overrideAttrs (old: {
+          passthru =
+            (old.passthru or {})
+            // {
+              wasix = ((old.passthru or {}).wasix or {}) // inheritedDeclarations.${name};
+            };
+        });
+      };
+    inheritedResults =
+      lib.optionals (prev.stdenv.hostPlatform.isWasix or false)
+      (map (name: {
+          kind = "inherited";
+          inherit definition;
+          result = inheritedResult prev name;
+          replay = _final: previous: inheritedResult previous name;
+        })
+        inheritedDeclarationNames);
     units =
       lib.filter (
         unit: let
@@ -590,7 +620,7 @@ in rec {
           !(lane == "packages" && wrongHost)
       )
       discoveredUnits;
-    results =
+    discoveredResults =
       map (unit: {
         inherit (unit) kind;
         definition = {
@@ -600,11 +630,12 @@ in rec {
         replay = instantiate unit;
       })
       units;
+    results = inheritedResults ++ discoveredResults;
     packages = builtins.foldl' mergeDisjoint {} (map (item: item.result) results);
     completeNames = lib.concatMap (item: lib.optionals (item.kind == "package") (lib.attrNames item.result)) results;
-    inheritedNames = lib.subtractLists (lib.attrNames packages) (expose ++ completeNames);
-    missingInherited = lib.filter (name: !(builtins.hasAttr name prev)) inheritedNames;
-    inherited = lib.genAttrs inheritedNames (name: prev.${name});
+    precedingNames = lib.subtractLists (lib.attrNames packages) (expose ++ completeNames);
+    missingPreceding = lib.filter (name: !(builtins.hasAttr name prev)) precedingNames;
+    preceding = lib.genAttrs precedingNames (name: prev.${name});
     unitOverlays = builtins.foldl' (state: item:
       state
       // lib.genAttrs (lib.attrNames item.result) (_: {
@@ -613,9 +644,13 @@ in rec {
       })) {}
     results;
   in
-    lib.throwIf (missingInherited != [])
-    "package directory ${toString dir} exposes missing preceding package(s): ${lib.concatStringsSep ", " missingInherited}"
-    (inherited // packages // {${unitOverlaysAttr} = unitOverlays;});
+    lib.throwIf (invalidInheritedDeclarations != [])
+    "package directory ${toString dir} has invalid inherited declaration(s): ${lib.concatStringsSep ", " invalidInheritedDeclarations}"
+    (lib.throwIf (inheritedUnitConflicts != [])
+      "package directory ${toString dir} declares inherited package unit(s): ${lib.concatStringsSep ", " inheritedUnitConflicts}"
+      (lib.throwIf (missingPreceding != [])
+        "package directory ${toString dir} exposes missing preceding package(s): ${lib.concatStringsSep ", " missingPreceding}"
+        (preceding // packages // {${unitOverlaysAttr} = unitOverlays;})));
 
   registerOverlay = {
     definition ? null,

--- a/pkgs/project/profiles.nix
+++ b/pkgs/project/profiles.nix
@@ -28,7 +28,7 @@ rec {
 
   # Default profile for shipped binaries and the library matrix. A package that
   # needs a different profile declares it via passthru.wasix; the project
-  # constructor reads that to build packages.preferred.
+  # constructor reads that to build packages.wasix.preferred.
   defaultProfileName = "exnrefEh";
 
   # The {eh, pic, exnref} encoding of each profile, which wasix-libc's

--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -102,7 +102,7 @@
     (lib.filterAttrs (_: package: (package.passthru.wasinix.source or null) == source) packages);
   updateCandidates =
     packagesFrom "packages.native" project.packages.native
-    // packagesFrom "packages.wasix" project.packages.preferred
+    // packagesFrom "packages.wasix" project.packages.wasix.preferred
     // lib.optionalAttrs (project.packages.python ? preferred)
     (packagesFrom "packages.python.preferred" project.packages.python.preferred);
   commandDrvsOf = lib.concatMap (value:

--- a/pkgs/project/selectors.nix
+++ b/pkgs/project/selectors.nix
@@ -13,7 +13,7 @@
       lib.intersectLists (entry.packageSubjects or [entry.address]) subjects != [])
     (builtins.attrValues catalog)));
   nativeSubjects = names: map (name: "packages.native.${name}") names;
-  pandocSubjects = map (profile: "packages.wasix.${profile}.pandoc") (builtins.attrNames project.packages.wasix);
+  pandocSubjects = map (profile: "packages.wasix.${profile}.pandoc") (builtins.attrNames project.internals.packageSets.wasixRaw);
   toolchainNames = [
     "cargo-wasix"
     "cargo-wasix-unwrapped"

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -913,12 +913,12 @@
     result = pythonArtifactModule.registryArtifact {
       catalog.entries = {};
       packages = {
-        preferred = lib.mapAttrs' (_: interpreterPackage:
+        wasix.preferred = lib.mapAttrs' (_: interpreterPackage:
           lib.nameValuePair interpreterPackage (webcFor interpreterPackage))
         interpreterPackages;
         python = lib.genAttrs (lib.attrNames interpreterPackages) (_: {});
       };
-      packageSets.preferred = lib.mapAttrs' (_: interpreterPackage:
+      packageSets.wasix.preferred = lib.mapAttrs' (_: interpreterPackage:
         lib.nameValuePair interpreterPackage (runtimeFor interpreterPackage))
       interpreterPackages;
       pythonVariants = {
@@ -1311,15 +1311,19 @@ in {
       inherit (project) schemaVersion;
       nativeNames = lib.attrNames project.packages.native;
       nativeInterfaceName = project.packages.native.core.profiles.default.package.name;
+      wasixViewNames = lib.attrNames project.packages.wasix;
+      topLevelPreferredAbsent = !(project.packages ? preferred);
       defaultNames = lib.attrNames project.packages.wasix.default;
       alternateNames = lib.attrNames project.packages.wasix.alternate;
       coreSource = project.packages.wasix.default.core.passthru.wasinix.source;
       coreLineage = project.packages.wasix.default.core.passthru.wasinix.lineage;
-      preferredProfile = project.packages.preferred.core.name;
-      limitedPreferred = project.packages.preferred.limited.name;
+      preferredProfile = project.packages.wasix.preferred.core.name;
+      limitedPreferred = project.packages.wasix.preferred.limited.name;
       consumerName = project.packages.wasix.alternate.consumer.name;
       inheritedDependencyName = project.packages.wasix.default.uses-inherited.name;
       focusedHelper = project.packages.wasix.default.uses-inherited.passthru.usedFocusedHelper;
+      preferredPackageSetName = project.packages.wasix.default.uses-inherited.passthru.preferredPackageSetName;
+      topLevelPreferredPackageSetAbsent = project.packages.wasix.default.uses-inherited.passthru.topLevelPreferredPackageSetAbsent;
       runnerContextName = project.packages.wasix.default.uses-inherited.passthru.runnerContextName;
       runnerName = project.runners.rawWasm.unbound.name;
       pythonHarnessAvailable = project.harnesses ? python;
@@ -1331,7 +1335,7 @@ in {
       pythonContextName = project.packages.python.py.contextProof.name;
       repairedPythonModules = pythonRepairProject.packages.python.py.repairPython.passthru.requiredPythonModules;
       wasixHistoryVersion = project.packages.wasix.default.core.versions."0.9".version;
-      preferredHistoryVersion = project.packages.preferred.core.versions."0.9".version;
+      preferredHistoryVersion = project.packages.wasix.preferred.core.versions."0.9".version;
       pythonHistoryVersion = project.packages.python.py.inheritedPython.versions."0.8".version;
       historyDependencyVersion = project.packages.python.py.inheritedPython.versions."0.8".passthru.wasinix.historyDependency;
       currentTransformed = project.packages.wasix.default.core.passthru.transformed;
@@ -1410,6 +1414,8 @@ in {
       schemaVersion = 1;
       nativeNames = ["broken" "ciNarrow" "consumer" "core" "dot.name" "limited" "topOwned" "uses-inherited"];
       nativeInterfaceName = "core";
+      wasixViewNames = ["alternate" "default" "preferred"];
+      topLevelPreferredAbsent = true;
       defaultNames = ["broken" "ciNarrow" "consumer" "core" "dot.name" "topOwned" "uses-inherited"];
       alternateNames = ["broken" "ciNarrow" "consumer" "core" "dot.name" "limited" "topOwned" "uses-inherited"];
       coreSource = "consumer";
@@ -1419,6 +1425,8 @@ in {
       consumerName = "consumer-alternate";
       inheritedDependencyName = "uses-inherited";
       focusedHelper = true;
+      preferredPackageSetName = "core";
+      topLevelPreferredPackageSetAbsent = true;
       runnerContextName = "raw-wasm-unbound";
       runnerName = "raw-wasm-unbound";
       pythonHarnessAvailable = true;

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -94,11 +94,22 @@
     projectLib.loadPackageOverlay {
       inherit contextFor;
       dir = ./tests/units;
+      inherited.dependency.supportedProfiles = ["eh"];
       lane = "packages";
     }
     final
     wasixPrev;
   loaded = removeAttrs loadedRaw [projectLib.unitOverlaysAttr];
+  replayedInherited = loadedRaw.${projectLib.unitOverlaysAttr}.dependency.overlay final wasixPrev;
+  nativeInherited =
+    projectLib.loadPackageOverlay {
+      inherit contextFor;
+      dir = ./tests/units;
+      inherited.dependency = {};
+      lane = "packages";
+    }
+    final
+    (prev // {stdenv.hostPlatform.isWasix = false;});
   discoveredUnits = projectLib.discoverShardedUnits {
     dir = ./tests/units;
     lane = "packages";
@@ -126,6 +137,33 @@
       inherit contextFor;
       dir = ./tests/units;
       expose = ["missing"];
+      lane = "packages";
+    }
+    final
+    wasixPrev;
+  missingInherited =
+    projectLib.loadPackageOverlay {
+      inherit contextFor;
+      dir = ./tests/units;
+      inherited.missing = {};
+      lane = "packages";
+    }
+    final
+    wasixPrev;
+  conflictingInherited =
+    projectLib.loadPackageOverlay {
+      inherit contextFor;
+      dir = ./tests/units;
+      inherited.existing = {};
+      lane = "packages";
+    }
+    final
+    wasixPrev;
+  invalidInherited =
+    projectLib.loadPackageOverlay {
+      inherit contextFor;
+      dir = ./tests/units;
+      inherited.dependency = true;
       lane = "packages";
     }
     final
@@ -1064,6 +1102,9 @@ in {
       names = lib.attrNames loaded;
       existingInputs = map (package: package.name) loaded.existing.buildInputs;
       existingPolicy = loaded.existing.passthru.wasinix.test;
+      inheritedProfiles = loaded.dependency.passthru.wasix.supportedProfiles;
+      replayedInheritedProfiles = replayedInherited.dependency.passthru.wasix.supportedProfiles;
+      inheritedAbsentFromNative = !(nativeInherited ? dependency);
       replayNames = lib.attrNames loadedRaw.${projectLib.unitOverlaysAttr};
       fileUnitDirectory = toString (lib.findFirst (unit: unit.name == "existing") null discoveredUnits).directory;
       directoryUnitDirectory = toString (lib.findFirst (unit: unit.name == "family") null discoveredUnits).directory;
@@ -1072,15 +1113,21 @@ in {
       inherit topLevelPackageFiles;
       exposed = exposedUnits.dependency.name;
       missingExposureFails = !(force missingExposure).success;
+      missingInheritedFails = !(force missingInherited).success;
+      conflictingInheritedFails = !(force conflictingInherited).success;
+      invalidInheritedFails = !(force invalidInherited).success;
       wasmRename = lib.hasInfix "tool.wasm" (projectLib.wasmRename {wasmName = "tool";} (mkPackage {name = "tool";})).postInstall;
       buildEditSupersedesPyPI = pythonBuildEdit.passthru.wasinix.publication.supersedesPyPI;
       testEditSupersedesPyPI = pythonTestEdit.passthru.wasinix.publication.supersedesPyPI or false;
     };
     expected = {
-      names = ["complete" "existing" "family-a" "family-b" "new"];
+      names = ["complete" "dependency" "existing" "family-a" "family-b" "new"];
       existingInputs = ["dependency"];
       existingPolicy = true;
-      replayNames = ["complete" "existing" "family-a" "family-b" "new"];
+      inheritedProfiles = ["eh"];
+      replayedInheritedProfiles = ["eh"];
+      inheritedAbsentFromNative = true;
+      replayNames = ["complete" "dependency" "existing" "family-a" "family-b" "new"];
       fileUnitDirectory = toString ./tests/units/e/existing;
       directoryUnitDirectory = toString ./tests/units/f/family;
       completeUnitDirectory = toString ./tests/units/c/complete;
@@ -1088,6 +1135,9 @@ in {
       topLevelPackageFiles = [];
       exposed = "dependency";
       missingExposureFails = true;
+      missingInheritedFails = true;
+      conflictingInheritedFails = true;
+      invalidInheritedFails = true;
       wasmRename = true;
       buildEditSupersedesPyPI = true;
       testEditSupersedesPyPI = false;

--- a/pkgs/project/tests/project-units/u/uses-inherited/package.nix
+++ b/pkgs/project/tests/project-units/u/uses-inherited/package.nix
@@ -1,6 +1,7 @@
 {
   dropInputsByName,
   exposePackage,
+  packageSets,
   packages,
   profileSets,
   runners,
@@ -9,6 +10,8 @@ exposePackage (packages.sameProfile.inherited.overrideAttrs (_: {
   name = "uses-inherited";
   passthru = {
     usedFocusedHelper = dropInputsByName ["dependency"] [packages.sameProfile.dependency] == [];
+    preferredPackageSetName = packageSets.wasix.preferred.core.name;
+    topLevelPreferredPackageSetAbsent = !(packageSets ? preferred);
     runnerContextName = runners.rawWasm.unbound.name;
     profileNames = profileSets.all;
   };

--- a/pkgs/python-overlays/d/dbt-core-experimental-parser.nix
+++ b/pkgs/python-overlays/d/dbt-core-experimental-parser.nix
@@ -9,7 +9,7 @@
 }:
 exposePackage (
   let
-    engine = packages.preferred.dbt-sa-cli;
+    engine = packages.wasix.preferred.dbt-sa-cli;
     # PEP 440 spelling of the engine's 2.0.0-alpha.5, which is what dbt-core's
     # `>=2.0.0a4` resolves against.
     version = "2.0.0a5";

--- a/pkgs/python-overlays/d/duckdb.nix
+++ b/pkgs/python-overlays/d/duckdb.nix
@@ -17,7 +17,7 @@ exposePackage (
       then package
       else
         package.override {
-          duckdb = packages.preferred.duckdb.versions.${package.version};
+          duckdb = packages.wasix.preferred.duckdb.versions.${package.version};
         };
   in
     extendPackage wheel {

--- a/pkgs/python-overlays/p/pyarrow/package.nix
+++ b/pkgs/python-overlays/p/pyarrow/package.nix
@@ -17,8 +17,8 @@
   isHistory = (package.passthru.wasix.historySpec or null) != null;
   arrowCpp =
     if isHistory
-    then packages.preferred.arrow-cpp.versions.${version}
-    else packages.preferred.arrow-cpp;
+    then packages.wasix.preferred.arrow-cpp.versions.${version}
+    else packages.wasix.preferred.arrow-cpp;
   # Before 24, setup.py reads PYARROW_CMAKE_OPTIONS and PYARROW_WITH_*.
   # Newer releases read the equivalent CMake variables.
   preSkbuild = lib.versionOlder version "24";

--- a/pkgs/python-overlays/p/pypandoc-binary.nix
+++ b/pkgs/python-overlays/p/pypandoc-binary.nix
@@ -20,7 +20,7 @@ exposePackage (
       # cross-build); drop the check.
       substituteInPlace setup.py \
         --replace-fail "setup_requires=pypandoc.__setup_requires__," ""
-      install -Dm755 ${packages.sameProfile.lib.getExe' packages.preferred.pandoc "pandoc.wasm"} pypandoc/files/pandoc
+      install -Dm755 ${packages.sameProfile.lib.getExe' packages.wasix.preferred.pandoc "pandoc.wasm"} pypandoc/files/pandoc
     '';
   }
 )

--- a/spot.nix
+++ b/spot.nix
@@ -17,7 +17,7 @@
   baseNative = baseProject.internals.packageSets.nativeRaw;
   baseByProfile = baseProject.internals.packageSets.wasixRaw;
   nativeNames = builtins.attrNames baseProject.packages.native;
-  packageNames = lib.unique (lib.concatMap builtins.attrNames (builtins.attrValues baseProject.packages.wasix));
+  packageNames = lib.unique (lib.concatMap builtins.attrNames (builtins.attrValues baseByProfile));
   defaultSources = lib.filter (address: builtins.hasAttr address workProject.ci.catalog.packages) workProject.ci.catalog.selectors.groups.toolchain.jobs;
   sourceAddresses =
     if sources == null

--- a/tools/wasinix/src/update/history.rs
+++ b/tools/wasinix/src/update/history.rs
@@ -130,7 +130,7 @@ fn wheel_path(attr: &str) -> Result<String> {
 fn cli_map() -> Result<BTreeMap<String, String>> {
     let packages = eval(
         &Flake::default(),
-        "packages.preferred",
+        "packages.wasix.preferred",
         Some(
             "builtins.mapAttrs (_: p: { aliases = p.passthru.wasinix.aliases or []; shipped = p.passthru.wasinix.shipped or false; })",
         ),
@@ -237,7 +237,7 @@ impl Sets {
         Ok(Target {
             attr: attr.clone(),
             path: format!(
-                "packages.preferred.{}",
+                "packages.wasix.preferred.{}",
                 crate::support::naming::quoted_attr(attr)?
             ),
             history: cli_history(repo),

--- a/tools/wasinix/src/update/retention.rs
+++ b/tools/wasinix/src/update/retention.rs
@@ -104,7 +104,7 @@ fn version_apply(include_notes: bool) -> String {
         "{ ok = true; value = {}; }"
     };
     format!(
-        "p: {{ wheels = {{ py313 = ({WHEEL_APPLY}) p.artifacts.wheel-py313; py314 = ({WHEEL_APPLY}) p.artifacts.wheel-py314; }}; clis = ({}) p.packages.preferred; notes = {notes}; }}",
+        "p: {{ wheels = {{ py313 = ({WHEEL_APPLY}) p.artifacts.wheel-py313; py314 = ({WHEEL_APPLY}) p.artifacts.wheel-py314; }}; clis = ({}) p.packages.wasix.preferred; notes = {notes}; }}",
         cli_apply()
     )
 }
@@ -370,7 +370,7 @@ mod tests {
             "let p = {{ \
              artifacts.wheel-py313.demo = {{ version = \"1\"; passthru.wasinix.retention = \"minor\"; }}; \
              artifacts.wheel-py314 = {{}}; \
-             packages.preferred.cli = {{ version = \"2\"; passthru.wasinix = {{ shipped = true; retention = \"major\"; }}; }}; \
+             packages.wasix.preferred.cli = {{ version = \"2\"; passthru.wasinix = {{ shipped = true; retention = \"major\"; }}; }}; \
              internals.repository.updates.updateNotes.versions.cli = \"2\"; \
              }}; in ({}) p",
             version_apply(true)


### PR DESCRIPTION
## Context

The preferred WASIX projection belongs with the profile views it selects from. Packages that use their preceding nixpkgs derivation unchanged also need a declarative registration path instead of one empty overlay file per package.

## Impact

The structured API moves `packages.preferred` and `packageSets.preferred` to `packages.wasix.preferred` and `packageSets.wasix.preferred`. The 21 unchanged WASIX packages are now declared through the extension package lane `inherited` attrset; their derivation paths are unchanged.

## Behavior checked

Project API evaluation covers nested preferred views, inherited-package compatibility metadata, replay, native exclusion, and malformed, missing, and conflicting declarations. Direct evaluation found all 21 inherited packages in the WASIX view and catalog with `wasinix` provenance, and their `eh` derivation paths exactly matched the base revision.