### PR TITLE
update: defer branches with human edits

### DIFF
--- a/tools/wasinix/src/github/changeset.rs
+++ b/tools/wasinix/src/github/changeset.rs
@@ -118,9 +118,13 @@ pub fn pr_body(changes: &ChangeSet, replayable: bool) -> Markdown {
     let mut body = Markdown::constant("### Automated pin update\n\n");
     body = body.push(sections(changes));
     if replayable {
-        body = body.push(Markdown::constant(MANAGED_FOOTER));
+        body = body.push(managed_footer());
     }
     body
+}
+
+pub fn managed_footer() -> Markdown {
+    Markdown::constant(MANAGED_FOOTER)
 }
 
 /// The `/wasinix` mutation reply: the same sections under the outcome

--- a/tools/wasinix/src/github/mutation.rs
+++ b/tools/wasinix/src/github/mutation.rs
@@ -43,6 +43,25 @@ pub fn open_pr(repo: &Path, changes: &ChangeSet, options: &PrOptions) -> Result<
     // Managed branches are the bot's, so replacing them is safe; the lease
     // still refuses to clobber a push that landed since this run last read
     // the remote. A human branch is never force-pushed.
+    let client = Client::new(crate::github::client::token().as_deref());
+    let existing = existing_pr(&client, options)?;
+    if let (true, Some(_), Some(number)) = (options.managed, options.recipe.as_ref(), existing) {
+        let live = pull(&client, &options.repository, number)?;
+        if let Some(state) = crate::update::managed::decode(&live.body)? {
+            if crate::update::managed::paused(&state, &live.head_sha) {
+                crate::github::update_pr::defer_human_edits(
+                    &client,
+                    &options.repository,
+                    number,
+                    &state,
+                    &live.head_sha,
+                )?;
+                return request_error(
+                    "managed update deferred: the pull request contains human commits",
+                );
+            }
+        }
+    }
     let head_ref = options.head_ref();
     let lease = format!("--force-with-lease=refs/heads/{}", options.branch);
     let mut push = vec!["push", "origin", &head_ref];
@@ -51,7 +70,6 @@ pub fn open_pr(repo: &Path, changes: &ChangeSet, options: &PrOptions) -> Result<
     }
     git(repo, &push)?;
 
-    let client = Client::new(crate::github::client::token().as_deref());
     let recipe = options.recipe.clone().filter(|_| options.managed);
     let mut body = crate::github::markdown::truncate_sections(
         changeset::pr_body(changes, recipe.is_some()).into_string(),
@@ -64,7 +82,7 @@ pub fn open_pr(repo: &Path, changes: &ChangeSet, options: &PrOptions) -> Result<
         let state = crate::update::managed::State::new(recipe, head)?;
         body = crate::update::managed::with_state(&body, &state)?;
     }
-    let number = if let Some(number) = existing_pr(&client, options)? {
+    let number = if let Some(number) = existing {
         client.patch(
             &format!("repos/{}/pulls/{number}", options.repository),
             &json!({ "title": options.title, "body": body }),

--- a/tools/wasinix/src/github/surfaces.rs
+++ b/tools/wasinix/src/github/surfaces.rs
@@ -122,6 +122,8 @@ pub enum Surface {
     Mutation { comment_id: u64 },
     /// The registry preview for a PR.
     Preview,
+    /// A managed update has newer work, but the branch has human commits.
+    UpdateDeferred,
 }
 
 /// The web address of the comment a reply answers, so a reader arriving at
@@ -137,6 +139,7 @@ impl Surface {
             Surface::CiReportReply { comment_id } => format!("ci-report:{comment_id}"),
             Surface::Mutation { comment_id } => format!("mutation:{comment_id}"),
             Surface::Preview => "preview".to_string(),
+            Surface::UpdateDeferred => "update-deferred".to_string(),
         }
     }
 
@@ -167,6 +170,7 @@ impl Surface {
         match self {
             Surface::CiReport => &["<!-- wasinix-ci-report -->"],
             Surface::Preview => &["<!-- wasinix-preview -->"],
+            Surface::UpdateDeferred => &[],
             _ => &[],
         }
     }

--- a/tools/wasinix/src/github/update_pr.rs
+++ b/tools/wasinix/src/github/update_pr.rs
@@ -36,3 +36,41 @@ pub fn reconcile(
     }
     Ok(())
 }
+
+pub fn defer_human_edits(
+    client: &Client,
+    repository: &str,
+    pull_request: u64,
+    state: &crate::update::managed::State,
+    head_sha: &str,
+) -> Result<()> {
+    let issue = format!("repos/{repository}/issues/{pull_request}");
+    client.post(
+        &format!("{issue}/labels"),
+        &json!({ "labels": ["3.automated: deferred-human-edits"] }),
+    )?;
+    let mut registry = crate::github::surfaces::Registry::new(
+        client,
+        repository,
+        pull_request,
+        crate::github::surfaces::BOT_AUTHOR,
+        crate::support::effects::Effects::Apply,
+    );
+    let body = crate::github::sanitize::Markdown::concat([
+        crate::github::sanitize::Markdown::constant("### Automated update deferred\n\n"),
+        crate::github::sanitize::Markdown::constant(
+            "A newer update is ready, but this branch moved past the bot-recorded head ",
+        ),
+        crate::github::sanitize::Markdown::code(&state.rewrite_safe_head),
+        crate::github::sanitize::Markdown::constant(" to "),
+        crate::github::sanitize::Markdown::code(head_sha),
+        crate::github::sanitize::Markdown::constant(".\n"),
+        crate::github::changeset::managed_footer(),
+    ]);
+    registry.upsert(
+        &crate::github::surfaces::Surface::UpdateDeferred,
+        &[("state", "deferred-human-edits".into())],
+        body,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- inspect a managed update PR before any force push
- preserve human commits, record a `deferred-human-edits` automation state, and upsert one actionable comment using the managed PR footer

## Validation

- `cargo check` in `tools/wasinix`
- `git diff --check`