### PR TITLE
ci: categorize rebuild labels

### DIFF
--- a/tools/wasinix/fixtures/golden/comment-diff-green.md
+++ b/tools/wasinix/fixtures/golden/comment-diff-green.md
@@ -17,8 +17,8 @@
 
 <details><summary>Rebuilt (2)</summary>
 
-- `checks.zlib` at 1.3.2
 - `packages.wasix.eh.zlib`
+- `checks.zlib` at 1.3.2
 
 </details>
 

--- a/tools/wasinix/src/ci/compare.rs
+++ b/tools/wasinix/src/ci/compare.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ci::evalmap::{EvalMap, StatusMap};
+use crate::ci::evalmap::{EvalMap, JobInfo, StatusMap};
 use crate::ci::types::{Build, CaseRef, RevSource};
 use crate::support::atoms::{JobAddr, JobStatus};
 use crate::support::error::{Result, request_error};
@@ -54,6 +54,71 @@ pub struct CaseCoverage {
 pub struct ComparisonCoverage {
     pub base: CaseCoverage,
     pub head: CaseCoverage,
+}
+
+/// The mutually exclusive rebuild buckets shown on pull requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RebuildCategory {
+    Packages,
+    Tests,
+    Artifacts,
+    Python,
+}
+
+/// A changed job's presentation bucket and whether it also touches native
+/// outputs. Native is a facet, rather than another bucket, so the four bucket
+/// counts remain a partition of the rebuild count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebuildRole {
+    pub category: RebuildCategory,
+    pub native: bool,
+}
+
+pub fn rebuild_role(job: &JobAddr, info: Option<&JobInfo>) -> Option<RebuildRole> {
+    let legacy = || {
+        let parts = job.as_str().split('.').collect::<Vec<_>>();
+        let category = match parts.as_slice() {
+            ["packages", "python", ..] => RebuildCategory::Python,
+            ["packages", ..] | ["artifacts", "pkg", ..] => RebuildCategory::Packages,
+            ["tests", ..] | ["checks", ..] => RebuildCategory::Tests,
+            ["artifacts", "registry", "python", ..] => RebuildCategory::Python,
+            ["artifacts", ..] => RebuildCategory::Artifacts,
+            _ => return None,
+        };
+        Some(RebuildRole {
+            category,
+            native: parts.contains(&"native"),
+        })
+    };
+    let Some(info) = info else {
+        return legacy();
+    };
+    let category = match info.kind.as_deref() {
+        Some("test") => RebuildCategory::Tests,
+        Some("package") if info.scope.as_deref() == Some("python") => RebuildCategory::Python,
+        Some("package") => RebuildCategory::Packages,
+        Some("artifact") if info.artifact_kind.as_deref() == Some("pkg") => {
+            RebuildCategory::Packages
+        }
+        Some("artifact")
+            if info.scope.as_deref() == Some("python")
+                && !info
+                    .artifact_kind
+                    .as_deref()
+                    .is_some_and(|kind| kind.starts_with("wheel-")) =>
+        {
+            RebuildCategory::Python
+        }
+        Some("artifact") => RebuildCategory::Artifacts,
+        Some(_) => return None,
+        None => return legacy(),
+    };
+    Some(RebuildRole {
+        category,
+        native: info.scope.as_deref() == Some("native"),
+    })
 }
 
 #[derive(Default)]
@@ -226,6 +291,9 @@ pub struct EvalDiff {
     pub removed: Vec<JobAddr>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rebuilt: Vec<JobAddr>,
+    /// Changed jobs' one partitioning rebuild category and native facet.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub rebuild_roles: BTreeMap<JobAddr, RebuildRole>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub identity_transitions: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -424,16 +492,30 @@ fn eval_diff(coverage: &Coverage, base_map: &EvalMap, head_map: &EvalMap) -> Eva
             });
         update.jobs.push(JobAddr(job.clone()));
     }
