### PR TITLE
update: cache project state by tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,12 +195,19 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           RUN_DIR: ${{ steps.run.outputs.runDir }}
+          RUN_OUTCOME: ${{ steps.run.outcome }}
         run: |
           if [ -z "$AWS_ACCESS_KEY_ID" ]; then
             echo "no credentials; skipping"
             exit 0
           fi
-          nix run .#ci -- publish --run-dir "$RUN_DIR" --baseline
+          update_snapshot=()
+          if [ "$GITHUB_EVENT_NAME" = push ] && \
+            [ "$GITHUB_REF_NAME" = main ] && [ "$RUN_OUTCOME" = success ]; then
+            update_snapshot=(--update-snapshot)
+          fi
+          nix run .#ci -- publish --run-dir "$RUN_DIR" --baseline \
+            "${update_snapshot[@]}"
 
       - name: Collect durable runs
         id: collect

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,6 +17,10 @@ on:
         description: "--base: the branch the PRs target (blank = this ref)"
         required: false
         default: ""
+      jobs:
+        description: "Maximum updates running at once"
+        required: false
+        default: "4"
 
 permissions:
   contents: write
@@ -43,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.UPDATE_PR_TOKEN || github.token }}
           TARGETS: ${{ github.event.inputs.targets }}
           BASE: ${{ github.event.inputs.base }}
+          JOBS: ${{ github.event.inputs.jobs || 4 }}
         run: |
           targets=()
           if [ -n "$TARGETS" ]; then
@@ -50,5 +55,5 @@ jobs:
           else
             targets=(--all)
           fi
-          nix run .#update -- "${targets[@]}" --pr --jobs 4 \
+          nix run .#update -- "${targets[@]}" --pr --jobs "$JOBS" \
             --base "${BASE:-$GITHUB_REF_NAME}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,9 @@ one is a compile error or a test failure, not a review comment.
   machine-output exit. `Effects{Apply,DryRun}` gates every outward writer at the
   write itself.
 - `cli/update.rs::MutationMode` + `conclude`: every tree mutation's flags and
-  exit; `update/managed.rs` is the managed-PR record.
+  exit; `update/managed.rs` is the managed-PR record, and `update/snapshot.rs`
+  is the typed, tree-keyed Nix view shared by discovery, preflight, hooks, and
+  retention.
 - `cargo-registry-wire`: the Cargo publish payload and sparse-index record come
   from one normalized-manifest translation. The narrow crate is also the
   derivation-facing binary, so foundational checks never depend on the main CLI.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,6 +47,8 @@ Python set or which package owners make up the C toolchain group.
 The CLI checks `schemaVersion` before interpreting those facts. It resolves
 aliases, omitted profile axes, globs, named sets and groups, unions, and tag
 gates, then requests the exact resulting job addresses from Nix in one batch.
+The evaluation-input phase persists the selector catalog and authoritative job
+evaluation reads that file, so a case evaluates the catalog only once.
 Historical jobs remain cataloged and are tagged `history-tests`; selecting one
 without enabling that tag is an error rather than a silent omission.
 
@@ -133,7 +135,9 @@ blocked under every policy. A directly selected failure is always red.
 A run directory dies with its runner, so the times a main build measures are
 published: per-job build seconds and per-task wall time ride the eval map
 (`eval-maps/<tree>.json`, keyed by git tree), and the workflow's own step
