### PR TITLE
project: add ownership registries

### DIFF
--- a/docs/project-api.md
+++ b/docs/project-api.md
@@ -107,6 +107,7 @@ The result starts with:
   artifacts = ...;
   runners = ...;
   probes = ...;
+  ownership = ...;
   tests = ...;
   ci = ...;
 }
@@ -183,6 +184,31 @@ an error when there is no preceding registered owner. Repeated layering inside
 one extension needs no declaration; providing one there is an error.
 
 Lineage is derived from the validated overlay chain. It is never handwritten.
+
+### Ownership
+
+An extension may register maintainers and logical review teams. These are
+project-policy identities, not nixpkgs `meta.maintainers`, and a team does not
+need a corresponding GitHub team:
+
+```nix
+{
+  id = "my-project";
+
+  ownership = let
+    maintainers.janeDoe.github = "jane-doe";
+  in {
+    inherit maintainers;
+    teams.php = [maintainers.janeDoe];
+  };
+}
+```
+
+Each maintainer is exactly `{ github = <nonempty login>; }`; each team is a list
+of values from that extension's maintainer registry. Package units receive their
+owning extension's `maintainers` and `teams` arguments, so package policy
+references the typed central values instead of repeating GitHub logins. The
+project exposes the contributions as `ownership.<extension-id>`.
 
 ## File layout and discovery
 

--- a/pkgs/project/default.nix
+++ b/pkgs/project/default.nix
@@ -34,6 +34,40 @@
   extensionError = extension: message:
     throw "Wasinix extension '${extension.id}' ${message}";
 
+  ownershipFor = extension: extension.ownership or {};
+  maintainerFor = extension: name: value:
+    lib.throwIf (
+      !lib.isAttrs value
+      || lib.isDerivation value
+      || lib.attrNames value != ["github"]
+      || !builtins.isString (value.github or null)
+      || value.github == ""
+    )
+    "Wasinix extension '${extension.id}' maintainer '${name}' must be { github = <nonempty login>; }"
+    value;
+  teamFor = extension: maintainers: name: members:
+    lib.throwIf (!builtins.isList members)
+    "Wasinix extension '${extension.id}' team '${name}' must be a list of maintainers"
+    (lib.throwIf (!(lib.all (member: builtins.elem member (lib.attrValues maintainers)) members))
+      "Wasinix extension '${extension.id}' team '${name}' contains a maintainer outside its registry"
+      members);
+  validateOwnership = extension: let
+    ownership = ownershipFor extension;
+    unknown = lib.subtractLists ["maintainers" "teams"] (lib.attrNames ownership);
+    maintainers = ownership.maintainers or {};
+    teams = ownership.teams or {};
+  in
+    lib.throwIf (!lib.isAttrs ownership || lib.isDerivation ownership)
+    "Wasinix extension '${extension.id}' ownership must be an attribute set"
+    (lib.throwIf (unknown != [])
+      "Wasinix extension '${extension.id}' ownership has unknown field(s): ${lib.concatStringsSep ", " unknown}"
+      (lib.throwIf (!lib.isAttrs maintainers || lib.isDerivation maintainers)
+        "Wasinix extension '${extension.id}' ownership.maintainers must be an attribute set"
+        (lib.throwIf (!lib.isAttrs teams || lib.isDerivation teams)
+          "Wasinix extension '${extension.id}' ownership.teams must be an attribute set"
+          (builtins.deepSeq (lib.mapAttrs (maintainerFor extension) maintainers)
+            (builtins.deepSeq (lib.mapAttrs (teamFor extension maintainers) teams) extension)))));
+
   declaredOverlayFor = {
     contextFor,
     declared,
@@ -87,7 +121,7 @@
       "Wasinix extension '${id}' has unknown overlay lane(s): ${lib.concatStringsSep ", " invalidLanes}"
       (lib.throwIf (invalidHistory != [])
         "Wasinix extension '${id}' has unknown history lane(s): ${lib.concatStringsSep ", " invalidHistory}"
-        extension));
+        (validateOwnership extension)));
 
   ensureUniqueExtensions = extensions: let
     grouped = lib.groupBy (extension: extension.id) extensions;
@@ -109,8 +143,15 @@
     scope,
     variant,
   }: let
+    sourceOwnership = ownershipFor extension;
     rawOverlay = declaredOverlayFor {
-      inherit contextFor declared extension scope;
+      contextFor = args:
+        (contextFor args)
+        // {
+          maintainers = sourceOwnership.maintainers or {};
+          teams = sourceOwnership.teams or {};
+        };
+      inherit declared extension scope;
       inherit label applyFunction extendPackageFor;
     };
     overlay = final: previous:
@@ -369,6 +410,12 @@ in rec {
   }: let
     allExtensions = ensureUniqueExtensions (map validateExtension extensions);
     extensionIds = map (extension: extension.id) allExtensions;
