### PR TITLE
update: route managed PR ownership

### DIFF
--- a/tools/wasinix/src/cli/update.rs
+++ b/tools/wasinix/src/cli/update.rs
@@ -60,6 +60,7 @@ struct PrShape {
     /// The comment that replays this branch; None for an arm no comment can
     /// spell, whose PR then advertises no refresh.
     recipe: Option<String>,
+    ownership: targets::Ownership,
 }
 
 /// The one mutation exit: PR upsert when asked, then the receipt or the
@@ -89,6 +90,7 @@ fn conclude(
                 base: mode.base.clone(),
                 managed: !mode.fork,
                 recipe: shape.recipe,
+                ownership: shape.ownership,
             },
         )?;
         ui::fact("pull request", number);
@@ -273,6 +275,7 @@ pub fn run_update(args: UpdateArgs) -> Result<CommandStatus> {
                     branch: None,
                     title: None,
                     recipe: None,
+                    ownership: targets::Ownership::default(),
                 },
             )
         }
@@ -305,11 +308,19 @@ pub fn run_update(args: UpdateArgs) -> Result<CommandStatus> {
                 .all
                 .then(|| "pins: automated source-pin bump".to_string());
             let recipe = args.comment_recipe();
-            let preflight = args
+            let preflight: Option<drive::Preflight> = args
                 .batch_preflight
                 .as_deref()
                 .map(schema::read)
                 .transpose()?;
+            let ownership = preflight
+                .as_ref()
+                .and_then(|preflight| {
+                    args.targets
+                        .first()
+                        .map(|spec| preflight.ownership_for(spec))
+                })
+                .unwrap_or_default();
             let changes = drive::drive(
                 &repo,
                 drive::Options {
@@ -329,6 +340,7 @@ pub fn run_update(args: UpdateArgs) -> Result<CommandStatus> {
                     branch,
                     title,
                     recipe,
+                    ownership,
                 },
             )
         }
@@ -459,6 +471,7 @@ pub fn run_versions(command: VersionsCommand) -> Result<CommandStatus> {
                     branch: Some(branch),
                     title: Some("pkgs: backfill registry history".into()),
                     recipe: None,
+                    ownership: targets::Ownership::default(),
                 },
             )
         }
@@ -478,6 +491,7 @@ pub fn run_versions(command: VersionsCommand) -> Result<CommandStatus> {
                     branch: Some("auto/backfill-import".into()),
                     title: Some("pkgs: backfill registry history".into()),
                     recipe: None,
+                    ownership: targets::Ownership::default(),
                 },
             )
         }
@@ -509,6 +523,7 @@ pub fn run_versions(command: VersionsCommand) -> Result<CommandStatus> {
                     branch: Some("auto/bump-rel".into()),
                     title: Some("pkgs: bump publication releases".into()),
                     recipe,
+                    ownership: targets::Ownership::default(),
                 },
             )
         }

--- a/tools/wasinix/src/github/mod.rs
+++ b/tools/wasinix/src/github/mod.rs
@@ -9,3 +9,4 @@ pub mod mutation;
 pub mod publish;
 pub mod sanitize;
 pub mod surfaces;
+pub mod update_pr;

--- a/tools/wasinix/src/github/mutation.rs
+++ b/tools/wasinix/src/github/mutation.rs
@@ -11,6 +11,7 @@ use crate::github::client::Client;
 use crate::support::error::{Error, Result, request_error};
 use crate::support::git::git;
 use crate::update::changeset::ChangeSet;
+use crate::update::targets::Ownership;
 
 pub struct PrOptions {
     pub repository: String,
@@ -24,6 +25,8 @@ pub struct PrOptions {
     /// `/wasinix update` and `/wasinix regenerate` can replay it. None for a
     /// mutation no comment can spell, which then advertises neither.
     pub recipe: Option<String>,
+    /// The package-declared reviewers and assignees for an automated update.
+    pub ownership: Ownership,
 }
 
 /// Push the committed changes to `branch` and open or update its PR. The
@@ -61,25 +64,35 @@ pub fn open_pr(repo: &Path, changes: &ChangeSet, options: &PrOptions) -> Result<
         let state = crate::update::managed::State::new(recipe, head)?;
         body = crate::update::managed::with_state(&body, &state)?;
     }