+    let rebuilt: Vec<JobAddr> = coverage
+        .both
+        .iter()
+        .filter(|job| {
+            base_map.jobs.get(job.as_str()) != head_map.jobs.get(job.as_str())
+                && head_map.rebuild_signal(job)
+        })
+        .map(|job| JobAddr(job.clone()))
+        .collect();
+    let rebuild_roles = added
+        .iter()
+        .chain(&removed)
+        .chain(&rebuilt)
+        .filter_map(|job| {
+            rebuild_role(
+                job,
+                head_map.info.get(job).or_else(|| base_map.info.get(job)),
+            )
+            .map(|role| (job.clone(), role))
+        })
+        .collect();
     EvalDiff {
-        rebuilt: coverage
-            .both
-            .iter()
-            .filter(|job| {
-                base_map.jobs.get(job.as_str()) != head_map.jobs.get(job.as_str())
-                    && head_map.rebuild_signal(job)
-            })
-            .map(|job| JobAddr(job.clone()))
-            .collect(),
+        rebuilt,
+        rebuild_roles,
         identity_transitions: identity_changed
             .iter()
             .map(|job| {

--- a/tools/wasinix/src/ci/evalmap.rs
+++ b/tools/wasinix/src/ci/evalmap.rs
@@ -27,6 +27,10 @@ pub struct TestExpectation {
 #[serde(rename_all = "camelCase")]
 pub struct JobInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject: Option<String>,
@@ -77,6 +81,8 @@ impl Default for JobInfo {
     fn default() -> Self {
         Self {
             rebuild_signal: true,
+            kind: None,
+            scope: None,
             display_name: None,
             subject: None,
             package_subject: None,
@@ -143,6 +149,8 @@ pub struct CatalogInstance {
 #[serde(rename_all = "camelCase")]
 pub struct CatalogJob {
     pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject: Option<String>,
@@ -174,6 +182,8 @@ impl CatalogJob {
             .map(str::to_owned);
         let is_test = self.kind == "test";
         JobInfo {
+            kind: Some(self.kind),
+            scope: self.scope,
             display_name: Some(self.name.clone()),
             subject: self.subject.or(Some(self.name)),
             package_subject: self.package_subject,

--- a/tools/wasinix/src/github/markdown.rs
+++ b/tools/wasinix/src/github/markdown.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::ci::compare::Comparison;
+use crate::ci::compare::{Comparison, RebuildRole};
 use crate::ci::events::Snapshot;
 use crate::ci::facts::{BUILD_PROCESS_ERROR_TITLE, DependencyPath, Failure, FailureCause};
 use crate::ci::report::{Conclusion, Fragment, FragmentData, Report};
@@ -834,6 +834,7 @@ const COMPARE_LIST_ROWS: usize = 250;
 fn job_list(
     title: &'static str,
     jobs: &[crate::support::atoms::JobAddr],
+    rebuild_roles: &BTreeMap<crate::support::atoms::JobAddr, RebuildRole>,
     identities: &BTreeMap<crate::support::atoms::JobAddr, String>,
     coverage: Option<&BTreeMap<crate::support::atoms::JobAddr, String>>,
     open: bool,
@@ -841,6 +842,16 @@ fn job_list(
     if jobs.is_empty() {
         return Markdown::constant("");
     }
+    let mut jobs = jobs.to_vec();
+    jobs.sort_by(|left, right| {
+        match (rebuild_roles.get(left), rebuild_roles.get(right)) {
+            (Some(left), Some(right)) => left.category.cmp(&right.category),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => left.cmp(right),
+        }
+        .then_with(|| left.cmp(right))
+    });
     let mut body = Markdown::concat([
         Markdown::constant("\n<details"),
         Markdown::constant(if open { " open" } else { "" }),
@@ -947,6 +958,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     body = body.push(job_list(
         "New evaluation failures",
         &eval.new_eval_errors,
+        &eval.rebuild_roles,
         &eval.identities,
         None,
         true,
@@ -955,6 +967,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
         body = body.push(job_list(
             "Removed jobs that passed",
             &builds.dropped_successes,
+            &eval.rebuild_roles,
             &eval.identities,
             None,
             true,
@@ -962,6 +975,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
         body = body.push(job_list(
             "Fixed",
             &builds.fixes,
+            &eval.rebuild_roles,
             &eval.identities,
             None,
             false,
@@ -998,6 +1012,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
         body = body.push(job_list(
             "Rebuilt",
             &eval.rebuilt,
+            &eval.rebuild_roles,
             &eval.identities,
             None,
             false,
@@ -1006,6 +1021,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     body = body.push(job_list(
         "Added",
         &eval.added,
+        &eval.rebuild_roles,
         &eval.identities,
         Some(&eval.catalog_job_coverage),
         false,
@@ -1013,6 +1029,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     body = body.push(job_list(
         "Removed",
         &eval.removed,
+        &eval.rebuild_roles,
         &eval.identities,
         Some(&eval.catalog_job_coverage),
         false,

--- a/tools/wasinix/src/github/publish.rs
+++ b/tools/wasinix/src/github/publish.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use serde_json::json;
 
+use crate::ci::compare::RebuildCategory;
 use crate::ci::events::Snapshot;
 use crate::ci::report::{Conclusion, Fragment, Report};
 use crate::github::client::Client;
@@ -16,17 +17,17 @@ use crate::support::error::Result;
 
 pub const PROGRESS_INTERVAL_SECONDS: u64 = 5 * 60;
 
-const REBUILD_LABEL_PREFIX: &str = "10.rebuild-wasix: ";
+const REBUILD_LABEL_PREFIX: &str = "10.rebuild";
 
-pub fn rebuild_label(count: usize) -> &'static str {
-    match count {
-        0 => "10.rebuild-wasix: 0",
-        1 => "10.rebuild-wasix: 1",
-        2..=10 => "10.rebuild-wasix: 1-10",
-        11..=100 => "10.rebuild-wasix: 11-100",
-        101..=500 => "10.rebuild-wasix: 101-500",
-        _ => "10.rebuild-wasix: 501+",
-    }
+fn rebuild_label(name: &str, count: usize) -> String {
+    let bucket = match count {
+        1 => "1",
+        2..=10 => "1-10",
+        11..=100 => "11-100",
+        101..=500 => "101-500",
+        _ => "501+",
+    };
+    format!("10.rebuilds-{name}: {bucket}")
 }
 
 pub struct Target {
@@ -66,22 +67,54 @@ pub struct Rendered {
     pub bisect: Option<crate::nix::bisect::Report>,
 }
 
-fn rebuild_count(report: &Report) -> Option<usize> {
+fn rebuild_labels(report: &Report) -> Result<Option<Vec<String>>> {
     let [comparison] = report.comparisons.as_slice() else {
-        return None;
+        return Ok(None);
     };
     if !comparison.base_evaluated || !comparison.head_evaluated {
-        return None;
+        return Ok(None);
     }
-    let eval = comparison.eval.as_ref()?;
-    Some(
-        eval.added
-            .iter()
-            .chain(&eval.removed)
-            .chain(&eval.rebuilt)
-            .collect::<BTreeSet<_>>()
-            .len(),
-    )
+    let Some(eval) = comparison.eval.as_ref() else {
+        return Ok(None);
+    };
+    let jobs: BTreeSet<_> = eval
+        .added
+        .iter()
+        .chain(&eval.removed)
+        .chain(&eval.rebuilt)
+        .collect();
+    let roles = jobs
+        .iter()
+        .map(|job| {
+            eval.rebuild_roles.get(*job).ok_or_else(|| {
+                crate::support::error::Error::Failure(format!(
+                    "comparison lacks a rebuild role for {job}"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut counts = BTreeMap::<RebuildCategory, usize>::new();
+    let mut native = 0;
+    for role in roles {
+        *counts.entry(role.category).or_default() += 1;
+        native += usize::from(role.native);
+    }
+    let mut labels = counts
+        .into_iter()
+        .map(|(category, count)| {
+            let name = match category {
+                RebuildCategory::Packages => "packages",
+                RebuildCategory::Tests => "tests",
+                RebuildCategory::Artifacts => "artifacts",
+                RebuildCategory::Python => "python",
+            };
+            rebuild_label(name, count)
+        })
+        .collect::<Vec<_>>();
+    if native > 0 {
+        labels.push(rebuild_label("native", native));
+    }
+    Ok(Some(labels))
 }
 
 pub fn reconcile_rebuild_label(
@@ -93,7 +126,8 @@ pub fn reconcile_rebuild_label(
     if target.untrusted || effects.is_dry_run() {
         return Ok(());
     }
-    let (Some(pull_request), Some(count)) = (target.pull_request, rebuild_count(&rendered.report))
+    let (Some(pull_request), Some(rebuild_labels)) =
+        (target.pull_request, rebuild_labels(&rendered.report)?)
     else {
         return Ok(());
     };
@@ -105,10 +139,10 @@ pub fn reconcile_rebuild_label(
         .iter()
         .filter_map(|label| label["name"].as_str())
         .filter(|label| !label.starts_with(REBUILD_LABEL_PREFIX))
-        .chain(std::iter::once(rebuild_label(count)))
+        .chain(rebuild_labels.iter().map(String::as_str))
         .collect::<Vec<_>>();
     client.put(&format!("{issue}/labels"), &json!({ "labels": labels }))?;
-    crate::support::ui::fact("rebuild count", count);
+    crate::support::ui::fact("rebuild labels", rebuild_labels.join(", "));
     Ok(())
 }
 
@@ -724,14 +758,22 @@ mod tests {
     fn rebuild_buckets_cover_every_boundary() {
         use super::rebuild_label;
 
-        assert_eq!(rebuild_label(0), "10.rebuild-wasix: 0");
-        assert_eq!(rebuild_label(1), "10.rebuild-wasix: 1");
-        assert_eq!(rebuild_label(2), "10.rebuild-wasix: 1-10");
-        assert_eq!(rebuild_label(10), "10.rebuild-wasix: 1-10");
-        assert_eq!(rebuild_label(11), "10.rebuild-wasix: 11-100");
-        assert_eq!(rebuild_label(100), "10.rebuild-wasix: 11-100");
-        assert_eq!(rebuild_label(101), "10.rebuild-wasix: 101-500");
-        assert_eq!(rebuild_label(500), "10.rebuild-wasix: 101-500");
-        assert_eq!(rebuild_label(501), "10.rebuild-wasix: 501+");
+        assert_eq!(rebuild_label("packages", 1), "10.rebuilds-packages: 1");
+        assert_eq!(rebuild_label("tests", 2), "10.rebuilds-tests: 1-10");
+        assert_eq!(
+            rebuild_label("artifacts", 10),
+            "10.rebuilds-artifacts: 1-10"
+        );
+        assert_eq!(rebuild_label("python", 11), "10.rebuilds-python: 11-100");
+        assert_eq!(rebuild_label("native", 100), "10.rebuilds-native: 11-100");
+        assert_eq!(
+            rebuild_label("packages", 101),
+            "10.rebuilds-packages: 101-500"
+        );
+        assert_eq!(
+            rebuild_label("packages", 500),
+            "10.rebuilds-packages: 101-500"
+        );
+        assert_eq!(rebuild_label("packages", 501), "10.rebuilds-packages: 501+");
     }
 }

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -906,7 +906,9 @@ mod authorization {
 }
 
 mod compare {
-    use crate::ci::compare::{BuildDiff, Comparison, EvalDiff, compare_loaded};
+    use crate::ci::compare::{
+        BuildDiff, Comparison, EvalDiff, RebuildCategory, compare_loaded, rebuild_role,
+    };
     use crate::ci::evalmap::{EvalMap, JobInfo, StatusMap};
     use crate::ci::types::{Build, CaseRef, RevSource, Selector, SelectorKind, Spot};
     use crate::support::atoms::{JobAddr, JobStatus, Rev};
@@ -976,6 +978,50 @@ mod compare {
 
     fn addrs(names: &[&str]) -> Vec<JobAddr> {
         names.iter().map(|name| JobAddr(name.to_string())).collect()
+    }
+
+    #[test]
+    fn rebuild_roles_partition_changed_jobs_and_mark_native() {
+        let package = JobInfo {
+            kind: Some("package".into()),
+            scope: Some("wasix".into()),
+            ..JobInfo::default()
+        };
+        let wheel = JobInfo {
+            kind: Some("artifact".into()),
+            scope: Some("python".into()),
+            artifact_kind: Some("wheel-py314".into()),
+            ..JobInfo::default()
+        };
+        let native_test = JobInfo {
+            kind: Some("test".into()),
+            scope: Some("native".into()),
+            ..JobInfo::default()
+        };
+        assert_eq!(
+            rebuild_role(&JobAddr("packages.wasix.eh.zlib".into()), Some(&package)),
+            Some(crate::ci::compare::RebuildRole {
+                category: RebuildCategory::Packages,
+                native: false,
+            })
+        );
+        assert_eq!(
+            rebuild_role(
+                &JobAddr("artifacts.wheel-py314.requests".into()),
+                Some(&wheel)
+            ),
+            Some(crate::ci::compare::RebuildRole {
+                category: RebuildCategory::Artifacts,
+                native: false,
+            })
+        );
+        assert_eq!(
+            rebuild_role(&JobAddr("tests.project.treefmt".into()), Some(&native_test)),
+            Some(crate::ci::compare::RebuildRole {
+                category: RebuildCategory::Tests,
+                native: true,
+            })
+        );
     }
 
     fn catalog_map(evaluated: &[(&str, &str)], catalog: &[(&str, &[&str])]) -> EvalMap {
@@ -8211,7 +8257,8 @@ mod scenarios {
     /// rebuilds, version moves, added and removed jobs.
     pub fn diff_green() -> (Report, Fragments) {
         use crate::ci::compare::{
-            BuildDiff, CaseCoverage, Comparison, ComparisonCoverage, EvalDiff, VersionUpdate,
+            BuildDiff, CaseCoverage, Comparison, ComparisonCoverage, EvalDiff, RebuildCategory,
+            RebuildRole, VersionUpdate,
         };
         let request = Request::diff(
             Diff {
@@ -8235,6 +8282,36 @@ mod scenarios {
                     JobAddr("checks.zlib".into()),
                     JobAddr("packages.wasix.eh.zlib".into()),
                 ],
+                rebuild_roles: BTreeMap::from([
+                    (
+                        JobAddr("checks.zlib".into()),
+                        RebuildRole {
+                            category: RebuildCategory::Tests,
+                            native: false,
+                        },
+                    ),
+                    (
+                        JobAddr("packages.wasix.eh.zlib".into()),
+                        RebuildRole {
+                            category: RebuildCategory::Packages,
+                            native: false,
+                        },
+                    ),
+                    (
+                        JobAddr("checks.brotli".into()),
+                        RebuildRole {
+                            category: RebuildCategory::Tests,
+                            native: false,
+                        },
+                    ),
+                    (
+                        JobAddr("checks.legacy-tool".into()),
+                        RebuildRole {
+                            category: RebuildCategory::Tests,
+                            native: false,
+                        },
+                    ),
+                ]),
                 identity_transitions: vec!["packages.wasix.eh.zlib: 1.3.1 -> 1.3.2".into()],
                 version_updates: vec![VersionUpdate {
                     subject: "zlib".into(),


### PR DESCRIPTION
## Context

Rebuild labels and rebuilt-list ordering now use one changed-job role projection. Packages precede tests and artifacts; native adds a nonzero-only overlapping label.

## Behavior checked

The golden CI comment renders a package before a test. Role coverage includes packages, wheel artifacts, and native tests; the complete Rust suite and flake checks pass.