-durations go to `step-timings/<rev>.json`.
+durations go to `step-timings/<rev>.json`. Successful main builds also attach
+the update snapshot described in [`updating.md`](updating.md); pull requests do
+not pay for that projection.
 
 ```sh
 wasinix timings --runs 100 [--by job|task|step|rev]

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -77,7 +77,8 @@ weekly on one runner. `wasinix update --all --pr` discovers the targets once and
 runs a bounded number concurrently in isolated worktrees. Each moved target
 still owns one `auto/update-<target>` branch and PR, and one failure does not
 stop the others. A manual dispatch with `targets` selects targets; `--jobs`
-controls the worker bound.
+controls the worker bound. The workflow exposes the same bound as its `jobs`
+input so concurrency experiments do not require workflow edits.
 
 Update PRs the bot opens are managed: the PR body records the recipe that
 generated the branch and the head the bot last wrote (a
@@ -98,6 +99,12 @@ The served-version tables are maintained under the `versions` noun:
 `versions add <package>@<version>` (or `--per-major`/`--per-minor` in bulk)
 backfills registry history, `versions import <lockfile>` pins what a lockfile
 declares, and `versions bump <package>` bumps a publication release counter.
+
+Target discovery, post-update hooks, note priors, and served versions come from
+one typed project snapshot. A successful main build publishes that snapshot in
+the tree-keyed eval map. An update on the same clean tree reuses it; a cache
+miss or a changed checkout evaluates the snapshot once. Batch workers receive
+the same preflight document, so increasing `--jobs` does not repeat discovery.
 
 Things to check on a bump are declared as `passthru.wasinix.update.notes`
 (`pkgs/lib/default.nix`) and surface in the PR body. Toolchain and nixpkgs bumps

--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -205,6 +205,50 @@
       else {};
   in
     lib.concatMapAttrs hookFor updateCandidates;
+  currentOwnedEntries = entriesMatching (entry: entry.instance.kind == "current");
+  servedValue = history_spec: entry: {
+    version = toString entry.instance.version;
+    inherit history_spec;
+    retention = entry.policy.retention or null;
+  };
+  uniqueServed = kind: historySpec: entries: let
+    values = lib.unique (map (servedValue historySpec) entries);
+  in
+    lib.throwIf (lib.length values != 1)
+    "current ${kind} entries disagree on served-version metadata"
+    (builtins.head values);
+  wheelEntries = lib.filter (entry:
+    entry.kind
+    == "artifact"
+    && lib.hasPrefix "wheel-" entry.artifactKind)
+  currentOwnedEntries;
+  cliEntries = lib.filter (entry:
+    entry.kind
+    == "package"
+    && entry.scope == "wasix"
+    && entry.preferred
+    && (entry.policy.shipped or false))
+  currentOwnedEntries;
+  servedVersions = {
+    wheel = lib.mapAttrs (name: entries:
+      uniqueServed "wheel ${name}" "packages.python.${name}" entries)
+    (lib.groupBy (entry: entry.name) wheelEntries);
+    cli = lib.mapAttrs (name: entries:
+      uniqueServed "CLI ${name}" "packages.wasix.${name}" entries)
+    (lib.groupBy (entry: entry.name) cliEntries);
+  };
+  noteVersions = builtins.tryEval updateNotes.versions;
+  updateSnapshot = {
+    schemaVersion = 1;
+    inherit postUpdateHooks servedVersions updateScripts;
+    notes = {
+      ok = noteVersions.success;
+      value =
+        if noteVersions.success
+        then noteVersions.value
+        else {};
+    };
+  };
 in {
   inherit root source;
   revisions = builtins.fromJSON (builtins.readFile revisionsFile);
@@ -220,5 +264,6 @@ in {
   };
   updates = {
     inherit postUpdateHooks updateNotes updateScripts;
+    snapshot = updateSnapshot;
   };
 }

--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -102,7 +102,7 @@
     (lib.filterAttrs (_: package: (package.passthru.wasinix.source or null) == source) packages);
   updateCandidates =
     packagesFrom "packages.native" project.packages.native
-    // packagesFrom "packages.wasix" project.packages.wasix.preferred
+    // packagesFrom "packages.wasix.preferred" project.packages.wasix.preferred
     // lib.optionalAttrs (project.packages.python ? preferred)
     (packagesFrom "packages.python.preferred" project.packages.python.preferred);
   commandDrvsOf = lib.concatMap (value:

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -54,7 +54,45 @@
         python = {};
       };
       artifacts = {};
-      catalog.entries = {};
+      catalog.entries = {
+        "artifacts.wheel-py313.demo" = {
+          kind = "artifact";
+          artifactKind = "wheel-py313";
+          name = "demo";
+          source = "fixture";
+          instance = {
+            kind = "current";
+            version = "3";
+          };
+          policy.retention = "minor";
+        };
+        "artifacts.wheel-py313.demo.versions.\"2\"" = {
+          kind = "artifact";
+          artifactKind = "wheel-py313";
+          name = "demo";
+          source = "fixture";
+          instance = {
+            kind = "history";
+            version = "2";
+          };
+          policy.retention = "minor";
+        };
+        "packages.wasix.default.cli" = {
+          kind = "package";
+          name = "cli";
+          source = "fixture";
+          scope = "wasix";
+          preferred = true;
+          instance = {
+            kind = "current";
+            version = "1";
+          };
+          policy = {
+            shipped = true;
+            retention = "major";
+          };
+        };
+      };
     };
   };
   repositoryHooks = repository.updates.postUpdateHooks;
@@ -1508,6 +1546,11 @@ in {
       postUpdateCommand = repositoryHooks."packages.native.command";
       postUpdateSync = repositoryHooks."packages.native.sync";
       updateScriptNames = lib.attrNames repositoryScripts;
+      updateSnapshot = {
+        inherit (repository.updates.snapshot) schemaVersion servedVersions;
+        hookNames = lib.attrNames repository.updates.snapshot.postUpdateHooks;
+        scriptNames = lib.attrNames repository.updates.snapshot.updateScripts;
+      };
     };
     expected = {
       schemaVersion = 1;
@@ -1723,6 +1766,23 @@ in {
         version = "2";
       };
       updateScriptNames = ["packages.wasix.preferred.cli"];
+      updateSnapshot = {
+        schemaVersion = 1;
+        servedVersions = {
+          cli.cli = {
+            version = "1";
+            history_spec = "packages.wasix.cli";
+            retention = "major";
+          };
+          wheel.demo = {
+            version = "3";
+            history_spec = "packages.python.demo";
+            retention = "minor";
+          };
+        };
+        hookNames = ["packages.native.command" "packages.native.sync"];
+        scriptNames = ["packages.wasix.preferred.cli"];
+      };
     };
   };
 }

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -22,35 +22,43 @@
         update = {inherit post;};
       };
     };
-  repositoryHooks =
-    (import ./repository.nix {
-      inherit lib;
-      root = ../..;
-      source = "fixture";
-      revisionsFile = ../../release-revisions.json;
-      project = {
-        packages = {
-          native = {
-            command = hookPackage "command" "1" ["./hook"];
-            sync = hookPackage "sync" "2" {
-              syncAttrList = {
-                input = "nixpkgs";
-                attrPath = "legacyPackages.\${system}";
-                match = "^icu([0-9]+)$";
-                capture = 1;
-                probe = "version";
-                sort = "numeric";
-                destination = "versions.nix";
-              };
+  repository = import ./repository.nix {
+    inherit lib;
+    root = ../..;
+    source = "fixture";
+    revisionsFile = ../../release-revisions.json;
+    project = {
+      packages = {
+        native = {
+          command = hookPackage "command" "1" ["./hook"];
+          sync = hookPackage "sync" "2" {
+            syncAttrList = {
+              input = "nixpkgs";
+              attrPath = "legacyPackages.\${system}";
+              match = "^icu([0-9]+)$";
+              capture = 1;
+              probe = "version";
+              sort = "numeric";
+              destination = "versions.nix";
             };
           };
-          wasix.preferred = {};
-          python = {};
         };
-        artifacts = {};
-        catalog.entries = {};
+        wasix.preferred.cli = mkPackage {
+          name = "cli";
+          version = "1";
+          passthru = {
+            updateScript = ["./update"];
+            wasinix.source = "fixture";
+          };
+        };
+        python = {};
       };
-    }).updates.postUpdateHooks;
+      artifacts = {};
+      catalog.entries = {};
+    };
+  };
+  repositoryHooks = repository.updates.postUpdateHooks;
+  repositoryScripts = repository.updates.updateScripts;
 
   dependency = mkPackage {name = "dependency";};
   previous = mkPackage {
@@ -1499,6 +1507,7 @@ in {
       projectTestSerializable = !(projectTestProject.ci.catalog.jobs."tests.project.format" ? check);
       postUpdateCommand = repositoryHooks."packages.native.command";
       postUpdateSync = repositoryHooks."packages.native.sync";
+      updateScriptNames = lib.attrNames repositoryScripts;
     };
     expected = {
       schemaVersion = 1;
@@ -1713,6 +1722,7 @@ in {
         };
         version = "2";
       };
+      updateScriptNames = ["packages.wasix.preferred.cli"];
     };
   };
 }

--- a/tools/wasinix/src/ci/baseline.rs
+++ b/tools/wasinix/src/ci/baseline.rs
@@ -105,6 +105,7 @@ pub fn publish_from_run(
     run_dir: &Path,
     case_id: &str,
     effects: crate::support::effects::Effects,
+    update: Option<(&str, &crate::update::snapshot::Snapshot)>,
 ) -> Result<()> {
     let paths = crate::ci::prepare::case_dir(run_dir, case_id);
     let eval_map = crate::ci::prepare::eval_map_path(&paths);
@@ -148,13 +149,16 @@ pub fn publish_from_run(
             .unwrap_or_default();
     junits.sort();
     let coverage: Vec<JobAddr> = status.keys().cloned().collect();
-    let document = publish_document(
+    let mut document = publish_document(
         &mapping,
         &status,
         &coverage,
         &crate::ci::facts::metrics(&junits).build_seconds,
         &task_timings(run_dir, case_id),
     );
+    if let Some((_, snapshot)) = update.filter(|(tree, _)| *tree == manifest.tree) {
+        document.update_snapshot = Some(snapshot.clone());
+    }
     let scratch = crate::support::fs::Scratch::create("wasinix-baseline")?;
     let file = scratch.path().join("eval-map.json");
     crate::support::schema::write(&file, &document)?;

--- a/tools/wasinix/src/ci/evalmap.rs
+++ b/tools/wasinix/src/ci/evalmap.rs
@@ -246,10 +246,8 @@ pub struct EvalMap {
     pub groups: BTreeMap<String, SelectorGroup>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub sources: BTreeMap<String, Vec<String>>,
-    /// Update-note versions as of this evaluation; a later run diffs against
-    /// them to decide which notes fired.
-    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
-    pub note_versions: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_snapshot: Option<crate::update::snapshot::Snapshot>,
     /// Per-job status, present only on a published baseline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<StatusMap>,

--- a/tools/wasinix/src/ci/exec.rs
+++ b/tools/wasinix/src/ci/exec.rs
@@ -111,6 +111,29 @@ mod artifact_tests {
         let scan = ["tree_", "bytes("].concat();
         assert!(!source.contains(&scan));
     }
+
+    #[test]
+    fn authoritative_evaluation_reuses_the_input_catalog() {
+        let source = include_str!("exec.rs");
+        let input = source
+            .split("\nfn eval_inputs(")
+            .nth(1)
+            .unwrap()
+            .split("pub(crate) fn selector_catalog(")
+            .next()
+            .unwrap();
+        let evaluation = source
+            .split("\nfn evaluate(")
+            .nth(1)
+            .unwrap()
+            .split("/// Resolve a spot case")
+            .next()
+            .unwrap();
+        assert!(input.contains("selector_catalog_path"));
+        assert!(input.contains("support::json::write"));
+        assert!(evaluation.contains("selector_catalog_path"));
+        assert!(!evaluation.contains("selector_catalog(worktree"));
+    }
 }
 
 /// The tail of a log as fragment content. The full file stays in the run
@@ -146,7 +169,11 @@ fn eval_inputs(
     let case_id = case.case_id();
     let logs = crate::ci::prepare::logs_dir(&case_dir(ctx.run_dir, case_id)).join("eval-inputs");
     let attr = format!("path:.#{}", crate::support::nix::project_attr("ci.jobs"));
-    let catalog = selector_catalog(worktree, route)?.into_map();
+    let selector_catalog = selector_catalog(worktree, route)?;
+    let catalog_path = crate::ci::prepare::selector_catalog_path(&case_dir(ctx.run_dir, case_id));
+    crate::support::json::write(&catalog_path, &selector_catalog)?;
+    artifacts.record(&catalog_path)?;
+    let catalog = selector_catalog.into_map();
     let selected: Vec<String> = crate::ci::compare::selected(case, &catalog)?
         .into_iter()
         .collect();
@@ -264,7 +291,10 @@ fn evaluate(
     let case_id = case.case_id();
     let maps = crate::ci::prepare::maps_dir(&case_dir(ctx.run_dir, case_id));
     let attr = format!("path:.#{}", crate::support::nix::project_attr("ci.jobs"));
-    let catalog = selector_catalog(worktree, route)?.into_map();
+    let catalog: crate::ci::evalmap::SelectorCatalog = crate::support::json::read(
+        &crate::ci::prepare::selector_catalog_path(&case_dir(ctx.run_dir, case_id)),
+    )?;
+    let catalog = catalog.into_map();
     let selected: Vec<String> = crate::ci::compare::selected(case, &catalog)?
         .into_iter()
         .collect();

--- a/tools/wasinix/src/ci/prepare.rs
+++ b/tools/wasinix/src/ci/prepare.rs
@@ -47,6 +47,10 @@ pub fn eval_map_path(case: &Path) -> PathBuf {
     maps_dir(case).join("eval-map.json")
 }
 
+pub fn selector_catalog_path(case: &Path) -> PathBuf {
+    maps_dir(case).join("selector-catalog.json")
+}
+
 pub fn eval_jobs_path(case: &Path) -> PathBuf {
     maps_dir(case).join("eval-jobs.jsonl")
 }

--- a/tools/wasinix/src/cli/mod.rs
+++ b/tools/wasinix/src/cli/mod.rs
@@ -431,6 +431,9 @@ pub enum CiCommand {
         /// Publish every built case's eval map for future reuse
         #[arg(long)]
         baseline: bool,
+        /// Attach the current tree's update state to its published eval map
+        #[arg(long, requires = "baseline")]
+        update_snapshot: bool,
         /// Publish the comment as a reply keyed to this command comment
         /// instead of the sticky report
         #[arg(long)]
@@ -1556,6 +1559,7 @@ fn ci_command(command: CiCommand) -> Result<CommandStatus> {
             check,
             step_summary,
             baseline,
+            update_snapshot,
             reply_to,
             untrusted,
             watch,
@@ -1574,6 +1578,14 @@ fn ci_command(command: CiCommand) -> Result<CommandStatus> {
                 // materialized trees, so heads and bases alike serve later
                 // runs. A case adopted from a published map is already there.
                 let loaded = crate::ci::prepare::load(&run_dir)?;
+                let cached_update = if update_snapshot {
+                    Some((
+                        crate::support::git::git(&repo, &["rev-parse", "HEAD^{tree}"])?,
+                        crate::update::snapshot::evaluate(&repo)?,
+                    ))
+                } else {
+                    None
+                };
                 for case in loaded.request.cases() {
                     let id = case.case_id();
                     if !matches!(case, crate::ci::types::CaseRef::Build(_)) {
@@ -1582,7 +1594,14 @@ fn ci_command(command: CiCommand) -> Result<CommandStatus> {
                     if loaded.preparation.reused.iter().any(|reused| reused == id) {
                         continue;
                     }
-                    crate::ci::baseline::publish_from_run(&run_dir, id, effects)?;
+                    crate::ci::baseline::publish_from_run(
+                        &run_dir,
+                        id,
+                        effects,
+                        cached_update
+                            .as_ref()
+                            .map(|(tree, snapshot)| (tree.as_str(), snapshot)),
+                    )?;
                 }
             }
             if !comment && !check && step_summary.is_none() {

--- a/tools/wasinix/src/cli/update.rs
+++ b/tools/wasinix/src/cli/update.rs
@@ -219,7 +219,8 @@ pub fn run_update(args: UpdateArgs) -> Result<CommandStatus> {
             Ok(CommandStatus::from_code(code.clamp(0, 255) as u8))
         }
         Some("list") if args.targets.len() == 1 => {
-            let targets = targets::all_targets(&repo)?;
+            let snapshot = crate::update::snapshot::load(&repo)?;
+            let targets = targets::all_targets(&repo, &snapshot)?;
             #[derive(serde::Serialize, serde::Deserialize)]
             struct UpdateTargets {
                 targets: Vec<String>,

--- a/tools/wasinix/src/nix/bisect.rs
+++ b/tools/wasinix/src/nix/bisect.rs
@@ -149,7 +149,8 @@ fn source_repository(source: &Value) -> Option<String> {
 
 /// Resolve the same target names accepted by `update` and `--with`.
 pub fn dependency(repo: &Path, spec: &str) -> Result<Dependency> {
-    let targets = updatetargets::all_targets(repo)?;
+    let snapshot = crate::update::snapshot::load(repo)?;
+    let targets = updatetargets::all_targets(repo, &snapshot)?;
     let names =
         updateselect::selected_names(&updatetargets::domain(&targets), &[spec.to_string()])?;
     require(

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -6792,6 +6792,12 @@ mod corpus {
                 "${{ always() && steps.run_artifact.outcome == 'success' && (steps.baseline.outcome == 'success' || steps.baseline.outcome == 'skipped') }}"
             )
         );
+        let baseline = field(step(build_job, "baseline"), "run").as_str().unwrap();
+        assert!(baseline.contains("[ \"$GITHUB_EVENT_NAME\" = push ]"));
+        assert!(baseline.contains("[ \"$GITHUB_REF_NAME\" = main ]"));
+        assert!(baseline.contains("[ \"$RUN_OUTCOME\" = success ]"));
+        assert!(baseline.contains("update_snapshot=(--update-snapshot)"));
+        assert!(baseline.contains("--baseline"));
 
         let command_job = job(&ci_command, "build");
         assert!(
@@ -6817,8 +6823,13 @@ mod corpus {
             .as_str()
             .unwrap();
         assert!(invocation.contains("nix run .#update --"), "{invocation}");
-        assert!(invocation.contains("--pr --jobs 4"), "{invocation}");
+        assert!(invocation.contains("--pr --jobs \"$JOBS\""), "{invocation}");
         assert!(!invocation.contains("update-matrix"), "{invocation}");
+        let update_step = step(job(&update, "update"), "update");
+        assert_eq!(
+            field(field(update_step, "env"), "JOBS").as_str(),
+            Some("${{ github.event.inputs.jobs || 4 }}")
+        );
 
         let cleanup = read("preview-cleanup.yml");
         let delete = step(job(&cleanup, "cleanup"), "delete_apps");
@@ -9556,6 +9567,7 @@ mod baseline {
             scratch.path(),
             "candidate",
             crate::support::effects::Effects::DryRun,
+            None,
         )
         .unwrap();
     }

--- a/tools/wasinix/src/update/batch.rs
+++ b/tools/wasinix/src/update/batch.rs
@@ -346,11 +346,16 @@ fn prepare(
     std::thread::scope(|scope| {
         scope.spawn(move || {
             let result = (|| {
-                let targets = crate::update::targets::all_targets(repo)?;
+                let snapshot = crate::update::snapshot::load(repo)?;
+                let targets = crate::update::targets::all_targets(repo, &snapshot)?;
                 let items = work_items(&targets, all, specs)?;
                 let release_work = items.iter().any(|item| item.release_work);
-                let preflight =
-                    crate::update::drive::Preflight::collect(repo, targets, release_work)?;
+                let preflight = crate::update::drive::Preflight::collect(
+                    repo,
+                    targets,
+                    &snapshot,
+                    release_work,
+                )?;
                 Ok((items, preflight))
             })();
             let _ = sender.send(result);

--- a/tools/wasinix/src/update/drive.rs
+++ b/tools/wasinix/src/update/drive.rs
@@ -44,11 +44,22 @@ impl crate::support::schema::Document for Preflight {
 }
 
 impl Preflight {
-    pub fn collect(repo: &Path, targets: Vec<Target>, release_work: bool) -> Result<Preflight> {
+    pub fn collect(
+        repo: &Path,
+        targets: Vec<Target>,
+        snapshot: &crate::update::snapshot::Snapshot,
+        release_work: bool,
+    ) -> Result<Preflight> {
         let revision = crate::support::git::git(repo, &["rev-parse", "HEAD"])?;
-        let prior_hooks = targets::discovered_post_update_hooks()?;
+        let prior_hooks = targets::discovered_post_update_hooks(&snapshot.post_update_hooks)?;
         let (priors, history_priors) = if release_work {
-            retention::prior_state(repo)?
+            if !snapshot.notes.ok {
+                ui::warning("note version eval failed");
+            }
+            (
+                snapshot.notes.value.clone(),
+                snapshot.served_versions.clone(),
+            )
         } else {
             (Value::Null, Versions::new())
         };
@@ -218,7 +229,8 @@ fn run_hooks(
     committer: Option<&crate::support::git::Identity<'_>>,
 ) -> Result<ChangeSet> {
     let mut changes = ChangeSet::default();
-    let hooks = targets::discovered_post_update_hooks()?
+    let snapshot = crate::update::snapshot::load(repo)?;
+    let hooks = targets::discovered_post_update_hooks(&snapshot.post_update_hooks)?
         .into_iter()
         .map(|hook| (hook, None))
         .collect();
@@ -254,25 +266,17 @@ pub fn drive(repo: &Path, options: Options) -> Result<ChangeSet> {
     if !options.all && options.targets.is_empty() {
         return request_error("update needs --all or at least one target");
     }
-    let (prior_hooks, mut targets, shared_priors) = match options.preflight {
-        Some(preflight) => {
-            preflight.validate(repo)?;
-            (
-                preflight.prior_hooks,
-                preflight.targets,
-                Some((
-                    preflight.release_priors,
-                    preflight.priors,
-                    preflight.history_priors,
-                )),
-            )
+    let preflight = match options.preflight {
+        Some(preflight) => preflight,
+        None => {
+            let snapshot = crate::update::snapshot::load(repo)?;
+            let targets = targets::all_targets(repo, &snapshot)?;
+            Preflight::collect(repo, targets, &snapshot, true)?
         }
-        None => (
-            targets::discovered_post_update_hooks()?,
-            targets::all_targets(repo)?,
-            None,
-        ),
     };
+    preflight.validate(repo)?;
+    let prior_hooks = preflight.prior_hooks;
+    let mut targets = preflight.targets;
     let domain = targets::domain(&targets);
     let (wanted, requests) = select::target_requests(&targets, &domain, &options.targets)?;
     if !options.all {
@@ -289,17 +293,14 @@ pub fn drive(repo: &Path, options: Options) -> Result<ChangeSet> {
     // A transient eval failure here must abort: retention diffs against these
     // versions, and starting from an empty map means retaining nothing while
     // the prune still runs. Both views come from one package-set evaluation.
-    let (priors, history_priors): (Value, Versions) =
-        if let Some((available, priors, versions)) = shared_priors {
-            if release_work && !available {
-                return request_error("update preflight carries no release priors");
-            }
-            (priors, versions)
-        } else if release_work {
-            retention::prior_state(repo)?
-        } else {
-            (Value::Null, Versions::new())
-        };
+    if release_work && !preflight.release_priors {
+        return request_error("update preflight carries no release priors");
+    }
+    let (priors, history_priors) = if release_work {
+        (preflight.priors, preflight.history_priors)
+    } else {
+        (Value::Null, Versions::new())
+    };
 
     // One flaky upstream must not abort the rest: isolate each target,
     // collect failures, and let the caller exit non-zero at the end.
@@ -357,11 +358,23 @@ pub fn drive(repo: &Path, options: Options) -> Result<ChangeSet> {
     }
 
     let release_changed = release_followups(&changes, release_work);
+    let current_snapshot = if changes.changed() {
+        Some(crate::update::snapshot::evaluate(repo)?)
+    } else {
+        None
+    };
 
     // Retain before pruning: the prune drops the rel key of any version no
     // longer served, which is exactly what retention just brought back.
     if release_changed {
-        match retention::regen_history(repo, &history_priors) {
+        match retention::regen_history(
+            repo,
+            &history_priors,
+            &current_snapshot
+                .as_ref()
+                .expect("a release change has current update state")
+                .served_versions,
+        ) {
             Ok(Some(retained)) => {
                 let entry = Entry {
                     kind: EntryKind::Retain,
@@ -411,10 +424,18 @@ pub fn drive(repo: &Path, options: Options) -> Result<ChangeSet> {
 
     // Package-declared re-syncs last, after any release-only history work.
     if changes.changed() {
-        let hooks = changed_hooks(&prior_hooks, targets::discovered_post_update_hooks()?)
-            .into_iter()
-            .map(|(hook, prior)| (hook, Some(prior)))
-            .collect();
+        let hooks = changed_hooks(
+            &prior_hooks,
+            targets::discovered_post_update_hooks(
+                &current_snapshot
+                    .as_ref()
+                    .expect("changed updates have current update state")
+                    .post_update_hooks,
+            )?,
+        )
+        .into_iter()
+        .map(|(hook, prior)| (hook, Some(prior)))
+        .collect();
         hook_stage(repo, &mut changes, options.commit, committer, hooks)?;
     }
 

--- a/tools/wasinix/src/update/mod.rs
+++ b/tools/wasinix/src/update/mod.rs
@@ -13,6 +13,7 @@ pub mod rels;
 pub mod request;
 pub mod retention;
 pub mod select;
+pub mod snapshot;
 pub mod sync;
 pub mod targets;
 

--- a/tools/wasinix/src/update/retention.rs
+++ b/tools/wasinix/src/update/retention.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::support::error::{Result, request_error};
-use crate::support::nix::{Invocation, SYSTEM, project_attr};
+use crate::support::nix::project_attr;
 use crate::support::ui;
 use crate::update::history::AddOutcome;
 
@@ -51,7 +51,7 @@ fn retention_note(prior: &str, level: usize) -> String {
     format!("latest {series}.x (outgoing {which})")
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Served {
     pub version: String,
     pub history_spec: String,
@@ -73,126 +73,14 @@ pub(crate) fn retention_add_spec(served: &Served) -> String {
     format!("{spec}@{}", served.version)
 }
 
-const WHEEL_APPLY: &str = "builtins.mapAttrs (name: w: \
-    { version = w.version; history_spec = \"packages.python.${name}\"; \
-    retention = w.passthru.wasinix.retention or null; })";
-fn cli_apply() -> String {
-    "builtins.mapAttrs (name: p: { inherit name; \
-     history_spec = \"packages.wasix.${name}\"; \
-     shipped = p.passthru.wasinix.shipped or false; version = p.version or null; \
-     retention = p.passthru.wasinix.retention or null; })"
-        .to_string()
-}
-
-#[derive(Deserialize)]
-struct EvaluatedNotes {
-    ok: bool,
-    value: Value,
-}
-
-#[derive(Deserialize)]
-struct VersionState {
-    wheels: Value,
-    clis: Value,
-    notes: EvaluatedNotes,
-}
-
-fn version_apply(include_notes: bool) -> String {
-    let notes = if include_notes {
-        "let n = builtins.tryEval p.internals.repository.updates.updateNotes.versions; in { ok = n.success; value = if n.success then n.value else {}; }"
-    } else {
-        "{ ok = true; value = {}; }"
-    };
-    format!(
-        "p: {{ wheels = {{ py313 = ({WHEEL_APPLY}) p.artifacts.wheel-py313; py314 = ({WHEEL_APPLY}) p.artifacts.wheel-py314; }}; clis = ({}) p.packages.wasix.preferred; notes = {notes}; }}",
-        cli_apply()
-    )
-}
-
-fn evaluate_versions(repo: &Path, include_notes: bool) -> Result<VersionState> {
-    let apply = version_apply(include_notes);
-    let value = Invocation::flake("eval", format!(".#legacyPackages.{SYSTEM}"))
-        .json()
-        .apply(&apply)
-        .workdir(repo)
-        .run_json("served versions")?;
-    crate::support::json::from_value(value, "served versions")
-}
-
-/// Current served versions, excluding the history entries themselves.
-pub fn current_versions(repo: &Path) -> Result<Versions> {
-    let state = evaluate_versions(repo, false)?;
-    versions_from_state(repo, &state)
-}
-
-fn versions_from_state(repo: &Path, state: &VersionState) -> Result<Versions> {
-    let mut result: Versions = BTreeMap::new();
-    result.insert("wheel".into(), BTreeMap::new());
-    result.insert("cli".into(), BTreeMap::new());
-    let history: Value = crate::support::json::read(&crate::update::history::wheel_history(repo))?;
-    let history_keys: std::collections::BTreeSet<String> = history
-        .as_object()
-        .into_iter()
-        .flatten()
-        .flat_map(|(attr, versions)| {
-            versions
-                .as_object()
-                .into_iter()
-                .flatten()
-                .map(move |(version, _)| format!("{attr}-{version}"))
-        })
-        .collect();
-
-    for (_, by_attr) in state.wheels.as_object().into_iter().flatten() {
-        for (attr, info) in by_attr.as_object().into_iter().flatten() {
-            if history_keys.contains(attr) {
-                continue;
-            }
-            result
-                .get_mut("wheel")
-                .expect("the wheel bucket exists")
-                .entry(attr.clone())
-                .or_insert(crate::support::json::from_value(
-                    info.clone(),
-                    "Python wheel artifact versions",
-                )?);
-        }
-    }
-
-    for (name, info) in state.clis.as_object().into_iter().flatten() {
-        if !info["shipped"].as_bool().unwrap_or(false) {
-            continue;
-        }
-        result
-            .get_mut("cli")
-            .expect("the cli bucket exists")
-            .entry(name.clone())
-            .or_insert(crate::support::json::from_value(
-                info.clone(),
-                "preferred package versions",
-            )?);
-    }
-    Ok(result)
-}
-
-pub fn prior_state(repo: &Path) -> Result<(Value, Versions)> {
-    let state = evaluate_versions(repo, true)?;
-    if !state.notes.ok {
-        ui::warning("note version eval failed");
-    }
-    let versions = versions_from_state(repo, &state)?;
-    Ok((state.notes.value, versions))
-}
-
 /// Retention keeps the outgoing version behind in the registry-history table
 /// so pinned consumers keep resolving. Not keyed to a target: what matters is
 /// that a served version moved, and a package pinning its own src moves on
 /// its own updateScript rather than the nixpkgs bump.
-pub fn regen_history(repo: &Path, priors: &Versions) -> Result<Option<String>> {
+pub fn regen_history(repo: &Path, priors: &Versions, current: &Versions) -> Result<Option<String>> {
     if priors.is_empty() {
         return Ok(None);
     }
-    let current = current_versions(repo)?;
     let mut lines = Vec::new();
     let mut failed = Vec::new();
     for (kind, by_attr) in priors {
@@ -357,36 +245,4 @@ pub fn fired_notes(repo: &Path, priors: &Value) -> Vec<Note> {
         }
     }
     seen.into_values().collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{VersionState, version_apply};
-    use crate::support::nix::Invocation;
-
-    #[test]
-    fn one_package_set_evaluation_returns_every_prior_view() {
-        let expression = format!(
-            "let p = {{ \
-             artifacts.wheel-py313.demo = {{ version = \"1\"; passthru.wasinix.retention = \"minor\"; }}; \
-             artifacts.wheel-py314 = {{}}; \
-             packages.wasix.preferred.cli = {{ version = \"2\"; passthru.wasinix = {{ shipped = true; retention = \"major\"; }}; }}; \
-             packages.wasix.preferred.libiconv = {{ versions = {{}}; passthru.wasinix.shipped = false; }}; \
-             internals.repository.updates.updateNotes.versions.cli = \"2\"; \
-             }}; in ({}) p",
-            version_apply(true)
-        );
-        let value = Invocation::expr("eval", expression)
-            .option("experimental-features", "nix-command")
-            .args(["--store", "dummy://"])
-            .json()
-            .run_json("combined update state")
-            .unwrap();
-        let state: VersionState = crate::support::json::from_value(value, "update state").unwrap();
-        assert_eq!(state.wheels["py313"]["demo"]["version"], "1");
-        assert_eq!(state.clis["cli"]["version"], "2");
-        assert_eq!(state.clis["libiconv"]["version"], serde_json::Value::Null);
-        assert_eq!(state.clis["libiconv"]["shipped"], false);
-        assert_eq!(state.notes.value["cli"], "2");
-    }
 }

--- a/tools/wasinix/src/update/snapshot.rs
+++ b/tools/wasinix/src/update/snapshot.rs
@@ -1,0 +1,189 @@
+//! The tree-keyed update inputs Nix projects once: target declarations,
+//! post-update hooks, served versions, and note versions. CI publishes this
+//! view with its eval map, and update commands evaluate it only on a miss.
+
+use std::path::Path;
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::support::error::{Error, Result, request_error};
+use crate::support::ui;
+use crate::update::retention::Versions;
+
+const SCHEMA: u64 = 1;
+const HEARTBEAT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Notes {
+    pub ok: bool,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Snapshot {
+    pub schema_version: u64,
+    pub update_scripts: Value,
+    pub post_update_hooks: Value,
+    pub served_versions: Versions,
+    pub notes: Notes,
+}
+
+impl Snapshot {
+    fn validate(self) -> Result<Self> {
+        if self.schema_version != SCHEMA {
+            return request_error(format!(
+                "update snapshot schema {} is not the supported {SCHEMA}",
+                self.schema_version
+            ));
+        }
+        Ok(self)
+    }
+}
+
+fn clean_tree(repo: &Path) -> Result<Option<String>> {
+    if !crate::support::git::git(repo, &["status", "--porcelain"])?
+        .trim()
+        .is_empty()
+    {
+        return Ok(None);
+    }
+    Ok(Some(crate::support::git::git(
+        repo,
+        &["rev-parse", "HEAD^{tree}"],
+    )?))
+}
+
+fn cached(repo: &Path, template: &str) -> Result<Option<Snapshot>> {
+    let Some(tree) = clean_tree(repo)? else {
+        ui::fact("update state", "working tree changed; evaluating");
+        return Ok(None);
+    };
+    ui::fact("update state", format!("checking cached tree {tree}"));
+    match crate::ci::baseline::fetch(&tree, template) {
+        crate::ci::baseline::Fetch::Found(map) => match map.update_snapshot {
+            Some(snapshot) => {
+                ui::fact("update state", "reused cached evaluation");
+                snapshot.validate().map(Some)
+            }
+            None => {
+                ui::fact("update state", "cached evaluation has no update state");
+                Ok(None)
+            }
+        },
+        crate::ci::baseline::Fetch::Missing(reason) => {
+            ui::fact("update state", format!("cache miss: {reason}"));
+            Ok(None)
+        }
+    }
+}
+
+pub(crate) fn evaluate(repo: &Path) -> Result<Snapshot> {
+    let started = Instant::now();
+    ui::fact(
+        "update state",
+        "evaluating targets, hooks, and served versions",
+    );
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    let value = std::thread::scope(|scope| {
+        scope.spawn(move || {
+            let result = crate::support::nix::Invocation::flake(
+                "eval",
+                crate::support::nix::active_project_installable(
+                    "internals.repository.updates.snapshot",
+                ),
+            )
+            .json()
+            .workdir(repo)
+            .run_json("update state");
+            let _ = sender.send(result);
+        });
+        loop {
+            match receiver.recv_timeout(HEARTBEAT) {
+                Ok(result) => break result,
+                Err(RecvTimeoutError::Timeout) => ui::fact(
+                    "update state",
+                    format!(
+                        "evaluating · running for {}",
+                        crate::support::format::duration(started.elapsed().as_secs_f64())
+                    ),
+                ),
+                Err(RecvTimeoutError::Disconnected) => {
+                    break Err(Error::Failure("update evaluation stopped".into()));
+                }
+            }
+        }
+    })?;
+    let snapshot: Snapshot = crate::support::json::from_value(value, "update state")?;
+    ui::fact(
+        "update state",
+        format!(
+            "evaluation ready · took {}",
+            crate::support::format::duration(started.elapsed().as_secs_f64())
+        ),
+    );
+    snapshot.validate()
+}
+
+pub fn load(repo: &Path) -> Result<Snapshot> {
+    match cached(repo, &crate::ci::baseline::map_url_template())? {
+        Some(snapshot) => Ok(snapshot),
+        None => evaluate(repo),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Snapshot;
+
+    fn snapshot(schema_version: u64) -> Snapshot {
+        Snapshot {
+            schema_version,
+            update_scripts: serde_json::json!({}),
+            post_update_hooks: serde_json::json!({}),
+            served_versions: Default::default(),
+            notes: super::Notes {
+                ok: true,
+                value: serde_json::json!({}),
+            },
+        }
+    }
+
+    #[test]
+    fn cached_update_state_rejects_an_unknown_schema() {
+        assert!(snapshot(1).validate().is_ok());
+        assert!(snapshot(2).validate().is_err());
+    }
+
+    #[test]
+    fn a_clean_tree_reuses_its_published_update_state() {
+        let scratch = crate::support::fs::Scratch::create("wasinix-update-cache-test").unwrap();
+        let repo = scratch.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        crate::support::git::git(&repo, &["init", "--initial-branch=main"]).unwrap();
+        crate::support::git::git(&repo, &["config", "user.name", "Test"]).unwrap();
+        crate::support::git::git(&repo, &["config", "user.email", "test@example.invalid"]).unwrap();
+        std::fs::write(repo.join("file"), "content\n").unwrap();
+        crate::support::git::git(&repo, &["add", "file"]).unwrap();
+        crate::support::git::git(&repo, &["commit", "-m", "fixture"]).unwrap();
+        let tree = crate::support::git::git(&repo, &["rev-parse", "HEAD^{tree}"]).unwrap();
+        let job = crate::support::atoms::JobAddr("checks.fixture".into());
+        let published = crate::ci::evalmap::EvalMap {
+            update_snapshot: Some(snapshot(1)),
+            status: Some([(job.clone(), crate::support::atoms::JobStatus::Success)].into()),
+            coverage: vec![job],
+            ..Default::default()
+        };
+        let maps = crate::ci::prepare::maps_dir(scratch.path());
+        std::fs::create_dir_all(&maps).unwrap();
+        crate::support::schema::write(&maps.join(format!("{tree}.json")), &published).unwrap();
+        let cached = super::cached(&repo, &format!("{}/{{tree}}.json", maps.display()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(cached, snapshot(1));
+    }
+}

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::support::error::{Result, request_error};
 use crate::support::naming::{self, Domain};
-use crate::support::nix::{Flake, eval, project_attr};
+use crate::support::nix::project_attr;
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -223,12 +223,7 @@ pub(crate) fn dedupe(declared: Vec<Target>) -> Vec<Target> {
     targets
 }
 
-pub fn discovered_targets(repo: &Path) -> Result<Vec<Target>> {
-    let declared = eval(
-        &Flake::default(),
-        "internals.repository.updates.updateScripts",
-        None,
-    )?;
+pub fn discovered_targets(repo: &Path, declared: &Value) -> Result<Vec<Target>> {
     let mut targets: Vec<Target> = Vec::new();
     for (attr, value) in declared.as_object().into_iter().flatten() {
         targets.push(declared_target(repo, attr, value)?);
@@ -237,12 +232,7 @@ pub fn discovered_targets(repo: &Path) -> Result<Vec<Target>> {
 }
 
 /// Package-declared post-update operations, deduped across profile attrs.
-pub fn discovered_post_update_hooks() -> Result<Vec<PostUpdateHook>> {
-    let declared = eval(
-        &Flake::default(),
-        "internals.repository.updates.postUpdateHooks",
-        None,
-    )?;
+pub fn discovered_post_update_hooks(declared: &Value) -> Result<Vec<PostUpdateHook>> {
     let mut hooks: BTreeMap<String, PostUpdateHook> = BTreeMap::new();
     for (attr, value) in declared.as_object().into_iter().flatten() {
         let hook = declared_post_update_hook(attr, value)?;
@@ -258,8 +248,11 @@ pub fn discovered_post_update_hooks() -> Result<Vec<PostUpdateHook>> {
     Ok(hooks.into_values().collect())
 }
 
-pub fn all_targets(repo: &Path) -> Result<Vec<Target>> {
-    let mut targets = discovered_targets(repo)?;
+pub fn all_targets(
+    repo: &Path,
+    snapshot: &crate::update::snapshot::Snapshot,
+) -> Result<Vec<Target>> {
+    let mut targets = discovered_targets(repo, &snapshot.update_scripts)?;
     for mut target in builtin_targets() {
         if target.backend == Backend::FlakeInput {
             let locked = crate::update::flake_lock::locked_input(repo, &target.input)?;


### PR DESCRIPTION
## Summary

- evaluate update targets, hooks, served versions, and note priors as one typed snapshot
- attach the snapshot to successful main eval maps and reuse it by Git tree
- reuse the prepared selector catalog during authoritative CI evaluation
- expose update worker concurrency as the manual workflow `jobs` input

## Measurements

- cold real-project discovery: 1m25s for all 46 update targets
- removing the duplicate selector-catalog evaluation saves roughly one 41s evaluation per case
- the scheduled concurrency remains 4 pending comparable hosted-runner runs at 6 and 8

## Verification

- production Wasinix package
- 370 Rust unit tests
- project API check
- real `wasinix update list --json` discovery
- pinned repository formatter

All package and test derivations were built on the configured remote builder.