### PR TITLE
python-registry: deploy only overlay packages

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -125,15 +125,23 @@ jobs:
       # repo admin, which GITHUB_TOKEN never has:
       #   gh api -X POST repos/wasix-org/wasinix/pages -f build_type=workflow
       - name: Prepare Pages snapshot
+        id: stage-pages
         # Pages intentionally tracks the fresh build, independently of the
         # append-only volume publication above.
         if:
           always() && steps.published.outputs.cache-hit != 'true' &&
           steps.build-index.outcome == 'success'
         run: |
-          # materialize the result symlink with writable modes for the tarring action
-          mkdir site
-          cp -r --no-preserve=mode,ownership --dereference registry-result/. site/
+          mkdir -p site/simple
+          cp --no-preserve=mode,ownership --dereference \
+            registry-result/index.html registry-result/packages.json site/
+          cp --no-preserve=mode,ownership --dereference \
+            registry-result/simple/index.html site/simple/
+          for page in registry-result/simple/*/index.html; do
+            project="$(basename "$(dirname "$page")")"
+            cp -r --no-preserve=mode,ownership --dereference \
+              "registry-result/simple/$project" site/simple/
+          done
 
       - name: Upload Pages artifact
         if:

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -145,8 +145,8 @@ after a pin bump.
 
 ## The Python wheel index
 
-All shipped wheels, plus their transitive python deps, are published as a static
-PEP 503 "simple" index:
+All shipped wheels, plus their transitive Python dependencies, are built into a
+static PEP 503 index artifact:
 `.#legacyPackages.x86_64-linux.artifacts.registry.python`
 (`pkgs/python-registry/`). Serve the output from any static file host, or
 install directly:
@@ -169,8 +169,8 @@ say. A project has to resolve on one interpreter, not all of them, since a
 release states its own supported range.
 
 Alongside `simple/`, the index root carries `packages.json`: one JSON object per
-line naming a published wheel, which is how `wasmerio/wasmer-compat` decides
-which projects the index covers.
+line naming a wheel listed by `simple/`, which is how `wasmerio/wasmer-compat`
+decides which projects the deployed index covers.
 
 `simple/` lists the projects PyPI cannot supply: those shipping a
 platform-tagged wheel, and those whose package unit changes their source,
@@ -188,10 +188,9 @@ could have supplied pins it to our version and rejects whatever version the
 consuming project asks for. Listing one we patched too narrowly is the opposite
 defect: the resolver takes upstream's build and drops the patch.
 
-`all/simple/` lists every wheel published here, for installing the closure from
-this index alone with no PyPI at all. It carries no wheels of its own; its pages
-link to the copies under `simple/<project>/`, where every wheel lives whether or
-not its project is listed in `simple/`.
+The built artifact also has an `all/simple/` view for local tests that install
+the complete closure without PyPI. It is not deployed. Its pages link to the
+copies under `simple/<project>/` in the local artifact.
 
 Cross-installing for wasix from a host needs pip. `pip --platform wasix_wasm32`
 selects the tagged wheels, while uv's `--python-platform` is a closed enum with
@@ -238,7 +237,8 @@ bleeding-edge snapshot and may serve new bytes under an existing filename. Use
 the volume-backed index for immutable, reproducible installs.
 
 After a green build of main, `publish-index` uploads new filenames to the volume
-and deploys the fresh snapshot to GitHub Pages. The volume service is defined by
+and deploys the fresh `simple/` snapshot to GitHub Pages. Neither deployment
+contains the local `all/` view. The volume service is defined by
 `python-registry/app.yaml`.
 
 A wheel built by both interpreters is published once, under the one filename its
@@ -278,7 +278,8 @@ explicitly or already released. Changed wheels become an ephemeral per-PR Edge
 app serving an overlay index:
 
 ```sh
-pip install --index-url <preview>/all/simple --extra-index-url <prod>/all/simple
+pip install --index-url <preview>/simple --extra-index-url <prod>/simple \
+  --extra-index-url https://pypi.org/simple <pkg>
 ```
 
 which prefers the preview wheels by their longer local version. The app is

--- a/pkgs/python-registry/check-integrity.py
+++ b/pkgs/python-registry/check-integrity.py
@@ -2,7 +2,7 @@
 exactly the project dirs; every project-page anchor resolves to a file whose
 sha256 matches the fragment; every wheel has a PEP 658 .metadata sidecar whose
 hash matches data-core-metadata; no wheel on disk is missing from its page;
-packages.json lists exactly the served wheels; and every wheel's Requires-Dist
+packages.json lists exactly the wheels in simple/; and every wheel's Requires-Dist
 is satisfiable from the index alone, on each interpreter the wheel installs on.
 
 Usage: check-integrity.py <registry store path> <check-dependencies.py path>
@@ -141,9 +141,10 @@ def check_packages_json(root: Path, wheels: list[tuple[str, Path]]) -> None:
         if "filename" not in entry:
             fail(f"packages.json line {n} has no 'filename' key")
         listed.add(entry["filename"])
-    on_disk = {path.name for _, path in wheels}
-    if listed != on_disk:
-        fail(f"packages.json vs wheels on disk differ: {sorted(listed ^ on_disk)}")
+    projects = set(PROJECT_LINK.findall((root / "simple" / "index.html").read_text()))
+    expected = {path.name for project, path in wheels if project in projects}
+    if listed != expected:
+        fail(f"packages.json vs simple/ wheels differ: {sorted(listed ^ expected)}")
 
 
 def check_requirements(wheels: list[tuple[str, Path]], wheel_deps) -> None:

--- a/pkgs/python-registry/make-index.py
+++ b/pkgs/python-registry/make-index.py
@@ -12,7 +12,7 @@ Emits, per PEP 503 (+ PEP 629 version meta, PEP 658/714 metadata files):
   <out>/simple/<project>/index.html     file list with #sha256= anchors
   <out>/simple/<project>/<wheel>        the wheel itself (relative hrefs)
   <out>/simple/<project>/<wheel>.metadata   its core metadata, for resolvers
-  <out>/packages.json                   flat wheel list, for wasmer-compat
+  <out>/packages.json                   simple/ wheel list, for wasmer-compat
   <out>/all/simple/...                  the same listing over every wheel here
 """
 
@@ -21,6 +21,7 @@ import hashlib
 import html
 import json
 import re
+import shutil
 import sys
 import zipfile
 from pathlib import Path
@@ -404,6 +405,25 @@ def write_packages_json(dest: Path, served) -> None:
     )
 
 
+def primary_projects(
+    pages: dict[str, list[tuple]], supersedes: set[str]
+) -> dict[str, list[tuple]]:
+    return {
+        project: files
+        for project, files in pages.items()
+        if project in supersedes or any(is_native(fname) for fname, *_ in files)
+    }
+
+
+def write_primary_view(out: Path, pages: dict[str, list[tuple]]) -> None:
+    for project, files in sorted(pages.items()):
+        pdir = out / "simple" / project
+        pdir.mkdir(parents=True, exist_ok=True)
+        (pdir / "index.html").write_text(project_page(project, files))
+    proot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(pages)]
+    (out / "simple" / "index.html").write_text(page("Simple index", proot))
+
+
 def write_views(out: Path, pages: dict[str, list[tuple]], supersedes: set[str]) -> dict:
     """Write both PEP 503 listings over the wheels under simple/<project>/.
 
@@ -415,17 +435,8 @@ def write_views(out: Path, pages: dict[str, list[tuple]], supersedes: set[str]) 
     for. all/simple/ lists everything published, for installing the closure
     from here alone (docs/registry.md). Both point at one copy of each wheel.
     """
-    primary = {
-        project: files
-        for project, files in pages.items()
-        if project in supersedes or any(is_native(fname) for fname, *_ in files)
-    }
-    for project, files in sorted(primary.items()):
-        pdir = out / "simple" / project
-        pdir.mkdir(parents=True, exist_ok=True)
-        (pdir / "index.html").write_text(project_page(project, files))
-    proot = [f'    <a href="{p}/">{p}</a><br/>' for p in sorted(primary)]
-    (out / "simple" / "index.html").write_text(page("Simple index", proot))
+    primary = primary_projects(pages, supersedes)
+    write_primary_view(out, primary)
 
     for project, files in sorted(pages.items()):
         adir = out / "all" / "simple" / project
@@ -442,6 +453,11 @@ def write_views(out: Path, pages: dict[str, list[tuple]], supersedes: set[str]) 
 
 def main() -> None:
     ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--primary-only",
+        action="store_true",
+        help="omit the complete local all/simple view",
+    )
     ap.add_argument("dists", type=Path)
     ap.add_argument("out", type=Path)
     args = ap.parse_args()
@@ -491,8 +507,7 @@ def main() -> None:
             f"{listed}"
         )
 
-    served: list[tuple[str, str]] = []
-    # project -> the rows its page was built from, reused by the native view
+    # project -> the rows its page was built from, reused by both views
     pages: dict[str, list[tuple]] = {}
     for project, wheels in sorted(projects.items()):
         pdir = out / "simple" / project
@@ -504,7 +519,6 @@ def main() -> None:
             (pdir / f"{fname}.metadata").write_bytes(metadata)
             md_digest = hashlib.sha256(metadata).hexdigest()
             digest = hashlib.sha256(src.read_bytes()).hexdigest()
-            served.append((fname, digest))
             # rev/attr/published are publish-time facts (publish.py fills them
             # from the manifest); size is intrinsic and source decides which
             # listing the project lands in, so both are known here already.
@@ -526,13 +540,22 @@ def main() -> None:
     supersedes = {
         normalize(entry["name"]) for entry in dists if entry.get("supersedes")
     }
-    primary = write_views(out, pages, supersedes)
+    primary = primary_projects(pages, supersedes)
+    if args.primary_only:
+        for project in set(pages) - set(primary):
+            shutil.rmtree(out / "simple" / project)
+        write_primary_view(out, primary)
+    else:
+        write_views(out, pages, supersedes)
 
-    (out / "index.html").write_text(landing(projects))
+    (out / "index.html").write_text(landing(primary))
     (out / "provenance.json").write_text(
         json.dumps(provenance, indent=2, sort_keys=True) + "\n"
     )
-    write_packages_json(out / "packages.json", served)
+    write_packages_json(
+        out / "packages.json",
+        ((fname, digest) for files in primary.values() for fname, digest, *_ in files),
+    )
     print(
         f"indexed {sum(map(len, projects.values()))} wheels across {len(projects)} projects"
         f" ({len(primary)} of them served to a resolver beside PyPI)"

--- a/pkgs/python-registry/publish.py
+++ b/pkgs/python-registry/publish.py
@@ -3,15 +3,14 @@
 
 Copies new wheels from a freshly built structured-project registry
 into the S3-compatible volume behind the index app and regenerates the index
-HTML over everything published so far. Published wheel filenames are
-immutable: a changed build with an existing filename stays unpublished until a
-release-revisions.json bump gives it a new name, and nothing is ever deleted, so old
-lockfiles keep resolving.
+HTML over everything published so far that the overlay index owns. Published
+wheel filenames are immutable: a changed build with an existing filename stays
+unpublished until a release-revisions.json bump gives it a new name, and nothing
+is ever deleted, so old lockfiles keep resolving.
 
 Volume layout (= the web root served by the app):
-  index.html, simple/...     as in the nix output
-  all/simple/...             the same listing over every wheel published
-  packages.json              flat list of everything published so far
+  index.html, simple/...     native and WASIX-modified projects
+  packages.json              flat list of wheels served through simple/
   manifests/<wheel>.json     {project, sha256, metadata_sha256, requires_python,
                               size, published (UTC date, frozen at first publish),
                               + provenance: attr, drv_path, wasinix_rev}
@@ -107,8 +106,15 @@ def main():
     staging = tmp / "staging"
     conflicts, new = [], []
     manifests = dict(published)
+    current_primary = {
+        path.name
+        for path in (args.registry / "simple").iterdir()
+        if path.is_dir() and (path / "index.html").is_file()
+    }
     for whl in sorted((args.registry / "simple").glob("*/*.whl")):
         project = whl.parent.name
