### PR TITLE
ci: quiet rebuild label reconciliation

### DIFF
--- a/tools/wasinix/src/ci/compare.rs
+++ b/tools/wasinix/src/ci/compare.rs
@@ -76,6 +76,42 @@ pub struct RebuildRole {
     pub native: bool,
 }
 
+impl RebuildCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            RebuildCategory::Packages => "packages",
+            RebuildCategory::Tests => "tests",
+            RebuildCategory::Artifacts => "artifacts",
+            RebuildCategory::Python => "python",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RebuildCounts {
+    pub categories: BTreeMap<RebuildCategory, usize>,
+    pub native: usize,
+}
+
+pub fn rebuild_counts(eval: &EvalDiff) -> Option<RebuildCounts> {
+    let jobs: BTreeSet<_> = eval
+        .added
+        .iter()
+        .chain(&eval.removed)
+        .chain(&eval.rebuilt)
+        .collect();
+    let roles = jobs
+        .iter()
+        .map(|job| eval.rebuild_roles.get(*job))
+        .collect::<Option<Vec<_>>>()?;
+    let mut counts = RebuildCounts::default();
+    for role in roles {
+        *counts.categories.entry(role.category).or_default() += 1;
+        counts.native += usize::from(role.native);
+    }
+    Some(counts)
+}
+
 pub fn rebuild_role(job: &JobAddr, info: Option<&JobInfo>) -> Option<RebuildRole> {
     let legacy = || {
         let parts = job.as_str().split('.').collect::<Vec<_>>();

--- a/tools/wasinix/src/cli/render.rs
+++ b/tools/wasinix/src/cli/render.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
+use crate::ci::compare::rebuild_counts;
 use crate::ci::events::{self, Event, ProgressSink};
 use crate::ci::facts::{Diagnostic, DiagnosticSeverity, FailureCause, TestOutcome, TestResult};
 use crate::ci::report::{Conclusion, Report};
@@ -639,6 +640,31 @@ pub(crate) fn failure_summary(report: &Report) -> Option<String> {
     (!parts.is_empty()).then(|| format!("Jobs: {}", crate::support::ui::counts(&parts)))
 }
 
+pub(crate) fn rebuild_summary(report: &Report) -> Option<String> {
+    let [comparison] = report.comparisons.as_slice() else {
+        return None;
+    };
+    let counts = rebuild_counts(comparison.eval.as_ref()?)?;
+    let mut parts = counts
+        .categories
+        .into_iter()
+        .map(|(category, count)| {
+            let label = match (category, count) {
+                (crate::ci::compare::RebuildCategory::Packages, 1) => "package",
+                (crate::ci::compare::RebuildCategory::Tests, 1) => "test",
+                (crate::ci::compare::RebuildCategory::Artifacts, 1) => "artifact",
+                (crate::ci::compare::RebuildCategory::Python, _) => "Python",
+                _ => category.label(),
+            };
+            format!("{count} {label}")
+        })
+        .collect::<Vec<_>>();
+    if counts.native > 0 {
+        parts.push(format!("{} native", counts.native));
+    }
+    (!parts.is_empty()).then(|| format!("Rebuilds: {}", crate::support::ui::counts(&parts)))
+}
+
 pub(crate) fn bisect_evidence_lines(report: &crate::nix::bisect::Report) -> Vec<String> {
     let Some(evidence) = report.boundary().and_then(|test| test.evidence.as_ref()) else {
         return Vec::new();
@@ -741,6 +767,9 @@ pub(crate) fn report_lines(report: &Report, view: ReportView<'_>, verbose: bool)
         }
     }
     if let Some(line) = failure_summary(report) {
+        lines.push(line);
+    }
+    if let Some(line) = rebuild_summary(report) {
         lines.push(line);
     }
     if verbose && !report.log_retention.is_empty() {

--- a/tools/wasinix/src/github/markdown.rs
+++ b/tools/wasinix/src/github/markdown.rs
@@ -829,10 +829,18 @@ fn comparison_block(report: &Report) -> Markdown {
 }
 
 const COMPARE_LIST_ROWS: usize = 250;
+const PROJECT_CHECK_PREFIX: &str = "tests.project.";
+
+#[derive(Clone, Copy)]
+enum JobListPresentation {
+    Individual,
+    CollapseProjectChecks,
+}
 
 /// One collapsible job list, each row naming the version the job serves.
 fn job_list(
     title: &'static str,
+    presentation: JobListPresentation,
     jobs: &[crate::support::atoms::JobAddr],
     rebuild_roles: &BTreeMap<crate::support::atoms::JobAddr, RebuildRole>,
     identities: &BTreeMap<crate::support::atoms::JobAddr, String>,
@@ -861,7 +869,27 @@ fn job_list(
         Markdown::text(&jobs.len().to_string()),
         Markdown::constant(")</summary>\n\n"),
     ]);
+    let project_checks = matches!(presentation, JobListPresentation::CollapseProjectChecks)
+        .then(|| {
+            jobs.iter()
+                .filter(|job| job.as_str().starts_with(PROJECT_CHECK_PREFIX))
+                .count()
+        })
+        .unwrap_or_default();
+    let mut rendered_project_checks = false;
     for job in jobs.iter().take(COMPARE_LIST_ROWS) {
+        if project_checks > 0 && job.as_str().starts_with(PROJECT_CHECK_PREFIX) {
+            if !rendered_project_checks {
+                body = Markdown::concat([
+                    body,
+                    Markdown::constant("- "),
+                    Markdown::text(&format!("{project_checks} project checks at project")),
+                    Markdown::constant("\n"),
+                ]);
+                rendered_project_checks = true;
+            }
+            continue;
+        }
         body = Markdown::concat([
             body,
             Markdown::constant("- "),
@@ -957,6 +985,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     }
     body = body.push(job_list(
         "New evaluation failures",
+        JobListPresentation::Individual,
         &eval.new_eval_errors,
         &eval.rebuild_roles,
         &eval.identities,
@@ -966,6 +995,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     if let Some(builds) = &comparison.builds {
         body = body.push(job_list(
             "Removed jobs that passed",
+            JobListPresentation::Individual,
             &builds.dropped_successes,
             &eval.rebuild_roles,
             &eval.identities,
@@ -974,6 +1004,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
         ));
         body = body.push(job_list(
             "Fixed",
+            JobListPresentation::Individual,
             &builds.fixes,
             &eval.rebuild_roles,
             &eval.identities,
@@ -1011,6 +1042,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     } else {
         body = body.push(job_list(
             "Rebuilt",
+            JobListPresentation::CollapseProjectChecks,
             &eval.rebuilt,
             &eval.rebuild_roles,
             &eval.identities,
@@ -1020,6 +1052,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     }
     body = body.push(job_list(
         "Added",
+        JobListPresentation::Individual,
         &eval.added,
         &eval.rebuild_roles,
         &eval.identities,
@@ -1028,6 +1061,7 @@ fn comparison_lists(comparison: &Comparison) -> Markdown {
     ));
     body = body.push(job_list(
         "Removed",
+        JobListPresentation::Individual,
         &eval.removed,
         &eval.rebuild_roles,
         &eval.identities,

--- a/tools/wasinix/src/github/publish.rs
+++ b/tools/wasinix/src/github/publish.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use serde_json::json;
 
-use crate::ci::compare::RebuildCategory;
+use crate::ci::compare::rebuild_counts;
 use crate::ci::events::Snapshot;
 use crate::ci::report::{Conclusion, Fragment, Report};
 use crate::github::client::Client;
@@ -28,6 +28,19 @@ fn rebuild_label(name: &str, count: usize) -> String {
         _ => "501+",
     };
     format!("10.rebuilds-{name}: {bucket}")
+}
+
+fn rebuild_labels_match(current_labels: &[serde_json::Value], desired_labels: &[String]) -> bool {
+    let current = current_labels
+        .iter()
+        .filter_map(|label| label["name"].as_str())
+        .filter(|label| label.starts_with(REBUILD_LABEL_PREFIX))
+        .collect::<BTreeSet<_>>();
+    let desired = desired_labels
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    current == desired
 }
 
 pub struct Target {
@@ -77,42 +90,16 @@ fn rebuild_labels(report: &Report) -> Result<Option<Vec<String>>> {
     let Some(eval) = comparison.eval.as_ref() else {
         return Ok(None);
     };
-    let jobs: BTreeSet<_> = eval
-        .added
-        .iter()
-        .chain(&eval.removed)
-        .chain(&eval.rebuilt)
-        .collect();
-    let roles = jobs
-        .iter()
-        .map(|job| {
-            eval.rebuild_roles.get(*job).ok_or_else(|| {
-                crate::support::error::Error::Failure(format!(
-                    "comparison lacks a rebuild role for {job}"
-                ))
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let mut counts = BTreeMap::<RebuildCategory, usize>::new();
-    let mut native = 0;
-    for role in roles {
-        *counts.entry(role.category).or_default() += 1;
-        native += usize::from(role.native);
-    }
+    let counts = rebuild_counts(eval).ok_or_else(|| {
+        crate::support::error::Error::Failure("comparison has unclassified rebuilds".into())
+    })?;
     let mut labels = counts
+        .categories
         .into_iter()
-        .map(|(category, count)| {
-            let name = match category {
-                RebuildCategory::Packages => "packages",
-                RebuildCategory::Tests => "tests",
-                RebuildCategory::Artifacts => "artifacts",
-                RebuildCategory::Python => "python",
-            };
-            rebuild_label(name, count)
-        })
+        .map(|(category, count)| rebuild_label(category.label(), count))
         .collect::<Vec<_>>();
-    if native > 0 {
-        labels.push(rebuild_label("native", native));
+    if counts.native > 0 {
+        labels.push(rebuild_label("native", counts.native));
     }
     Ok(Some(labels))
 }
@@ -133,16 +120,19 @@ pub fn reconcile_rebuild_label(
     };
     let issue = format!("repos/{}/issues/{pull_request}", target.repository);
     let current = client.get(&issue)?;
-    let labels = current["labels"]
-        .as_array()
-        .ok_or_else(|| crate::support::error::Error::Failure("pull request has no labels".into()))?
+    let current_labels = current["labels"].as_array().ok_or_else(|| {
+        crate::support::error::Error::Failure("pull request has no labels".into())
+    })?;
+    if rebuild_labels_match(current_labels, &rebuild_labels) {
+        return Ok(());
+    }
+    let labels = current_labels
         .iter()
         .filter_map(|label| label["name"].as_str())
         .filter(|label| !label.starts_with(REBUILD_LABEL_PREFIX))
         .chain(rebuild_labels.iter().map(String::as_str))
         .collect::<Vec<_>>();
     client.put(&format!("{issue}/labels"), &json!({ "labels": labels }))?;
-    crate::support::ui::fact("rebuild labels", rebuild_labels.join(", "));
     Ok(())
 }
 
@@ -775,5 +765,26 @@ mod tests {
             "10.rebuilds-packages: 101-500"
         );
         assert_eq!(rebuild_label("packages", 501), "10.rebuilds-packages: 501+");
+    }
+
+    #[test]
+    fn matching_rebuild_labels_need_no_update() {
+        use serde_json::json;
+
+        let current = vec![
+            json!({ "name": "automated" }),
+            json!({ "name": "10.rebuilds-packages: 1" }),
+            json!({ "name": "10.rebuilds-tests: 1-10" }),
+        ];
+        let desired = vec![
+            "10.rebuilds-tests: 1-10".into(),
+            "10.rebuilds-packages: 1".into(),
+        ];
+
+        assert!(super::rebuild_labels_match(&current, &desired));
+        assert!(!super::rebuild_labels_match(
+            &current,
+            &["10.rebuilds-packages: 1".into()]
+        ));
     }
 }

--- a/tools/wasinix/src/support/schema.rs
+++ b/tools/wasinix/src/support/schema.rs
@@ -14,8 +14,8 @@ use crate::support::error::{Error, Result, request_error};
 const PROJECT_SCHEMA: &str = include_str!("../../../../schema/project.json");
 
 pub fn project_version() -> u64 {
-    serde_json::from_str::<Value>(PROJECT_SCHEMA)
-        .expect("schema/project.json must be valid JSON")["version"]
+    serde_json::from_str::<Value>(PROJECT_SCHEMA).expect("schema/project.json must be valid JSON")
+        ["version"]
         .as_u64()
         .expect("schema/project.json version must be an unsigned integer")
 }

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4062,6 +4062,32 @@ mod markdown {
     }
 
     #[test]
+    fn rebuilt_project_checks_share_one_detail_row() {
+        use crate::ci::compare::{RebuildCategory, RebuildRole};
+        use crate::support::atoms::JobAddr;
+
+        let (mut report, fragments) = scenarios::diff_green();
+        let eval = report.comparisons[0].eval.as_mut().unwrap();
+        for name in ["deadnix", "nil", "nixf", "statix", "treefmt"] {
+            let job = JobAddr(format!("tests.project.{name}"));
+            eval.rebuilt.push(job.clone());
+            eval.rebuild_roles.insert(
+                job,
+                RebuildRole {
+                    category: RebuildCategory::Tests,
+                    native: false,
+                },
+            );
+        }
+
+        let body = comment(&report, &fragments, None, &links()).into_string();
+        assert!(body.contains("- 5 project checks at project"), "{body}");
+        for name in ["deadnix", "nil", "nixf", "statix", "treefmt"] {
+            assert!(!body.contains(&format!("tests.project.{name}")), "{body}");
+        }
+    }
+
+    #[test]
     fn the_check_run_names_failing_jobs_and_stays_short() {
         let (report, fragments) = scenarios::failing();
         let projected = check(&report, &fragments, &links());

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4429,7 +4429,8 @@ mod render {
     use crate::ci::events::Event;
     use crate::ci::facts::{Diagnostic, DiagnosticSeverity, TestOutcome, TestResult};
     use crate::cli::render::{
-        LineRenderer, ReportView, failure_summary, report_lines, report_title, test_summary,
+        LineRenderer, ReportView, failure_summary, rebuild_summary, report_lines, report_title,
+        test_summary,
     };
     use crate::support::atoms::{Bytes, DurationSecs, JobAddr, JobStatus, RunState, TaskStatus};
 
@@ -4478,6 +4479,16 @@ mod render {
                 "Inspect failures: wasinix run failures /tmp/run",
                 "Inspect logs: wasinix run logs /tmp/run",
             ]
+        );
+    }
+
+    #[test]
+    fn a_comparison_reports_grouped_rebuild_counts() {
+        let report = scenarios::diff_green().0;
+
+        assert_eq!(
+            rebuild_summary(&report).as_deref(),
+            Some("Rebuilds: 1 package · 3 tests")
         );
     }
 


### PR DESCRIPTION
Make rebuild-label reconciliation a silent no-op when labels are already current, and print grouped rebuild counts once in normal CLI report output.