-    if let Some(number) = existing_pr(&client, options)? {
+    let number = if let Some(number) = existing_pr(&client, options)? {
         client.patch(
             &format!("repos/{}/pulls/{number}", options.repository),
             &json!({ "title": options.title, "body": body }),
         )?;
-        return Ok(number);
+        number
+    } else {
+        let created = client.post(
+            &format!("repos/{}/pulls", options.repository),
+            &json!({
+                "title": options.title,
+                "head": options.branch,
+                "base": options.base,
+                "body": body,
+            }),
+        )?;
+        created["number"]
+            .as_u64()
+            .ok_or_else(|| Error::Failure("created pull request has no number".into()))?
+    };
+    if options.managed && options.recipe.is_some() {
+        crate::github::update_pr::reconcile(
+            &client,
+            &options.repository,
+            number,
+            &options.ownership,
+        )?;
     }
-    let created = client.post(
-        &format!("repos/{}/pulls", options.repository),
-        &json!({
-            "title": options.title,
-            "head": options.branch,
-            "base": options.base,
-            "body": body,
-        }),
-    )?;
-    created["number"]
-        .as_u64()
-        .ok_or_else(|| Error::Failure("created pull request has no number".into()))
+    Ok(number)
 }
 
 fn existing_pr(client: &Client, options: &PrOptions) -> Result<Option<u64>> {

--- a/tools/wasinix/src/github/update_pr.rs
+++ b/tools/wasinix/src/github/update_pr.rs
@@ -25,13 +25,13 @@ pub fn reconcile(
     if !ownership.assignees.is_empty() {
         client.post(
             &format!("{issue}/assignees"),
-            &json!({ "assignees": ownership.assignees }),
+            &json!({ "assignees": ownership.assignees.iter().map(|maintainer| &maintainer.github).collect::<Vec<_>>() }),
         )?;
     }
     if !ownership.reviewers.is_empty() {
         client.post(
             &format!("repos/{repository}/pulls/{pull_request}/requested_reviewers"),
-            &json!({ "reviewers": ownership.reviewers }),
+            &json!({ "reviewers": ownership.reviewers.iter().map(|maintainer| &maintainer.github).collect::<Vec<_>>() }),
         )?;
     }
     Ok(())

--- a/tools/wasinix/src/github/update_pr.rs
+++ b/tools/wasinix/src/github/update_pr.rs
@@ -1,0 +1,38 @@
+//! GitHub state owned by a managed update pull request.
+
+use serde_json::json;
+
+use crate::github::client::Client;
+use crate::support::error::Result;
+use crate::update::targets::Ownership;
+
+const AUTOMATION_LABELS: &[&str] = &["3.automated", "3.automated: update"];
+
+/// Apply facts that come from the update declaration, never from a branch
+/// name or title. GitHub additions are idempotent, so replaying an update
+/// reasserts the contract without touching unrelated labels or reviewers.
+pub fn reconcile(
+    client: &Client,
+    repository: &str,
+    pull_request: u64,
+    ownership: &Ownership,
+) -> Result<()> {
+    let issue = format!("repos/{repository}/issues/{pull_request}");
+    client.post(
+        &format!("{issue}/labels"),
+        &json!({ "labels": AUTOMATION_LABELS }),
+    )?;
+    if !ownership.assignees.is_empty() {
+        client.post(
+            &format!("{issue}/assignees"),
+            &json!({ "assignees": ownership.assignees }),
+        )?;
+    }
+    if !ownership.reviewers.is_empty() {
+        client.post(
+            &format!("repos/{repository}/pulls/{pull_request}/requested_reviewers"),
+            &json!({ "reviewers": ownership.reviewers }),
+        )?;
+    }
+    Ok(())
+}

--- a/tools/wasinix/src/update/drive.rs
+++ b/tools/wasinix/src/update/drive.rs
@@ -73,6 +73,15 @@ impl Preflight {
         })
     }
 
+    pub fn ownership_for(&self, spec: &str) -> crate::update::targets::Ownership {
+        let name = spec.split('@').next().unwrap_or(spec);
+        self.targets
+            .iter()
+            .find(|target| target.name == name)
+            .map(|target| target.ownership.clone())
+            .unwrap_or_default()
+    }
+
     fn validate(&self, repo: &Path) -> Result<()> {
         let revision = crate::support::git::git(repo, &["rev-parse", "HEAD"])?;
         if revision != self.revision {


### PR DESCRIPTION
## Summary

- label managed update PRs as automated updates
- request declared reviewers and assign declared owners when the PR is opened or refreshed

## Validation

- `cargo check` in `tools/wasinix`
- `git diff --check`