### PR TITLE
publish-index: drop GitHub Pages and realise the index at the publish commit

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -15,8 +15,6 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  pages: write
-  id-token: write
 
 env:
   REGISTRY: wasmer.io
@@ -29,9 +27,6 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     env:
       # the app itself is resolved from pkgs/python-registry/app.yaml (app_id)
       INDEX_VOLUME: index
@@ -121,48 +116,15 @@ jobs:
             "$(readlink -f registry-result)" \
             --rev "${{ github.event.workflow_run.head_sha }}"
 
-      # the Pages site must exist with build_type=workflow; creating it needs
-      # repo admin, which GITHUB_TOKEN never has:
-      #   gh api -X POST repos/wasix-org/wasinix/pages -f build_type=workflow
-      - name: Prepare Pages snapshot
-        # Pages intentionally tracks the fresh build, independently of the
-        # append-only volume publication above.
-        if:
-          always() && steps.published.outputs.cache-hit != 'true' &&
-          steps.build-index.outcome == 'success'
-        run: |
-          # materialize the result symlink with writable modes for the tarring action
-          mkdir site
-          cp -r --no-preserve=mode,ownership --dereference registry-result/. site/
-
-      - name: Upload Pages artifact
-        if:
-          always() && steps.published.outputs.cache-hit != 'true' &&
-          steps.build-index.outcome == 'success'
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
-        with:
-          path: site
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        if:
-          always() && steps.published.outputs.cache-hit != 'true' &&
-          steps.build-index.outcome == 'success'
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
-
       - name: Record publication
-        if:
-          always() && steps.publish-volume.outcome == 'success' &&
-          steps.deploy.outcome == 'success'
+        if: always() && steps.publish-volume.outcome == 'success'
         env:
           INDEX_PATH: ${{ steps.identity.outputs.path }}
         run: echo "$INDEX_PATH" > .wasinix-published-index
 
       - name: Save publication state
         id: save_publication_state
-        if:
-          always() && steps.publish-volume.outcome == 'success' &&
-          steps.deploy.outcome == 'success'
+        if: always() && steps.publish-volume.outcome == 'success'
         uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: .wasinix-published-index

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -225,21 +225,16 @@ Webc rels land in `[package.metadata] wasix-rel` only, for now: the registry has
 no version encoding for republishing (`WASIX-TODO.md`), so a bumped webc still
 cannot republish.
 
-## Immutability, and the two indexes
+## Immutability
 
 Published filenames are immutable and accumulate. A normal registry rebuild can
 change the bytes behind an existing filename through a nixpkgs, toolchain, or
 runtime update, and the volume keeps its original artifact in that case. Bump
 the rel only when that rebuilt wheel is itself a release.
 
-GitHub Pages behaves differently: it is always deployed from the fresh
-`legacyPackages.x86_64-linux.artifacts.registry.python` result, so it is a
-bleeding-edge snapshot and may serve new bytes under an existing filename. Use
-the volume-backed index for immutable, reproducible installs.
-
-After a green build of main, `publish-index` uploads new filenames to the volume
-and deploys the fresh snapshot to GitHub Pages. The volume service is defined by
-`python-registry/app.yaml`.
+After a green build of main, `publish-index` uploads new filenames to the
+append-only volume, served at `python-registry.wasix.org`. The volume service is
+defined by `python-registry/app.yaml`.
 
 A wheel built by both interpreters is published once, under the one filename its
 `py3-none-any` tag earns it. Where the two builds differ, that name cannot hold


### PR DESCRIPTION
Two publish-index changes, stacked so the wheel republish can go out. Both are needed for the backfill of the stale `-threads` wheels (already rel-bumped to `+wasix.3` in `release-revisions.json`) to actually ship.

## 1. Drop the GitHub Pages deploy
The Pages deploy step fails with `Multiple artifacts named "github-pages"`, and because "Record publication" / "Save publication state" gated on it, a run that uploaded wheels still ended red and never saved state. Pages is a secondary mirror we no longer need (the registry is served from the wasmer app). Removes the deploy/prepare/upload-pages steps, the `pages`/`id-token` permissions, the `github-pages` environment, and the deploy gating on the state steps.

## 2. Realise the index at the triggering commit (the republish fix)
The publish job never rebuilt the index at the publish commit — it materialized whatever store path the Build's **diff-based** eval map carried (`nix-store --realise "$INDEX_PATH"`). A diff build reuses the baseline path for any job the HEAD commit didn't touch, so a commit that leaves the index alone hands the publisher a **stale, pre-rel-bump index**; `publish.py` then reports "no new immutable wheels to publish" and uploads nothing. That is exactly how the last whole-registry republish silently no-op'd.

Now it `nix eval`s the index at `workflow_run.head_sha` and realises that, so it always publishes the current rels. The dedup cache still short-circuits an unchanged index. The publish-index corpus test (`tools/wasinix/src/tests/mod.rs`) is updated to the new contract (fresh `nix eval` identity before the publication-state check, `nix-store --realise` not `nix build`).

Also raises the job timeout `30 → 120`: a full backfill uploads the whole volume serially (the S3 proxy forces `--transfers 1`), which doesn't fit 30 minutes; a routine publish is unaffected.

## After merge
A green main Build auto-triggers `publish-index`, which now realises the current (rel-3, non-threads) registry and uploads the missing `+wasix.3` wheels — fixing the `-threads` import failures (pydantic-core/rpds/MCP and anybuild builds).

Supersedes #271 (its commits are folded in here).
