### PR TITLE
update: carry package ownership to PRs

### DIFF
--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -123,7 +123,7 @@
         "package ownership.${field} must be a list"
         (lib.throwIf (!(lib.all (value: builtins.elem value known) values))
           "package ownership.${field} contains a maintainer outside source '${toString source}'"
-          (map (value: value.github) values));
+          values);
     in
       lib.throwIf (!lib.isAttrs declared || lib.isDerivation declared)
       "package ownership must be an attribute set"

--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -111,6 +111,28 @@
     else builtins.attrNames (builtins.getContext (toString value)));
   updateScripts = let
     srcRoot = toString root;
+    updateOwnership = package: let
+      declared = package.passthru.wasinix.ownership or {};
+      source = package.passthru.wasinix.source or null;
+      registry = project.ownership.${source}.maintainers or {};
+      people = field: let
+        values = declared.${field} or [];
+        known = builtins.attrValues registry;
+      in
+        lib.throwIf (!lib.isList values)
+        "package ownership.${field} must be a list"
+        (lib.throwIf (!(lib.all (value: builtins.elem value known) values))
+          "package ownership.${field} contains a maintainer outside source '${toString source}'"
+          (map (value: value.github) values));
+    in
+      lib.throwIf (!lib.isAttrs declared || lib.isDerivation declared)
+      "package ownership must be an attribute set"
+      (lib.throwIf (lib.subtractLists ["assignees" "reviewers"] (lib.attrNames declared) != [])
+        "package ownership has unknown field(s)"
+        {
+          assignees = people "assignees";
+          reviewers = people "reviewers";
+        });
     scriptFor = address: package: let
       declaration = package.passthru.updateScript or null;
       commandValues =
@@ -137,6 +159,7 @@
             commandDrvPaths = commandDrvsOf commandValues;
             version = package.version or null;
             position = package.meta.position or null;
+            ownership = updateOwnership package;
           }
           // lib.optionalAttrs (lib.isAttrs declaration && declaration ? name) {inherit (declaration) name;}
           // lib.optionalAttrs (lib.isAttrs declaration && declaration ? attrPath) {inherit (declaration) attrPath;}

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -1828,7 +1828,7 @@ in {
         };
         version = "2";
       };
-      updateScriptNames = ["packages.wasix.preferred.cli"];
+      updateScriptNames = ["packages.native.ownedUpdate" "packages.wasix.preferred.cli"];
       updateSnapshot = {
         schemaVersion = 1;
         servedVersions = {
@@ -1844,7 +1844,7 @@ in {
           };
         };
         hookNames = ["packages.native.command" "packages.native.sync"];
-        scriptNames = ["packages.wasix.preferred.cli"];
+        scriptNames = ["packages.native.ownedUpdate" "packages.wasix.preferred.cli"];
       };
     };
   };

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -22,6 +22,20 @@
         update = {inherit post;};
       };
     };
