### PR TITLE
update: route targets through the core team

### DIFF
--- a/docs/project-api.md
+++ b/docs/project-api.md
@@ -210,6 +210,10 @@ owning extension's `maintainers` and `teams` arguments, so package policy
 references the typed central values instead of repeating GitHub logins. The
 project exposes the contributions as `ownership.<extension-id>`.
 
+The repository's `core` team is the default assignee and reviewer set for all
+updates, including flake inputs. It may be empty while the project establishes
+its roster; package declarations can still name a narrower typed owner set.
+
 ## File layout and discovery
 
 Extensions may handwrite every overlay. Wasinix also provides a convenience

--- a/pkgs/project/extension.nix
+++ b/pkgs/project/extension.nix
@@ -56,6 +56,8 @@ in {
 
   inherit overlays;
 
+  ownership.teams.core = [];
+
   history = {
     wasix = ../overlays/history.json;
     python = ../python-overlays/history.json;

--- a/pkgs/project/repository.nix
+++ b/pkgs/project/repository.nix
@@ -11,6 +11,12 @@
   registry = project.artifacts.registry.python or null;
   cargoRegistryArtifact = project.artifacts.registry.cargo-registry or null;
   ownedEntries = projectLib.entriesForSource project.catalog.entries source;
+  defaultUpdateOwnership = let
+    core = project.ownership.${source}.teams.core or (throw "project source '${source}' has no core update team");
+  in {
+    assignees = core;
+    reviewers = core;
+  };
 
   subjectsOf = entries:
     lib.unique (lib.concatMap (entry: entry.packageSubjects or []) entries);
@@ -116,7 +122,7 @@
       source = package.passthru.wasinix.source or null;
       registry = project.ownership.${source}.maintainers or {};
       people = field: let
-        values = declared.${field} or [];
+        values = declared.${field} or defaultUpdateOwnership.${field};
         known = builtins.attrValues registry;
       in
         lib.throwIf (!lib.isList values)
@@ -262,8 +268,8 @@
   };
   noteVersions = builtins.tryEval updateNotes.versions;
   updateSnapshot = {
-    schemaVersion = 1;
-    inherit postUpdateHooks servedVersions updateScripts;
+    schemaVersion = 2;
+    inherit defaultUpdateOwnership postUpdateHooks servedVersions updateScripts;
     notes = {
       ok = noteVersions.success;
       value =

--- a/pkgs/project/tests.nix
+++ b/pkgs/project/tests.nix
@@ -69,7 +69,10 @@
         python = {};
       };
       artifacts = {};
-      ownership.fixture.maintainers.janeDoe.github = "jane-doe";
+      ownership.fixture = {
+        maintainers.janeDoe.github = "jane-doe";
+        teams.core = [];
+      };
       catalog.entries = {
         "artifacts.wheel-py313.demo" = {
           kind = "artifact";
@@ -1625,6 +1628,7 @@ in {
       reviewerLogins = ["jane-doe"];
       ownership = {
         maintainers.janeDoe.github = "jane-doe";
+        teams.core = [];
         teams.php = [{github = "jane-doe";}];
       };
       updateOwnership = {
@@ -1830,7 +1834,11 @@ in {
       };
       updateScriptNames = ["packages.native.ownedUpdate" "packages.wasix.preferred.cli"];
       updateSnapshot = {
-        schemaVersion = 1;
+        schemaVersion = 2;
+        defaultUpdateOwnership = {
+          assignees = [];
+          reviewers = [];
+        };
         servedVersions = {
           cli.cli = {
             version = "1";

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -5024,6 +5024,21 @@ mod update {
     }
 
     #[test]
+    fn builtin_targets_inherit_the_default_update_ownership() {
+        let ownership = crate::update::targets::Ownership {
+            assignees: vec![crate::update::targets::Maintainer {
+                github: "jane-doe".into(),
+            }],
+            reviewers: vec![],
+        };
+        assert!(
+            crate::update::targets::builtin_targets(ownership.clone())
+                .into_iter()
+                .all(|target| target.ownership == ownership)
+        );
+    }
+
+    #[test]
     fn attr_list_hooks_parse_the_flakes_tagged_operation() {
         let value = serde_json::json!({
             "action": {

--- a/tools/wasinix/src/update/snapshot.rs
+++ b/tools/wasinix/src/update/snapshot.rs
@@ -13,7 +13,7 @@ use crate::support::error::{Error, Result, request_error};
 use crate::support::ui;
 use crate::update::retention::Versions;
 
-const SCHEMA: u64 = 1;
+const SCHEMA: u64 = 2;
 const HEARTBEAT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -27,6 +27,7 @@ pub struct Notes {
 #[serde(rename_all = "camelCase")]
 pub struct Snapshot {
     pub schema_version: u64,
+    pub default_update_ownership: crate::update::targets::Ownership,
     pub update_scripts: Value,
     pub post_update_hooks: Value,
     pub served_versions: Versions,
@@ -143,6 +144,7 @@ mod tests {
     fn snapshot(schema_version: u64) -> Snapshot {
         Snapshot {
             schema_version,
+            default_update_ownership: Default::default(),
             update_scripts: serde_json::json!({}),
             post_update_hooks: serde_json::json!({}),
             served_versions: Default::default(),
@@ -155,8 +157,8 @@ mod tests {
 
     #[test]
     fn cached_update_state_rejects_an_unknown_schema() {
-        assert!(snapshot(1).validate().is_ok());
-        assert!(snapshot(2).validate().is_err());
+        assert!(snapshot(2).validate().is_ok());
+        assert!(snapshot(1).validate().is_err());
     }
 
     #[test]

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -102,14 +102,19 @@ impl Target {
 
 /// Flake inputs are their own targets so `update nixpkgs` works like a
 /// package; the crate-pin set is named for the file it regenerates.
-fn builtin_targets() -> Vec<Target> {
+pub(crate) fn builtin_targets(ownership: Ownership) -> Vec<Target> {
     let mut targets: Vec<Target> = ["nixpkgs", "wasmer", "treefmt-nix", "ghc-wasm-meta"]
         .into_iter()
-        .map(Target::flake)
+        .map(|name| {
+            let mut target = Target::flake(name);
+            target.ownership = ownership.clone();
+            target
+        })
         .collect();
     targets.push(Target {
         name: "cargo-registry".into(),
         backend: Backend::CratePins,
+        ownership,
         ..Target::flake("cargo-registry")
     });
     targets
@@ -281,7 +286,7 @@ pub fn all_targets(
     snapshot: &crate::update::snapshot::Snapshot,
 ) -> Result<Vec<Target>> {
     let mut targets = discovered_targets(repo, &snapshot.update_scripts)?;
-    for mut target in builtin_targets() {
+    for mut target in builtin_targets(snapshot.default_update_ownership.clone()) {
         if target.backend == Backend::FlakeInput {
             let locked = crate::update::flake_lock::locked_input(repo, &target.input)?;
             target.version = locked["rev"].as_str().unwrap_or_default().to_string();


### PR DESCRIPTION
Routes every update target through the typed core team default. The team is intentionally empty for now, so this establishes the policy without requesting anyone.\n\nAssisted-by: codex:gpt-5