### PR TITLE
update: track wasmer releases instead of the main branch

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -18,6 +18,40 @@ target's remote and pinned as the commit it names, so a repository that tags
 target that does not accept the mode you asked for says so; `cargo-registry`
 re-resolves the crate pins.
 
+## Release-tracked pins
+
+Most pins bump to whatever is newest. A release-tracked pin does not: it moves
+only to an upstream release newer than the one it names, and otherwise stays
+put. `wasmer` is the one today, because the runtime the packages are built and
+tested against is the runtime users run — a pin following a branch would test
+every package against a commit nobody released.
+
+The pin's identity is the version its commit declares in the workspace
+manifest, which upstream moves in the release commit itself, so a commit merged
+into the trunk reports the release that precedes it. That identity must name a
+release that exists; if it does not, the update fails rather than proceeding,
+because a pin whose version has no release would find nothing newer forever and
+silently freeze. `flake.lock` records the tag as the input's `ref`, so the
+release a pin names is readable without resolving anything.
+
+Prereleases never win: an `-rc` or `-alpha` tag is not a release version and is
+skipped when picking the newest.
+
+A manual pin ahead of a release is still available — `wasmer@rev:<40-hex>` for
+an unreleased fix a package needs — with one rule: **the revision must already
+be merged upstream**. Nothing else refuses a pull-request head, which locks and
+builds perfectly well and then rides on code that may never merge. A tag skips
+this check, since a release is authoritative even when it was cut off a release
+branch. The manual pin stops being special on its own: once a release contains
+that commit, the release is newer than the pin's identity and the pin advances
+to it like any other.
+
+When a move lands on a release that does not contain what the outgoing pin
+carried — a pin held ahead, or a release cut off a release branch — the bump
+raises a note naming how many commits are dropped. A note makes the ChangeSet
+notable, which keeps auto-merge off, so the drop is reviewed rather than
+silently applied.
+
 How a pin bumps is declared next to it (`passthru.updateScript`, the standard
 nixpkgs convention); its constraints and quirks are comments in the same file. A
 derived pin is recalculated by the package's `updateScript`, so the bump is