+  ownedUpdatePackage = mkPackage {
+    name = "owned-update";
+    version = "1";
+    passthru = {
+      updateScript = ["./update-owned"];
+      wasinix = {
+        source = "fixture";
+        ownership = {
+          assignees = [{github = "jane-doe";}];
+          reviewers = [{github = "jane-doe";}];
+        };
+      };
+    };
+  };
   repository = import ./repository.nix {
     inherit lib;
     root = ../..;
@@ -31,6 +45,7 @@
       packages = {
         native = {
           command = hookPackage "command" "1" ["./hook"];
+          ownedUpdate = ownedUpdatePackage;
           sync = hookPackage "sync" "2" {
             syncAttrList = {
               input = "nixpkgs";
@@ -54,6 +69,7 @@
         python = {};
       };
       artifacts = {};
+      ownership.fixture.maintainers.janeDoe.github = "jane-doe";
       catalog.entries = {
         "artifacts.wheel-py313.demo" = {
           kind = "artifact";
@@ -1580,6 +1596,7 @@ in {
       postUpdateCommand = repositoryHooks."packages.native.command";
       postUpdateSync = repositoryHooks."packages.native.sync";
       updateScriptNames = lib.attrNames repositoryScripts;
+      updateOwnership = repositoryScripts."packages.native.ownedUpdate".ownership;
       updateSnapshot = {
         inherit (repository.updates.snapshot) schemaVersion servedVersions;
         hookNames = lib.attrNames repository.updates.snapshot.postUpdateHooks;
@@ -1609,6 +1626,10 @@ in {
       ownership = {
         maintainers.janeDoe.github = "jane-doe";
         teams.php = [{github = "jane-doe";}];
+      };
+      updateOwnership = {
+        assignees = [{github = "jane-doe";}];
+        reviewers = [{github = "jane-doe";}];
       };
       runnerName = "raw-wasm-unbound";
       pythonHarnessAvailable = true;

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4785,7 +4785,7 @@ mod update {
     use crate::update::history::substitute_version;
     use crate::update::retention::retention_crossed;
     use crate::update::select::target_requests;
-    use crate::update::targets::{Backend, PostUpdateAction, Target, domain};
+    use crate::update::targets::{Backend, Ownership, PostUpdateAction, Target, domain};
 
     fn flake_target(name: &str) -> Target {
         Target {
@@ -4799,6 +4799,7 @@ mod update {
             file: String::new(),
             accepts: vec!["revision".into()],
             source: Some(serde_json::json!({"kind": "github", "owner": "o", "repo": "r"})),
+            ownership: Ownership::default(),
         }
     }
 
@@ -4946,6 +4947,7 @@ mod update {
             file: file.into(),
             accepts: Vec::new(),
             source: None,
+            ownership: Ownership::default(),
         };
         let deduped = crate::update::targets::dedupe(vec![
             // A wrapper and its unwrapped package: same file, same command.
@@ -4970,7 +4972,8 @@ mod update {
                 "pkgs/grammars.nix",
                 &["update-grammars", "go"],
             ),
-        ]);
+        ])
+        .unwrap();
         let names: Vec<&str> = deduped.iter().map(|target| target.name.as_str()).collect();
         assert_eq!(names, ["cargo-wasix", "tree-sitter-c", "tree-sitter-go"]);
     }
@@ -4985,6 +4988,10 @@ mod update {
             "command": ["/nix/store/bbb-wasix-libc-update/bin/wasix-libc-update"],
             "commandDrvPaths": ["/nix/store/ccc-wasix-libc-update.drv"],
             "accepts": ["release"],
+            "ownership": {
+                "assignees": ["jane-doe"],
+                "reviewers": ["john-smith", "jane-doe"]
+            }
         });
         let target = crate::update::targets::declared_target(
             std::path::Path::new("/repo"),
@@ -5004,6 +5011,8 @@ mod update {
             target.attr
         );
         assert_eq!(target.file, "pkgs/overlays/w/wasix-sysroot/libc.nix");
+        assert_eq!(target.ownership.assignees, ["jane-doe"]);
+        assert_eq!(target.ownership.reviewers, ["john-smith", "jane-doe"]);
     }
 
     #[test]

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4989,8 +4989,8 @@ mod update {
             "commandDrvPaths": ["/nix/store/ccc-wasix-libc-update.drv"],
             "accepts": ["release"],
             "ownership": {
-                "assignees": ["jane-doe"],
-                "reviewers": ["john-smith", "jane-doe"]
+                "assignees": [{"github": "jane-doe"}],
+                "reviewers": [{"github": "john-smith"}, {"github": "jane-doe"}]
             }
         });
         let target = crate::update::targets::declared_target(
@@ -5011,8 +5011,16 @@ mod update {
             target.attr
         );
         assert_eq!(target.file, "pkgs/overlays/w/wasix-sysroot/libc.nix");
-        assert_eq!(target.ownership.assignees, ["jane-doe"]);
-        assert_eq!(target.ownership.reviewers, ["john-smith", "jane-doe"]);
+        assert_eq!(target.ownership.assignees[0].github, "jane-doe");
+        assert_eq!(
+            target
+                .ownership
+                .reviewers
+                .iter()
+                .map(|maintainer| maintainer.github.as_str())
+                .collect::<Vec<_>>(),
+            ["john-smith", "jane-doe"]
+        );
     }
 
     #[test]

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::support::error::{request_error, Result};
+use crate::support::error::{Result, request_error};
 use crate::support::naming::{self, Domain};
 use crate::support::nix::project_attr;
 

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -37,6 +37,15 @@ pub struct Target {
     pub file: String,
     pub accepts: Vec<String>,
     pub source: Option<Value>,
+    #[serde(default)]
+    pub ownership: Ownership,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Ownership {
+    pub assignees: Vec<String>,
+    pub reviewers: Vec<String>,
 }
 
 impl Target {
@@ -52,6 +61,7 @@ impl Target {
             file: String::new(),
             accepts: Vec::new(),
             source: None,
+            ownership: Ownership::default(),
         }
     }
 
@@ -117,6 +127,8 @@ struct Declaration {
     accepts: Vec<String>,
     #[serde(default)]
     source: Option<Value>,
+    #[serde(default)]
+    ownership: Ownership,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -199,6 +211,7 @@ pub(crate) fn declared_target(repo: &Path, attr: &str, value: &Value) -> Result<
             .unwrap_or_default(),
         accepts: declaration.accepts,
         source: declaration.source,
+        ownership: declaration.ownership,
     })
 }
 
@@ -206,12 +219,21 @@ pub(crate) fn declared_target(repo: &Path, attr: &str, value: &Value) -> Result<
 /// declaring a name wins. A wrapper and its unwrapped package (or the same
 /// package under several profiles) declare the same script against the same
 /// file, which is one pin and one target, not one per spelling.
-pub(crate) fn dedupe(declared: Vec<Target>) -> Vec<Target> {
+pub(crate) fn dedupe(declared: Vec<Target>) -> Result<Vec<Target>> {
     let mut targets: Vec<Target> = Vec::new();
     let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut pins: std::collections::BTreeSet<(String, Vec<String>)> =
         std::collections::BTreeSet::new();
+    let mut ownership = BTreeMap::new();
     for target in declared {
+        if let Some(previous) = ownership.insert(target.name.clone(), target.ownership.clone()) {
+            if previous != target.ownership {
+                return request_error(format!(
+                    "update target {} has conflicting ownership declarations",
+                    target.name
+                ));
+            }
+        }
         if !target.file.is_empty() && !pins.insert((target.file.clone(), target.command.clone())) {
             continue;
         }
@@ -220,7 +242,7 @@ pub(crate) fn dedupe(declared: Vec<Target>) -> Vec<Target> {
         }
         targets.push(target);
     }
-    targets
+    Ok(targets)
 }
 
 pub fn discovered_targets(repo: &Path, declared: &Value) -> Result<Vec<Target>> {
@@ -228,7 +250,7 @@ pub fn discovered_targets(repo: &Path, declared: &Value) -> Result<Vec<Target>> 
     for (attr, value) in declared.as_object().into_iter().flatten() {
         targets.push(declared_target(repo, attr, value)?);
     }
-    Ok(dedupe(targets))
+    dedupe(targets)
 }
 
 /// Package-declared post-update operations, deduped across profile attrs.

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::support::error::{Result, request_error};
+use crate::support::error::{request_error, Result};
 use crate::support::naming::{self, Domain};
 use crate::support::nix::project_attr;
 
@@ -44,8 +44,14 @@ pub struct Target {
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Ownership {
-    pub assignees: Vec<String>,
-    pub reviewers: Vec<String>,
+    pub assignees: Vec<Maintainer>,
+    pub reviewers: Vec<Maintainer>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Maintainer {
+    pub github: String,
 }
 
 impl Target {


### PR DESCRIPTION
## Summary

- emit update-target assignee and reviewer facts from source-local ownership registries
- reject conflicting ownership declarations for one update target

## Validation

- `nix fmt` and Nix parser checks completed
- focused Cargo test command was started, but this environment lost the executor session before it returned a verdict