+        if project not in current_primary:
+            continue
         sha = hashlib.sha256(whl.read_bytes()).hexdigest()
         prev = published.get(whl.name)
         if prev:
@@ -194,11 +200,12 @@ def main():
     # a manifest predating the field has no flag, so a project last published
     # before it existed stays out of simple/ until its next publish
     supersedes = {m["project"] for m in manifests.values() if m.get("supersedes")}
-    primary = make_index.write_views(staging, pages, supersedes)
-    (staging / "index.html").write_text(make_index.landing(projects))
+    primary = make_index.primary_projects(pages, supersedes)
+    make_index.write_primary_view(staging, primary)
+    (staging / "index.html").write_text(make_index.landing(primary))
     make_index.write_packages_json(
         staging / "packages.json",
-        ((fname, m["sha256"]) for fname, m in manifests.items()),
+        ((fname, digest) for files in primary.values() for fname, digest, *_ in files),
     )
 
     print(

--- a/pkgs/python-registry/tests.nix
+++ b/pkgs/python-registry/tests.nix
@@ -37,7 +37,15 @@
 
   fakeRclone = pkgs.writeShellScript "fake-rclone" ''
     printf '%s\n' "$*" >> "$FAKE_RCLONE_LOG"
-    exit 3
+    operation="$6"
+    if [ "$operation" = copy ] && [ "$7" = test:bucket/manifests ]; then
+      exit 3
+    fi
+    if [ "$operation" = copy ]; then
+      source="''${@: -2:1}"
+      cp -r "$source/." "$FAKE_CAPTURE/"
+    fi
+    exit 0
   '';
 
   # pip-install <attr> from the index, assert expectDeps (top-level module/dir
@@ -70,14 +78,37 @@ in {
     name = "registry-publisher-explicit-rclone";
     packages = [pkgs.python3];
     script = ''
-      mkdir registry
-      echo '{}' > registry/provenance.json
+      native=native-1.0+wasix.1-cp313-none-wasix_wasm32.whl
+      pure=pure-1.0+wasix.1-py3-none-any.whl
+      mkdir -p registry/simple/native registry/simple/pure capture
+      printf native > "registry/simple/native/$native"
+      printf 'Metadata-Version: 2.1\n' > "registry/simple/native/$native.metadata"
+      printf pure > "registry/simple/pure/$pure"
+      printf 'Metadata-Version: 2.1\n' > "registry/simple/pure/$pure.metadata"
+      printf '<a href="native/">native</a>\n' > registry/simple/index.html
+      printf '<a href="$native">native</a>\n' > registry/simple/native/index.html
+      cat > registry/provenance.json <<EOF
+      {
+        "$native": {"attr": "native", "drv_path": "/nix/store/native", "name": "native", "rel_key": "native", "version": "1.0"},
+        "$pure": {"attr": "pure", "drv_path": "/nix/store/pure", "name": "pure", "rel_key": "pure", "version": "1.0"}
+      }
+      EOF
       export FAKE_RCLONE_LOG="$PWD/rclone.log"
+      export FAKE_CAPTURE="$PWD/capture"
       python3 ${./.}/publish.py \
         --registry registry \
         --remote test:bucket \
-        --rclone ${fakeRclone}
+        --rclone ${fakeRclone} \
+        --refresh-listings \
+        --dry-run
       grep -F 'copy test:bucket/manifests' "$FAKE_RCLONE_LOG"
+      test -f "capture/simple/native/$native"
+      test -f "capture/manifests/$native.json"
+      test ! -e capture/all
+      test ! -e capture/simple/pure
+      test ! -e "capture/manifests/$pure.json"
+      grep -F "$native" capture/packages.json
+      ! grep -F "$pure" capture/packages.json
     '';
   };
 

--- a/tools/wasinix/src/cli/preview.rs
+++ b/tools/wasinix/src/cli/preview.rs
@@ -227,7 +227,7 @@ fn published_body(
             Markdown::constant(", preferred over the published wheels by version:\n"),
             Markdown::fenced(
                 &format!(
-                    "pip install --index-url {url}/all/simple --extra-index-url {}/all/simple <pkg>",
+                    "pip install --index-url {url}/simple --extra-index-url {}/simple --extra-index-url https://pypi.org/simple <pkg>",
                     prod.as_deref().unwrap_or("<prod index>")
                 ),
                 "",

--- a/tools/wasinix/src/registries/python.rs
+++ b/tools/wasinix/src/registries/python.rs
@@ -583,7 +583,11 @@ pub fn preview_index(
     let dists = scratch.join("dists.json");
     crate::support::json::write(&dists, &Value::Array(suffixed))?;
     let mut index = Capability::PythonIndex.command()?;
-    index.arg(&dists).arg(site).current_dir(repo);
+    index
+        .arg("--primary-only")
+        .arg(&dists)
+        .arg(site)
+        .current_dir(repo);
     if !index.run()?.success() {
         return request_error("building the preview index failed");
     }

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -6981,6 +6981,12 @@ mod corpus {
                 .contains("nix build"),
             "publishing must reuse the output the Build workflow evaluated"
         );
+        let pages = field(step(publish_job, "stage-pages"), "run")
+            .as_str()
+            .unwrap();
+        assert!(pages.contains("registry-result/simple/*/index.html"));
+        assert!(!pages.contains("registry-result/."));
+        assert!(!pages.contains("registry-result/all"));
 
         let build_job = job(&build, "build");
         assert!(


### PR DESCRIPTION
## Motivation

The Python registry serves two different purposes. Local tests need a self-contained index containing the complete wheel closure, while the deployed registry is an overlay beside PyPI and should contain only projects PyPI cannot supply correctly: WASIX-native wheels and packages whose source or build is materially adapted here.

When `/simple/` was narrowed to that overlay set, the landing page and `packages.json` continued to describe the complete local closure, and the deployment still copied `/all/simple/`. `wasmerio/wasmer-compat` reads `packages.json` to decide which projects the overlay covers, so pure-Python projects such as `pg8000` were advertised even though they had no `/simple/<project>/` page. Consumers selected the WASIX overlay for those names instead of falling through to PyPI, then reached an empty or missing project entry.

## Changes

This makes the overlay project selection the single source of truth for every deployed surface:

- `/simple/`, the human landing page, and `packages.json` are generated from the same native-or-materially-modified project set.
- The complete `/all/simple/` closure remains in the built artifact for local resolution and tests, but a primary-only index mode omits it from generated deployments.
- Volume publication stages only overlay projects, their wheels, and their manifests. Pure-only closure wheels are not uploaded.
- GitHub Pages and generated PR previews deploy only the overlay view. Preview install instructions use PyPI for pure dependencies.
- Integrity checks pin `packages.json` to the projects listed by `/simple/`, and the publisher regression test proves that a native wheel is staged while a pure wheel and `/all` are absent.

The existing production `packages.json`, `/all` view, pure-only wheel objects, and pure-only manifests were repaired manually as a one-time migration. No recurring cleanup mechanism is added here.

## Testing

- focused synthetic index and publisher staging test
- `nix fmt`
- `git diff --check`
- `nix flake check --no-build`

Linear: https://linear.app/wasmer/issue/WAX-610/remove-empty-pure-python-packages-from-overlay-index