### PR TITLE
wasinix: satisfy a * webc dependency from any published version

### DIFF
--- a/tools/wasinix/src/registries/wasmer.rs
+++ b/tools/wasinix/src/registries/wasmer.rs
@@ -537,6 +537,48 @@ const QUERY: &str = "query GetPackageVersion($name: String!, $version: String!) 
     id readme distribution { webcSha256Hash piritaSha256Hash } \
     packagewebcSet(first: 1) { edges { node { tag webc { webcSha256 } webcV3 { webcSha256 } } } } } }";
 
+/// How the pre-flight verifies a dependency will resolve on the registry.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DependencyCheck<'a> {
+    /// `*` resolves at load time, so any published version of the package does.
+    AnyVersion,
+    /// A pin resolves to one version, which must be present.
+    ExactVersion(&'a str),
+}
+
+/// Classify a dependency from its manifest requirement. `resolved` is the
+/// version this checkout built, used only for a pin.
+pub(crate) fn dependency_check<'a>(
+    requirement: Option<&str>,
+    resolved: &'a str,
+) -> DependencyCheck<'a> {
+    match requirement {
+        Some("*") => DependencyCheck::AnyVersion,
+        _ => DependencyCheck::ExactVersion(resolved),
+    }
+}
+
+const PACKAGE_QUERY: &str =
+    "query GetPackage($name: String!) { getPackage(name: $name) { lastVersion { version } } }";
+
+// Whether the registry serves any version of a package. A `*` dependency is
+// satisfied by whatever is published, so this stands in for an exact-version
+// lookup there.
+pub fn package_published(graphql_url: &str, full_name: &str) -> Result<bool> {
+    let payload = json!({
+        "query": PACKAGE_QUERY,
+        "variables": {"name": full_name},
+        "operationName": "GetPackage",
+    });
+    let document: Value = crate::support::http::post_json(graphql_url, &payload)?;
+    if let Some(errors) = document.get("errors").filter(|errors| !errors.is_null()) {
+        if !errors.as_array().is_some_and(Vec::is_empty) {
+            return package_error(format!("GraphQL returned errors for {full_name}: {errors}"));
+        }
+    }
+    Ok(!document["data"]["getPackage"]["lastVersion"]["version"].is_null())
+}
+
 pub fn get_published(graphql_url: &str, full_name: &str, version: &str) -> Result<Published> {
     let payload = json!({
         "query": QUERY,
@@ -1066,18 +1108,32 @@ fn publish_one(
     // registry or the published webc cannot resolve them. Keyed by
     // (name, version): a dependent needs its exact pin.
     for (dep_name, dep_version) in &pkg.resolved_dependencies {
-        let dep = (dep_name.clone(), dep_version.clone());
+        let requirement = pkg.dependencies.get(dep_name).map(String::as_str);
+        let version = match dependency_check(requirement, dep_version) {
+            // Any published version resolves a `*`; the build's own is irrelevant
+            // and never has to be published.
+            DependencyCheck::AnyVersion => {
+                if !package_published(graphql_url, dep_name)? {
+                    return package_error(format!(
+                        "depends on {dep_name}@*, but the registry has no version to resolve"
+                    ));
+                }
+                continue;
+            }
+            DependencyCheck::ExactVersion(version) => version,
+        };
+        let dep = (dep_name.clone(), version.to_string());
         if available.contains(&dep) {
             continue;
         }
         if packages.contains_key(&dep) {
             return package_error(format!(
-                "dependency {dep_name}@{dep_version} failed earlier in this run"
+                "dependency {dep_name}@{version} failed earlier in this run"
             ));
         }
-        if !get_published(graphql_url, dep_name, dep_version)?.exists {
+        if !get_published(graphql_url, dep_name, version)?.exists {
             return package_error(format!(
-                "depends on {dep_name}@{dep_version}, which is neither published nor part of this run"
+                "depends on {dep_name}@{version}, which is neither published nor part of this run"
             ));
         }
         available.insert(dep);

--- a/tools/wasinix/src/tests/mod.rs
+++ b/tools/wasinix/src/tests/mod.rs
@@ -1,3 +1,28 @@
+mod publish_dependency_check {
+    use crate::registries::wasmer::{dependency_check, DependencyCheck};
+
+    #[test]
+    fn a_star_requirement_accepts_any_published_version() {
+        // A `*` dep must never demand the version this checkout happened to
+        // build; the published webc resolves it at load time.
+        assert_eq!(
+            dependency_check(Some("*"), "5.3.15"),
+            DependencyCheck::AnyVersion
+        );
+    }
+
+    #[test]
+    fn a_pin_demands_its_resolved_version() {
+        for requirement in [Some("=5.3.15"), Some("^5.3.15"), Some("5.3.15"), None] {
+            assert_eq!(
+                dependency_check(requirement, "5.3.15"),
+                DependencyCheck::ExactVersion("5.3.15"),
+                "{requirement:?}"
+            );
+        }
+    }
+}
+
 mod naming {
     use crate::support::naming::{Domain, axis_of, parse, render, resolve_all, split};
 


### PR DESCRIPTION
The webc publish pre-flight checks each dependency against the registry before publishing a package. It used the dependency's **built** version (from the Nix graph), so a package declaring `wasmer/bash = "*"` failed to publish unless *our* exact `wasmer/bash@5.3.15` was on the registry:

```
✗ python/python@3.13.20  depends on wasmer/bash@5.3.15, which is
  neither published nor part of this run
```

That defeats the point of an unpinned requirement. `*` exists precisely so the package takes whatever bash the registry serves (currently `wasmer/bash@1.0.25`) and we never ship our own build of it — but the publisher still demanded the build's version.

## Change

The pre-flight now classifies a dependency by its manifest requirement:

- **`*`** → satisfied by any published version. New `package_published` helper (`getPackage(name){lastVersion}`) checks the package exists at all; the built version is irrelevant and is never required to be published.
- **a pin** (`=x`, `^x`, `~x`, bare) → unchanged: its resolved version must be present.

The decision is a pure `dependency_check` classifier, unit-tested for both arms (a `*` requirement never demands the built version; every pin form demands its resolved version). The network effect stays in `publish_one`.

## Verified

With this, `python/python@3.13.20` (depends on `wasmer/bash@*`) publishes, and the published webc resolves `wasmer/bash` to the registry's `1.0.25` at load time — confirmed by running `shell=True` and `subprocess.getoutput` against it. This is what unblocked the WAX-611 interpreter republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