+    ownership = lib.listToAttrs (map (extension:
+      lib.nameValuePair extension.id {
+        maintainers = (ownershipFor extension).maintainers or {};
+        teams = (ownershipFor extension).teams or {};
+      })
+    allExtensions);
     requestedCiSources = ci.sources or (map (extension: extension.id) extensions);
     unknownCiSources = lib.subtractLists extensionIds requestedCiSources;
     invalidProjectionRules = lib.attrNames (lib.filterAttrs (_: rule:
@@ -1177,6 +1224,7 @@ in rec {
         runners = runnersView;
         probes = probesView;
         tests = lib.mapAttrs (_: entry: entry.check) testEntries;
+        inherit ownership;
         catalog = {inherit entries;};
         ci = {
           sources = requestedCiSources;

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -596,6 +596,12 @@
   };
   unitExtension = {
     id = "unit-consumer";
+    ownership = let
+      maintainers.janeDoe.github = "jane-doe";
+    in {
+      inherit maintainers;
+      teams.php = [maintainers.janeDoe];
+    };
     overlays = projectApi.loadPackageOverlays {
       packages = {
         directory = ./tests/project-units;
@@ -803,6 +809,29 @@
     system = "test-system";
     importNixpkgs = fakeImportNixpkgs;
     extensions = [consumerExtension consumerExtension];
+  };
+  invalidMaintainerOwnership = projectApi.mkProject {
+    system = "test-system";
+    importNixpkgs = fakeImportNixpkgs;
+    extensions = [
+      {
+        id = "invalid-maintainer";
+        ownership.maintainers.invalid.github = "";
+      }
+    ];
+  };
+  invalidTeamOwnership = projectApi.mkProject {
+    system = "test-system";
+    importNixpkgs = fakeImportNixpkgs;
+    extensions = [
+      {
+        id = "invalid-team";
+        ownership = {
+          maintainers.janeDoe.github = "jane-doe";
+          teams.php = [{github = "outside-registry";}];
+        };
+      }
+    ];
   };
   aliasCollisionProject = projectApi.mkProject {
     system = "test-system";
@@ -1413,6 +1442,9 @@ in {
       preferredPackageSetName = project.packages.wasix.default.uses-inherited.passthru.preferredPackageSetName;
       topLevelPreferredPackageSetAbsent = project.packages.wasix.default.uses-inherited.passthru.topLevelPreferredPackageSetAbsent;
       runnerContextName = project.packages.wasix.default.uses-inherited.passthru.runnerContextName;
+      maintainerLogin = project.packages.wasix.default.uses-inherited.passthru.maintainerLogin;
+      reviewerLogins = project.packages.wasix.default.uses-inherited.passthru.reviewerLogins;
+      ownership = project.ownership."unit-consumer";
       runnerName = project.runners.rawWasm.unbound.name;
       pythonHarnessAvailable = project.harnesses ? python;
       ifdProbe = project.probes.ifd.passthru.text;
@@ -1454,6 +1486,8 @@ in {
       testContextName = project.tests."tests.packages.wasix.default.consumer.probe".name;
       unknownCiSourceFails = !(force unknownCiSource).success;
       duplicateExtensionFails = !(force duplicateExtension).success;
+      invalidMaintainerOwnershipFails = !(force invalidMaintainerOwnership).success;
+      invalidTeamOwnershipFails = !(force invalidTeamOwnership).success;
       aliasCollisionFails = !(force aliasCollisionProject).success;
       duplicateProjectionFails = !(force duplicateProjectionProject.tests).success;
       duplicateArtifactFails = !(force duplicateArtifactProject.artifacts).success;
@@ -1518,6 +1552,12 @@ in {
       preferredPackageSetName = "core";
       topLevelPreferredPackageSetAbsent = true;
       runnerContextName = "raw-wasm-unbound";
+      maintainerLogin = "jane-doe";
+      reviewerLogins = ["jane-doe"];
+      ownership = {
+        maintainers.janeDoe.github = "jane-doe";
+        teams.php = [{github = "jane-doe";}];
+      };
       runnerName = "raw-wasm-unbound";
       pythonHarnessAvailable = true;
       ifdProbe = "ok";
@@ -1653,6 +1693,8 @@ in {
       testContextName = "probe-consumer-default-0.9";
       unknownCiSourceFails = true;
       duplicateExtensionFails = true;
+      invalidMaintainerOwnershipFails = true;
+      invalidTeamOwnershipFails = true;
       aliasCollisionFails = true;
       duplicateProjectionFails = true;
       duplicateArtifactFails = true;

--- a/pkgs/project/tests/project-units/u/uses-inherited/package.nix
+++ b/pkgs/project/tests/project-units/u/uses-inherited/package.nix
@@ -1,10 +1,12 @@
 {
   dropInputsByName,
   exposePackage,
+  maintainers,
   packageSets,
   packages,
   profileSets,
   runners,
+  teams,
 }:
 exposePackage (packages.sameProfile.inherited.overrideAttrs (_: {
   name = "uses-inherited";
@@ -14,5 +16,7 @@ exposePackage (packages.sameProfile.inherited.overrideAttrs (_: {
     topLevelPreferredPackageSetAbsent = !(packageSets ? preferred);
     runnerContextName = runners.rawWasm.unbound.name;
     profileNames = profileSets.all;
+    maintainerLogin = maintainers.janeDoe.github;
+    reviewerLogins = map (maintainer: maintainer.github) teams.php;
   };
 }))


### PR DESCRIPTION
## Context

Adds extension-owned typed maintainer registries and logical review teams to the structured project API. Package units receive their source registry, while the project exposes contributions by extension ID for later update-policy consumers.

## Behavior checked

Fixtures cover a package unit consuming a typed maintainer and logical team, plus invalid maintainer and team declarations. Nix formatting and parsing pass. The broader flake evaluation session did not return a verdict from this environment after beginning output.