--- a/flake.lock
+++ b/flake.lock
@@ -203,16 +203,18 @@
         "wasinix": "wasinix"
       },
       "locked": {
-        "lastModified": 1787736660,
-        "narHash": "sha256-YZA4bUKBmMP+Z9bp8Po7rfwnMN9xwYHckrpnxaI8k0M=",
-        "ref": "refs/heads/main",
-        "rev": "b62e8c11630738d4061c2572bd4dd315de335c0e",
-        "revCount": 20849,
+        "lastModified": 1788189023,
+        "narHash": "sha256-IfrwkJQEOHxXS/Ly/rn4xus7CROc9vv3MNDIHhzU7hU=",
+        "ref": "refs/tags/v7.4.0",
+        "rev": "32b50f8b600efa8e2d5f88593c453139bf1ca222",
+        "revCount": 20870,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/wasmerio/wasmer"
       },
       "original": {
+        "ref": "refs/tags/v7.4.0",
+        "submodules": true,
         "type": "git",
         "url": "https://github.com/wasmerio/wasmer"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     wasmer = {
-      url = "git+https://github.com/wasmerio/wasmer";
+      # A release tag, not a branch: the runtime the packages are built and
+      # tested against is the one users run. `wasinix update wasmer` moves
+      # this to the newest release and leaves it alone otherwise, so the ref
+      # here is the pin's identity rather than something to follow.
+      url = "git+https://github.com/wasmerio/wasmer?ref=refs/tags/v7.4.0&submodules=1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane.follows = "wasmer/crane";

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -4904,6 +4904,7 @@ mod update {
             command_drv_paths: Vec::new(),
             file: String::new(),
             accepts: vec!["revision".into()],
+            release_line: false,
             source: Some(serde_json::json!({"kind": "github", "owner": "o", "repo": "r"})),
             ownership: Ownership::default(),
         }
@@ -5052,6 +5053,7 @@ mod update {
             command_drv_paths: Vec::new(),
             file: file.into(),
             accepts: Vec::new(),
+            release_line: false,
             source: None,
             ownership: Ownership::default(),
         };

--- a/tools/wasinix/src/update/backends.rs
+++ b/tools/wasinix/src/update/backends.rs
@@ -12,7 +12,35 @@ use crate::support::format::short_rev;
 use crate::support::nix::eval_installable;
 use crate::support::ui;
 use crate::update::targets::{Backend, Target};
+use crate::update::upstream::Release;
 use crate::update::{Mode, REQUEST_ENV, Request};
+
+/// What a backend did: the outcome line the ChangeSet renders, and any notes
+/// the move itself raised. A note is the backend's own observation about the
+/// bump, distinct from the package-declared notes the fold collects later.
+#[derive(Debug, Default)]
+pub struct Outcome {
+    pub summary: Option<String>,
+    pub notes: Vec<String>,
+}
+
+impl Outcome {
+    fn summary(summary: String) -> Outcome {
+        Outcome {
+            summary: Some(summary),
+            notes: Vec::new(),
+        }
+    }
+}
+
+impl From<Option<String>> for Outcome {
+    fn from(summary: Option<String>) -> Outcome {
+        Outcome {
+            summary,
+            notes: Vec::new(),
+        }
+    }
+}
 
 /// The crate-pins backend reports its state rather than a version.
 static CRATE_STATE: LazyLock<Regex> =
@@ -266,27 +294,124 @@ pub(crate) fn flake_override_ref(source: &Value, rev: &str) -> Result<String> {
     }
 }
 
-fn update_flake_input(
-    repo: &Path,
-    target: &Target,
-    request: Option<&Request>,
-) -> Result<Option<String>> {
+/// A flake reference that names the release tag as well as its commit, so
+/// `flake.lock` records which release the pin is rather than an anonymous
+/// revision. The tag is a ref, not a substitute for the rev: the rev is what
+/// pins, and the ref only carries the identity.
+fn flake_release_ref(source: &Value, tag: &str, rev: &str) -> Result<String> {
+    let reference = flake_override_ref(source, rev)?;
+    let separator = if reference.contains('?') { '&' } else { '?' };
+    Ok(format!("{reference}{separator}ref=refs/tags/{tag}"))
+}
+
+/// The release a release-tracked pin should move to, if upstream has one
+/// newer than the pin. `None` leaves the pin where it is, which is what a
+/// quiet upstream and a pin already at the newest release both mean.
+fn release_move(target: &Target, before: &str) -> Result<Option<(Release, Option<String>)>> {
+    let mirror = release_mirror(target)?;
+    let releases = crate::update::upstream::releases(&mirror)?;
+    let current = crate::update::upstream::identity(&mirror, before, &releases)?;
+    let Some(release) = crate::update::upstream::newer_than(&releases, current) else {
+        ui::note(format!("  {current} is the newest release"));
+        return Ok(None);
+    };
+    // Whether the release still contains what the outgoing pin carried. A
+    // pin deliberately held ahead of its release, or a release cut off a
+    // release branch, makes this false: the move is still the right one, but
+    // it drops commits and must not land unreviewed.
+    let dropped = crate::update::upstream::commits_not_in(&mirror, before, &release.rev)?;
+    let note = (dropped > 0).then(|| {
+        format!(
+            "{} {current} -> {} does not contain the outgoing pin {}: {dropped} commit(s) it \
+             carried are not in the release. Confirm nothing needed is lost before merging.",
+            target.name,
+            release.version,
+            short_rev(before),
+        )
+    });
+    Ok(Some((release.clone(), note)))
+}
+
+/// The release an explicit release request names.
+fn requested_release(target: &Target, value: &str) -> Result<Release> {
+    let Some(version) = crate::update::upstream::Version::parse(value) else {
+        return request_error(format!(
+            "{}: {value:?} is not a release version",
+            target.name
+        ));
+    };
+    let mirror = release_mirror(target)?;
+    let releases = crate::update::upstream::releases(&mirror)?;
+    match crate::update::upstream::release_named(&releases, version) {
+        Some(release) => Ok(release.clone()),
+        None => request_error(format!("{}: no release {version} upstream", target.name)),
+    }
+}
+
+fn release_mirror(target: &Target) -> Result<std::path::PathBuf> {
+    let Some(repository) = target
+        .source
+        .as_ref()
+        .and_then(crate::update::upstream::source_repository)
+    else {
+        return request_error(format!(
+            "{} tracks releases but declares no git source",
+            target.name
+        ));
+    };
+    crate::update::upstream::mirror(&repository)
+}
+
+fn update_flake_input(repo: &Path, target: &Target, request: Option<&Request>) -> Result<Outcome> {
     let before = flake_input_rev(repo, &target.input)?;
-    let requested = request.map(|request| request.value.as_str());
+    let source = || {
+        request
+            .and_then(|request| request.source.clone())
+            .or_else(|| target.source.clone())
+            .unwrap_or(Value::Null)
+    };
+    let mut notes = Vec::new();
+    // What the lock must hold afterwards, for the request kinds that name a
+    // commit. A resolution that lands somewhere else is a failure, not a
+    // surprise the caller has to notice in the receipt.
+    let mut expected: Option<String> = None;
     let override_ref = match request {
-        None => None,
+        Some(request) if request.mode == Mode::Release => {
+            if !target.release_line {
+                return request_error(format!("{} only accepts revision requests", target.name));
+            }
+            let release = requested_release(target, &request.value)?;
+            expected = Some(release.rev.clone());
+            Some(flake_release_ref(&source(), &release.tag, &release.rev)?)
+        }
         Some(request) if request.mode != Mode::Revision => {
             return request_error(format!("{} only accepts revision requests", target.name));
         }
         Some(request) => {
-            let source = request.source.as_ref().unwrap_or(&Value::Null);
-            Some(flake_override_ref(source, &request.value).map_err(|_| {
+            expected = Some(request.value.clone());
+            Some(flake_override_ref(&source(), &request.value).map_err(|_| {
                 crate::support::error::Error::Request(format!(
                     "{} has no Git revision source",
                     target.name
                 ))
             })?)
         }
+        // A release-tracked pin never follows its ref. Advancing to the
+        // newest release is the whole rule; anything else would put the pin
+        // back on whatever the branch happened to hold.
+        None if target.release_line => match release_move(target, &before)? {
+            None => {
+                let outcome = "up to date".to_string();
+                ui::note(format!("  {outcome}"));
+                return Ok(Outcome::summary(outcome));
+            }
+            Some((release, note)) => {
+                notes.extend(note);
+                expected = Some(release.rev.clone());
+                Some(flake_release_ref(&source(), &release.tag, &release.rev)?)
+            }
+        },
+        None => None,
     };
     let mut command = vec!["nix".into(), "flake".into()];
     if let Some(reference) = &override_ref {
@@ -305,11 +430,11 @@ fn update_flake_input(
         return request_error(format!("nix flake pin update exited {code}"));
     }
     let after = flake_input_rev(repo, &target.input)?;
-    if requested.is_some_and(|rev| rev != after) {
+    if expected.as_deref().is_some_and(|rev| rev != after) {
         return request_error(format!(
             "{} resolved requested revision {} to {after}",
             target.name,
-            requested.unwrap_or_default()
+            expected.unwrap_or_default()
         ));
     }
     let outcome = if before == after {
@@ -318,7 +443,13 @@ fn update_flake_input(
         format!("{} -> {}", short_rev(&before), short_rev(&after))
     };
     ui::note(format!("  {outcome}"));
-    Ok(Some(outcome))
+    for note in &notes {
+        ui::warning(note);
+    }
+    Ok(Outcome {
+        summary: Some(outcome),
+        notes,
+    })
 }
 
 fn update_crate_pins(repo: &Path, request: Option<&Request>) -> Result<Option<String>> {
@@ -332,14 +463,42 @@ fn update_crate_pins(repo: &Path, request: Option<&Request>) -> Result<Option<St
         .map(|(_, rest)| rest.trim().to_string()))
 }
 
-pub fn run_backend(
-    repo: &Path,
-    target: &Target,
-    request: Option<&Request>,
-) -> Result<Option<String>> {
+pub fn run_backend(repo: &Path, target: &Target, request: Option<&Request>) -> Result<Outcome> {
     match target.backend {
-        Backend::UpdateScript => run_update_script(repo, target, request),
+        Backend::UpdateScript => run_update_script(repo, target, request).map(Outcome::from),
         Backend::FlakeInput => update_flake_input(repo, target, request),
-        Backend::CratePins => update_crate_pins(repo, request),
+        Backend::CratePins => update_crate_pins(repo, request).map(Outcome::from),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The tag rides along as a ref so the lock records which release the pin
+    /// is; the rev is still what pins, and submodules must survive both.
+    #[test]
+    fn a_release_reference_carries_the_tag_beside_the_revision() {
+        let source = serde_json::json!({
+            "kind": "git",
+            "url": "https://github.com/wasmerio/wasmer",
+            "submodules": true,
+        });
+        let rev = "32b50f8b600efa8e2d5f88593c453139bf1ca222";
+        assert_eq!(
+            flake_release_ref(&source, "v7.4.0", rev).unwrap(),
+            format!(
+                "git+https://github.com/wasmerio/wasmer?rev={rev}&submodules=1&ref=refs/tags/v7.4.0"
+            )
+        );
+    }
+
+    #[test]
+    fn a_github_release_reference_still_names_the_tag() {
+        let source = serde_json::json!({"kind": "github", "owner": "o", "repo": "r"});
+        assert_eq!(
+            flake_release_ref(&source, "v1.2.3", "abc").unwrap(),
+            "github:o/r/abc?ref=refs/tags/v1.2.3"
+        );
     }
 }

--- a/tools/wasinix/src/update/drive.rs
+++ b/tools/wasinix/src/update/drive.rs
@@ -343,7 +343,9 @@ pub fn drive_timed(repo: &Path, options: Options, timings: &mut Recorder) -> Res
             Ok(outcome) => {
                 let after = repo_status(repo)?;
                 let changed = after != before;
+                let backend_notes = outcome.notes;
                 let outcome = outcome
+                    .summary
                     .unwrap_or_else(|| if changed { "updated" } else { "up to date" }.to_string());
                 let outcome = backends::normalize_outcome(target, outcome, changed);
                 if changed {
@@ -354,6 +356,20 @@ pub fn drive_timed(repo: &Path, options: Options, timings: &mut Recorder) -> Res
                         })?;
                     }
                     changes.entries.push(entry);
+                    // The backend's own notes ride with the bump: they say
+                    // something about this move that no later evaluation of
+                    // the new tree could rediscover.
+                    for note in backend_notes {
+                        changes.entries.push(Entry {
+                            kind: EntryKind::Notable,
+                            subject: target.name.clone(),
+                            from: None,
+                            to: None,
+                            detail: Some(note),
+                            changelog: None,
+                            files: Vec::new(),
+                        });
+                    }
                     moved.push(target);
                 } else {
                     changes.unchanged.push(Unchanged {

--- a/tools/wasinix/src/update/mod.rs
+++ b/tools/wasinix/src/update/mod.rs
@@ -17,5 +17,6 @@ pub mod snapshot;
 pub mod sync;
 pub mod targets;
 pub mod timing;
+pub mod upstream;
 
 pub use request::{Mode, REQUEST_ENV, Request};

--- a/tools/wasinix/src/update/select.rs
+++ b/tools/wasinix/src/update/select.rs
@@ -61,7 +61,11 @@ fn resolve_tag(targets: &[Target], name: &str, tag: &str) -> Result<String> {
         .iter()
         .find(|target| target.name == name)
         .ok_or_else(|| crate::support::error::Error::Request(format!("unknown target {name:?}")))?;
-    let Some(repository) = target.source.as_ref().and_then(source_repository) else {
+    let Some(repository) = target
+        .source
+        .as_ref()
+        .and_then(crate::update::upstream::source_repository)
+    else {
         return request_error(format!(
             "tag:{tag}: {name} declares no git source to resolve a tag against"
         ));
@@ -96,17 +100,41 @@ pub(crate) fn tag_commit(output: &str) -> Option<&str> {
     found
 }
 
-/// The clone url a target's source names, for the backends that have one.
-fn source_repository(source: &Value) -> Option<String> {
-    match source["kind"].as_str()? {
-        "github" => Some(format!(
-            "https://github.com/{}/{}.git",
-            source["owner"].as_str()?,
-            source["repo"].as_str()?
-        )),
-        "git" => source["url"].as_str().map(str::to_string),
-        _ => None,
+/// A manual revision must already be merged upstream. Nothing else stops a
+/// pin naming a pull-request head: the commit is fetchable, so it locks and
+/// builds, and the pin then rides on code that may never be merged and that
+/// no release will ever contain. A tag skips this — a release is
+/// authoritative even when it was cut off a release branch.
+fn require_merged(targets: &[Target], name: &str, rev: &str) -> Result<()> {
+    let Some(target) = targets.iter().find(|target| target.name == name) else {
+        return request_error(format!("unknown target {name:?}"));
+    };
+    if !target.release_line {
+        return Ok(());
     }
+    // A malformed revision is the request grammar's error to report, with
+    // its own message; this gate must not answer it with "not merged".
+    if crate::support::atoms::Rev::parse(rev).is_err() {
+        return Ok(());
+    }
+    let Some(repository) = target
+        .source
+        .as_ref()
+        .and_then(crate::update::upstream::source_repository)
+    else {
+        return request_error(format!(
+            "rev:{rev}: {name} declares no git source to check the revision against"
+        ));
+    };
+    let mirror = crate::update::upstream::mirror(&repository)?;
+    if crate::update::upstream::is_merged(&mirror, rev)? {
+        return Ok(());
+    }
+    request_error(format!(
+        "rev:{rev}: not merged into {repository} {}; pin a merged commit, \
+         not a pull-request head",
+        crate::update::upstream::TRUNK
+    ))
 }
 
 /// Validate per-target requests against the modes each target declares.
@@ -224,7 +252,10 @@ pub fn target_requests(
         }
         use crate::support::naming::SourceSpec;
         let (mode, value) = match crate::support::naming::source_spec(source.as_str())? {
-            SourceSpec::Revision(rev) => (Mode::Revision, rev.to_string()),
+            SourceSpec::Revision(rev) => {
+                require_merged(targets, &name, rev)?;
+                (Mode::Revision, rev.to_string())
+            }
             // A tag names one commit; resolving it here means nothing
             // downstream learns a third kind of source.
             SourceSpec::Tag(tag) => (Mode::Revision, resolve_tag(targets, &name, tag)?),

--- a/tools/wasinix/src/update/targets.rs
+++ b/tools/wasinix/src/update/targets.rs
@@ -36,6 +36,11 @@ pub struct Target {
     /// Repo-relative pin file, from meta.position.
     pub file: String,
     pub accepts: Vec<String>,
+    /// Whether the pin follows upstream releases rather than a branch. A
+    /// release-tracked input advances only to a newer release, so an
+    /// ordinary "bump to whatever the ref resolves to now" would defeat it.
+    #[serde(default)]
+    pub release_line: bool,
     pub source: Option<Value>,
     #[serde(default)]
     pub ownership: Ownership,
@@ -66,6 +71,7 @@ impl Target {
             command_drv_paths: Vec::new(),
             file: String::new(),
             accepts: Vec::new(),
+            release_line: false,
             source: None,
             ownership: Ownership::default(),
         }
@@ -100,6 +106,12 @@ impl Target {
     }
 }
 
+/// Flake inputs whose pin follows upstream releases instead of a branch.
+/// The runtime the packages are built and tested against is the one users
+/// run, so its pin names a release rather than whatever the branch held the
+/// moment the updater ran.
+const RELEASE_LINE_INPUTS: &[&str] = &["wasmer"];
+
 /// Flake inputs are their own targets so `update nixpkgs` works like a
 /// package; the crate-pin set is named for the file it regenerates.
 pub(crate) fn builtin_targets(ownership: Ownership) -> Vec<Target> {
@@ -107,6 +119,7 @@ pub(crate) fn builtin_targets(ownership: Ownership) -> Vec<Target> {
         .into_iter()
         .map(|name| {
             let mut target = Target::flake(name);
+            target.release_line = RELEASE_LINE_INPUTS.contains(&name);
             target.ownership = ownership.clone();
             target
         })
@@ -221,6 +234,7 @@ pub(crate) fn declared_target(repo: &Path, attr: &str, value: &Value) -> Result<
             .map(|file| repo_relative(file, repo))
             .unwrap_or_default(),
         accepts: declaration.accepts,
+        release_line: false,
         source: declaration.source,
         ownership: declaration.ownership,
     })
@@ -305,6 +319,9 @@ pub fn all_targets(
             };
             if target.source.is_some() && !target.version.is_empty() {
                 target.accepts.push("revision".into());
+                if target.release_line {
+                    target.accepts.push("release".into());
+                }
             }
         }
         targets.push(target);

--- a/tools/wasinix/src/update/upstream.rs
+++ b/tools/wasinix/src/update/upstream.rs
@@ -1,0 +1,293 @@
+//! What a git-sourced pin's upstream says about itself: which releases exist,
+//! which commits are merged, and what version a commit calls itself.
+//!
+//! A release-tracked pin advances only to a newer release, so the questions
+//! all need real history rather than a `ls-remote` answer: whether a manual
+//! revision is merged, and whether a release still contains what the outgoing
+//! pin carried. One bare blobless mirror per repository answers all of them
+//! and is reused across runs.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::support::error::{Result, request_error};
+use crate::support::git;
+
+/// The branch a manual revision must be merged into. Releases are cut from
+/// it, so a commit outside it has no release that will ever contain it.
+pub const TRUNK: &str = "main";
+
+/// A release version. Wasmer-style `vMAJOR.MINOR.PATCH`, with anything
+/// carrying a prerelease suffix rejected rather than ordered: an `-rc.1` is
+/// not a release and must never win the "newest" comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+impl Version {
+    /// Parse a release version, with or without the `v` prefix. `None` for a
+    /// prerelease, a build-metadata suffix, or anything not three numbers:
+    /// the caller wants those skipped, not diagnosed.
+    pub fn parse(text: &str) -> Option<Version> {
+        let text = text.strip_prefix('v').unwrap_or(text);
+        if text.contains(['-', '+']) {
+            return None;
+        }
+        let mut parts = text.split('.');
+        let mut number = || parts.next()?.parse::<u64>().ok();
+        let (major, minor, patch) = (number()?, number()?, number()?);
+        parts.next().is_none().then_some(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// A release tag and the commit it names.
+#[derive(Debug, Clone)]
+pub struct Release {
+    pub version: Version,
+    pub tag: String,
+    pub rev: String,
+}
+
+/// The clone url a target's source names.
+pub fn source_repository(source: &Value) -> Option<String> {
+    match source["kind"].as_str()? {
+        "github" => Some(format!(
+            "https://github.com/{}/{}.git",
+            source["owner"].as_str()?,
+            source["repo"].as_str()?
+        )),
+        "git" => source["url"].as_str().map(str::to_string),
+        _ => None,
+    }
+}
+
+fn mirror_root() -> Result<PathBuf> {
+    let root = match crate::support::env::xdg_state_home() {
+        Some(state) => state.join("wasinix/upstream"),
+        None => crate::support::shell::home_dir()?.join(".local/state/wasinix/upstream"),
+    };
+    Ok(root)
+}
+
+/// A stable directory name for a clone url, so the mirror is reused rather
+/// than re-cloned. Non-word bytes collapse to `-`; the url stays readable in
+/// the path, which matters when someone has to inspect the cache by hand.
+fn mirror_key(repository: &str) -> String {
+    let mut key = String::with_capacity(repository.len());
+    for c in repository.trim_end_matches(".git").chars() {
+        if c.is_ascii_alphanumeric() {
+            key.push(c);
+        } else if !key.ends_with('-') {
+            key.push('-');
+        }
+    }
+    key.trim_matches('-').to_string()
+}
+
+/// A bare blobless mirror of `repository`, cloned once and refreshed after.
+/// Blobless keeps the clone small while still allowing `git show` to fetch
+/// the one file a version read needs.
+pub fn mirror(repository: &str) -> Result<PathBuf> {
+    let dir = mirror_root()?.join(mirror_key(repository));
+    if dir.join("HEAD").exists() {
+        git::git_logged(&dir, &["fetch", "--prune", "--tags", "origin"])?;
+        return Ok(dir);
+    }
+    crate::support::fs::create_dir_all(&mirror_root()?)?;
+    git::git_global(&[
+        "clone",
+        "--bare",
+        "--filter=blob:none",
+        repository,
+        &dir.to_string_lossy(),
+    ])?;
+    Ok(dir)
+}
+
+/// Every release the mirror knows, oldest first. Prereleases are dropped:
+/// `Version::parse` refuses them, so an `-rc` tag cannot be selected as the
+/// newest release by accident.
+pub fn releases(mirror: &Path) -> Result<Vec<Release>> {
+    let output = git::git(mirror, &["show-ref", "--dereference", "--tags"])?;
+    let mut found: Vec<Release> = Vec::new();
+    for line in output.lines() {
+        let Some((rev, reference)) = line.split_once(' ') else {
+            continue;
+        };
+        // An annotated tag lists the tag object and, as `^{}`, the commit.
+        // Take the dereferenced line and let it replace the tag object's.
+        let dereferenced = reference.ends_with("^{}");
+        let reference = reference.trim_end_matches("^{}");
+        let Some(tag) = reference.strip_prefix("refs/tags/") else {
+            continue;
+        };
+        let Some(version) = Version::parse(tag) else {
+            continue;
+        };
+        match found.iter_mut().find(|release| release.tag == tag) {
+            Some(existing) if dereferenced => existing.rev = rev.to_string(),
+            Some(_) => {}
+            None => found.push(Release {
+                version,
+                tag: tag.to_string(),
+                rev: rev.to_string(),
+            }),
+        }
+    }
+    found.sort_by_key(|release| release.version);
+    Ok(found)
+}
+
+/// The version a commit calls itself, from the workspace manifest. Tags and
+/// the manifest move together in one release commit, so a commit merged into
+/// the trunk reports the newest release that precedes it — which is exactly
+/// the identity a "newer release than this pin" comparison needs.
+pub fn version_at(mirror: &Path, rev: &str) -> Result<Version> {
+    let manifest = git::git(mirror, &["show", &format!("{rev}:Cargo.toml")])?;
+    let mut in_workspace = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_workspace = line == "[workspace.package]";
+            continue;
+        }
+        if !in_workspace {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "version" {
+            continue;
+        }
+        let text = value.trim().trim_matches('"');
+        return Version::parse(text).ok_or_else(|| {
+            crate::support::error::Error::Request(format!(
+                "{rev} declares workspace version {text:?}, which is not a release version"
+            ))
+        });
+    }
+    request_error(format!(
+        "{rev} has no [workspace.package] version in Cargo.toml"
+    ))
+}
+
+/// Whether a commit is merged into the trunk. A pin outside it is a commit
+/// no release will ever contain, which is the pull-request head this gate
+/// exists to refuse.
+pub fn is_merged(mirror: &Path, rev: &str) -> Result<bool> {
+    git::is_ancestor(mirror, rev, &format!("refs/heads/{TRUNK}"))
+}
+
+/// The release a pinned commit should be compared against, and the check
+/// that it names a release that exists.
+///
+/// Reading the identity from the manifest assumes the trunk only learns a new
+/// version through the release commit itself. If that ever stops holding, a
+/// pin taken in the window would report an unreleased version, and every
+/// later comparison would find nothing newer and silently freeze the pin. A
+/// frozen pin looks exactly like a quiet upstream, so this refuses loudly
+/// instead.
+pub fn identity(mirror: &Path, rev: &str, releases: &[Release]) -> Result<Version> {
+    let version = version_at(mirror, rev)?;
+    if !releases.iter().any(|release| release.version == version) {
+        return request_error(format!(
+            "pinned commit {rev} declares version {version}, which has no release tag; \
+             the pin cannot be compared against upstream releases"
+        ));
+    }
+    Ok(version)
+}
+
+/// The release naming an exact version, for an explicit release request.
+pub fn release_named(releases: &[Release], version: Version) -> Option<&Release> {
+    releases.iter().find(|release| release.version == version)
+}
+
+/// How many commits `rev` carries that `reference` does not. Zero means the
+/// reference already contains everything the revision did.
+pub fn commits_not_in(mirror: &Path, rev: &str, reference: &str) -> Result<usize> {
+    let output = git::git(
+        mirror,
+        &["rev-list", "--count", &format!("{reference}..{rev}")],
+    )?;
+    output.trim().parse().map_err(|_| {
+        crate::support::error::Error::Request(format!(
+            "git rev-list --count {reference}..{rev} returned {output:?}"
+        ))
+    })
+}
+
+/// The newest release strictly newer than `current`, if upstream has one.
+pub fn newer_than(releases: &[Release], current: Version) -> Option<&Release> {
+    releases.iter().rfind(|release| release.version > current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prereleases_are_not_release_versions() {
+        assert_eq!(
+            Version::parse("v7.4.0"),
+            Some(Version {
+                major: 7,
+                minor: 4,
+                patch: 0
+            })
+        );
+        assert_eq!(Version::parse("7.4.0"), Version::parse("v7.4.0"));
+        for text in ["v7.3.0-rc.1", "v7.2.0-alpha.2", "v7.4", "v7.4.0.1", "main"] {
+            assert_eq!(Version::parse(text), None, "{text} parsed as a release");
+        }
+    }
+
+    #[test]
+    fn versions_order_numerically_rather_than_lexically() {
+        let (v9, v10) = (Version::parse("v7.9.0"), Version::parse("v7.10.0"));
+        assert!(v9 < v10, "{v9:?} should precede {v10:?}");
+    }
+
+    #[test]
+    fn newest_wins_and_an_equal_release_is_not_newer() {
+        let releases: Vec<Release> = ["v7.2.0", "v7.2.1", "v7.3.0", "v7.4.0"]
+            .into_iter()
+            .map(|tag| Release {
+                version: Version::parse(tag).unwrap(),
+                tag: tag.to_string(),
+                rev: tag.to_string(),
+            })
+            .collect();
+        let current = Version::parse("v7.2.1").unwrap();
+        assert_eq!(
+            newer_than(&releases, current).map(|r| r.tag.as_str()),
+            Some("v7.4.0")
+        );
+        let newest = Version::parse("v7.4.0").unwrap();
+        assert!(newer_than(&releases, newest).is_none());
+    }
+
+    #[test]
+    fn mirror_keys_are_stable_and_path_safe() {
+        assert_eq!(
+            mirror_key("https://github.com/wasmerio/wasmer.git"),
+            "https-github-com-wasmerio-wasmer"
+        );
+        assert!(!mirror_key("https://example.com/a/../b").contains(".."));
+    }
+}


### PR DESCRIPTION
The `wasmer` input declared no `ref=`, so `nix flake update wasmer` followed the default branch: the Monday cron and the release-triggered dispatch both pinned whatever main held at the moment they ran. Every package was built and tested against a commit nobody released, and the pin carried no identity a report or a bisect could name. The pin this replaces is `b62e8c116`, titled *"Potential fix for pull request finding"*.

## The rule

A release-tracked pin advances only to an upstream release newer than the one it names, and otherwise stays put. `wasmer` is the only such input today.

- **Identity** is the version the pinned commit declares in `[workspace.package]`. Upstream moves that in the release commit itself, which reaches the trunk only as the tagged merge, so a commit merged into the trunk reports the release preceding it. The identity must name a release that exists — a pin whose version has no release would find nothing newer forever and freeze without saying so, which looks exactly like a quiet upstream.
- **Prereleases** are not release versions. `-rc`/`-alpha` tags are skipped rather than ordered, so one cannot win the "newest" comparison.
- **Manual pins ahead of a release** stay available for an unreleased fix a package needs, gated on the revision already being merged upstream. Nothing refused a pull-request head before: it locks and builds fine, and the pin then rides on code that may never merge and that no release will ever contain. A tag skips the gate, since a release is authoritative even when cut off a release branch (4 of wasmer's 30 patch releases were). Such a pin stops being special on its own — once a release contains that commit, the release is newer than the pin's identity and it advances like any other.
- **Dropped commits** are reported, not swallowed. If a move lands on a release that does not contain what the outgoing pin carried, the bump raises a note counting them. A note makes the ChangeSet notable, which keeps auto-merge off, so a human clears it.

`flake.lock` now records the tag as the input's `ref`, so the release a pin names is readable without resolving anything.

## Shape

- `update/upstream.rs` (new) — release enumeration, version parsing, identity, reachability and containment, over one bare blobless mirror per repository, reused across runs. Both questions need real history, so `ls-remote` alone will not do.
- `update/backends.rs` — the release path in `update_flake_input`, plus `Outcome` so a backend can return notes alongside its outcome line.
- `update/select.rs` — the merged-commit gate on manual `rev:` requests.
- `update/targets.rs` — `release_line` on `Target`; `wasmer` flagged, and it now accepts release requests (`wasinix update wasmer@7.4.0`).
- `update/drive.rs` — backend notes become `Notable` ChangeSet entries.
- `flake.nix` / `flake.lock` — the pin moves to `refs/tags/v7.4.0`, a strict forward move of 21 commits from `b62e8c116`.

## Verification

- 392 tests pass; `cargo clippy --all-targets` clean for the touched files.
- The logic was run against a real wasmer checkout: prereleases filtered, `identity(b62e8c116)` = `7.3.0`, newest newer release = `v7.4.0`, dropped commits = 0, so the first bump raises no note.
- `nix flake lock --override-input wasmer 'git+https://github.com/wasmerio/wasmer?ref=refs/tags/v7.4.0&rev=32b50f8b600...&submodules=1'` — the exact reference this code builds — produces the committed lock, with `submodules` preserved.

## Not in scope

The 11 out-of-tree wasmer patches in `pkgs/overlays/w/wasmer` are a separate effort. Worth noting for review: all 11 still apply cleanly to v7.4.0, so this change loses none of them, and none of their fixes are in any release.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPbZmY2EjbJrim78yWnTeD